### PR TITLE
feat: persist tracker registry and monitor external file changes

### DIFF
--- a/FEATURE_COMPARISON_WIRED2_WIRED3.md
+++ b/FEATURE_COMPARISON_WIRED2_WIRED3.md
@@ -52,6 +52,11 @@ The most notable gaps concern:
 - some file metadata operations inherited from Wired 2
 - a few legacy server operational functions
 
+Recent parity completions on the Swift side include:
+
+- persistent local tracker registry storage
+- native filesystem monitoring for out-of-band changes on macOS and Linux
+
 ## Parity Table
 
 | Domain | Feature | Legacy C Server | New Swift Server | Status | Notes |
@@ -95,10 +100,10 @@ The most notable gaps concern:
 | Files | `wired.file.subscribe_directory` / `unsubscribe_directory` | Yes | Yes | Ported | Notifications maintained on Swift side. |
 | Files | `wired.file.set_type` | Yes | Yes | Extended | Carried over and extended with `sync` type. |
 | Files | `wired.file.set_permissions` | Yes | Yes | Extended | Carried over, with additional sync policy management. |
-| Files | `wired.file.link` | Yes | Not visible | Missing | Legacy handler present in `wired/messages.c`, not routed in `ServerController.swift`. |
-| Files | `wired.file.set_comment` | Yes | Not visible | Missing | New server returns `wired.file.comment`, but does not route a setter. |
-| Files | `wired.file.set_executable` | Yes | Not visible | Missing | New server returns `wired.file.executable`, but does not route a setter. |
-| Files | `wired.file.set_label` | Yes | Not visible | Missing | New server returns `wired.file.label`, but does not route a setter. |
+| Files | `wired.file.link` | Yes | Not visible | Ported | Legacy handler present in `wired/messages.c`, not routed in `ServerController.swift`. |
+| Files | `wired.file.set_comment` | Yes | Not visible | Ported | New server returns `wired.file.comment`, but does not route a setter. |
+| Files | `wired.file.set_executable` | Yes | Not visible | Ported | New server returns `wired.file.executable`, but does not route a setter. |
+| Files | `wired.file.set_label` | Yes | Not visible | Ported | New server returns `wired.file.label`, but does not route a setter. |
 | Files | Directory sync | No | Yes | New | `wired.file.set_sync_policy` and sync privileges. |
 | Transfers | `wired.transfer.download_file` | Yes | Yes | Ported | Carried over to Swift. |
 | Transfers | `wired.transfer.upload_file` | Yes | Yes | Ported | Carried over to Swift. |
@@ -115,36 +120,30 @@ The most notable gaps concern:
 | Events | `wired.event.get_events` | Yes | Yes | Ported | Carried over to Swift. |
 | Events | `wired.event.subscribe` / `unsubscribe` | Yes | Yes | Ported | Carried over to Swift. |
 | Events | `wired.event.delete_events` | Yes | Yes | Ported | Carried over to Swift. |
-| Events | Automatic event purge via config | Yes | Not visible | Missing | Legacy: `events time`; new: manual deletion only. |
+| Events | Automatic event purge via config | Yes | Not visible | Ported | Legacy: `events time`; new: manual deletion only. |
 | Logs | `wired.log.get_log` | Yes | Yes | Ported | Carried over to Swift. |
 | Logs | `wired.log.subscribe` / `unsubscribe` | Yes | Yes | Ported | Carried over to Swift. |
 | Settings | `wired.settings.get_settings` | Yes | Yes | Ported | Carried over to Swift. |
 | Settings | `wired.settings.set_settings` | Yes | Yes | Ported | Carried over to Swift. |
 | Settings | Name, description, banner, transfer quotas, trackers | Yes | Yes | Ported | Fields present in Swift setter. |
-| Settings | Automatic SQLite database snapshots | Yes | Not visible | Missing | Legacy: `snapshots`, `snapshot time`; no visible equivalent in Swift `config.ini`. |
-| Settings | Auto NAT-PMP / UPnP port mapping | Yes | Not visible | Missing | Legacy: `map port` + `portmap.c`; no visible equivalent on Swift side. |
+| Settings | Automatic SQLite database snapshots | Yes | Not visible | Ported | Legacy: `snapshots`, `snapshot time`; no visible equivalent in Swift `config.ini`. |
+| Settings | Auto NAT-PMP / UPnP port mapping | Yes | Not visible | Discontinued | Legacy: `map port` + `portmap.c`; no visible equivalent on Swift side. |
 | Tracker | `wired.tracker.get_categories` | Yes | Yes | Ported | Carried over to Swift. |
 | Tracker | `wired.tracker.get_servers` | Yes | Yes | Ported | Carried over to Swift. |
 | Tracker | `wired.tracker.send_register` / `send_update` | Yes | Yes | Ported | Carried over to Swift. |
 | Tracker | Outgoing registration to remote trackers | Yes | Yes | Ported | Handled by `OutgoingTrackersController`. |
-| Tracker | Local tracker registry persistence | Yes | Not visible | Partial | Legacy SQLite storage in `servers.c`; new tracker in-memory in `TrackerController.swift`. |
+| Tracker | Local tracker registry persistence | Yes | Yes | Ported | Persisted in SQLite via `TrackerController.swift` + `TrackedServerRecord.swift`, reloaded at startup and purged on expiration. |
 | Indexing | Periodic re-indexing | Yes | Yes | Ported | Legacy `index time`, new `reindex_interval`. |
-| Indexing | Real-time detection of out-of-band filesystem changes | Yes | Partial | Partial | Legacy used `fsevents`; new primarily notifications on internal operations + periodic reindex. |
+| Indexing | Real-time detection of out-of-band filesystem changes | Yes | Yes | Ported | Native monitoring via `FSEvents` on macOS and `inotify` on Linux, with debounced reindex + directory notifications. |
 | Security | Known default admin password | Yes | No | Extended | New server generates a random password at bootstrap. |
 | Security | Legacy RSA handshake | Yes | No | Intentional change | Replaced by ECDH / ECDSA in Wired 3. |
 
 ## Legacy Features to Prioritize for More Complete Parity
 
-The most concrete and actionable gaps on the Swift side are:
+The most concrete remaining legacy parity questions are now concentrated in:
 
-1. `wired.file.link`
-2. `wired.file.set_comment`
-3. `wired.file.set_executable`
-4. `wired.file.set_label`
-5. automatic event purge via configuration
-6. auto NAT-PMP / UPnP port mapping
-7. tracker registry persistence
-8. native filesystem monitoring for out-of-band changes
+1. a few document-status mismatches in older comparison notes
+2. discontinued operational features such as automatic NAT-PMP / UPnP port mapping
 
 ## Main References
 

--- a/Sources/wired3/Controllers/FilesController+Metadata.swift
+++ b/Sources/wired3/Controllers/FilesController+Metadata.swift
@@ -420,6 +420,49 @@ extension FilesController {
         notify(path: path, messageName: "wired.file.directory_deleted", removeSubscriptionAfterNotify: true)
     }
 
+    func handleExternalFilesystemChanges(realPaths: [String]) {
+        let root = URL(fileURLWithPath: rootPath).standardizedFileURL.path
+        let fileManager = FileManager.default
+        var changedDirectories = Set<String>()
+        var deletedDirectories = Set<String>()
+
+        for realPath in realPaths {
+            let standardizedPath = URL(fileURLWithPath: realPath).standardizedFileURL.path
+            guard standardizedPath == root || standardizedPath.hasPrefix(root + "/") else {
+                continue
+            }
+            guard !standardizedPath.contains("/.wired") else {
+                continue
+            }
+
+            if standardizedPath == root {
+                changedDirectories.insert("/")
+                continue
+            }
+
+            let virtualPath = normalizeVirtualPath(virtual(path: standardizedPath))
+            let parentVirtualPath = normalizeVirtualPath(virtual(path: (standardizedPath as NSString).deletingLastPathComponent))
+            changedDirectories.insert(parentVirtualPath)
+
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: standardizedPath, isDirectory: &isDirectory) {
+                if isDirectory.boolValue {
+                    changedDirectories.insert(virtualPath)
+                }
+            } else {
+                deletedDirectories.insert(virtualPath)
+            }
+        }
+
+        for path in changedDirectories.sorted() {
+            notifyDirectoryChanged(path: path)
+        }
+
+        for path in deletedDirectories.sorted() {
+            notifyDirectoryDeleted(path: path)
+        }
+    }
+
     func notify(path: String, messageName: String, removeSubscriptionAfterNotify: Bool) {
         let realPath = resolvedVirtualPath(for: path).resolvedRealPath
         let targets: [(UInt32, String)] = subscriptionsQueue.sync {

--- a/Sources/wired3/Controllers/FilesystemMonitor.swift
+++ b/Sources/wired3/Controllers/FilesystemMonitor.swift
@@ -1,0 +1,300 @@
+import Foundation
+#if canImport(CoreServices)
+import CoreServices
+#endif
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+final class FilesystemMonitor {
+    typealias EventHandler = ([String]) -> Void
+
+    private let debounceInterval: TimeInterval
+    private let eventHandler: EventHandler
+    private let stateQueue = DispatchQueue(label: "wired3.filesystem-monitor.state", qos: .utility)
+
+    private var watchedPath: String
+    private var pendingPaths = Set<String>()
+    private var pendingWorkItem: DispatchWorkItem?
+
+    #if canImport(CoreServices)
+    private let streamQueue = DispatchQueue(label: "wired3.filesystem-monitor.stream", qos: .utility)
+    private var stream: FSEventStreamRef?
+    #elseif canImport(Glibc)
+    private let inotifyQueue = DispatchQueue(label: "wired3.filesystem-monitor.inotify", qos: .utility)
+    private var inotifyFileDescriptor: Int32 = -1
+    private var inotifyReadSource: DispatchSourceRead?
+    private var watchedDirectoriesByDescriptor: [Int32: String] = [:]
+    #endif
+
+    init(path: String, debounceInterval: TimeInterval = 0.35, eventHandler: @escaping EventHandler) {
+        self.watchedPath = path
+        self.debounceInterval = debounceInterval
+        self.eventHandler = eventHandler
+    }
+
+    @discardableResult
+    func start() -> Bool {
+        #if canImport(CoreServices)
+        stateQueue.sync {
+            pendingPaths.removeAll()
+            pendingWorkItem?.cancel()
+            pendingWorkItem = nil
+        }
+
+        var context = FSEventStreamContext(
+            version: 0,
+            info: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        let flags = FSEventStreamCreateFlags(
+            kFSEventStreamCreateFlagUseCFTypes |
+            kFSEventStreamCreateFlagFileEvents |
+            kFSEventStreamCreateFlagNoDefer
+        )
+
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            { (_, info, numEvents, eventPathsPointer, _, _) in
+                guard let info else { return }
+                let monitor = Unmanaged<FilesystemMonitor>.fromOpaque(info).takeUnretainedValue()
+                let eventPaths = unsafeBitCast(eventPathsPointer, to: NSArray.self) as? [String] ?? []
+                monitor.processObservedPaths(Array(eventPaths.prefix(Int(numEvents))))
+            },
+            &context,
+            [watchedPath] as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.2,
+            flags
+        ) else {
+            return false
+        }
+
+        FSEventStreamSetDispatchQueue(stream, streamQueue)
+        guard FSEventStreamStart(stream) else {
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            return false
+        }
+
+        self.stream = stream
+        return true
+        #elseif canImport(Glibc)
+        stateQueue.sync {
+            pendingPaths.removeAll()
+            pendingWorkItem?.cancel()
+            pendingWorkItem = nil
+        }
+
+        let descriptor = inotify_init1(Int32(IN_NONBLOCK))
+        guard descriptor >= 0 else {
+            return false
+        }
+
+        inotifyFileDescriptor = descriptor
+
+        guard installRecursiveWatches(rootPath: watchedPath) else {
+            stop()
+            return false
+        }
+
+        let readSource = DispatchSource.makeReadSource(fileDescriptor: descriptor, queue: inotifyQueue)
+        readSource.setEventHandler { [weak self] in
+            self?.drainInotifyEvents()
+        }
+        readSource.setCancelHandler { [weak self] in
+            guard let self else { return }
+            if self.inotifyFileDescriptor >= 0 {
+                _ = Glibc.close(self.inotifyFileDescriptor)
+                self.inotifyFileDescriptor = -1
+            }
+        }
+        inotifyReadSource = readSource
+        readSource.resume()
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    func stop() {
+        stateQueue.sync {
+            pendingWorkItem?.cancel()
+            pendingWorkItem = nil
+            pendingPaths.removeAll()
+        }
+
+        #if canImport(CoreServices)
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            self.stream = nil
+        }
+        #elseif canImport(Glibc)
+        watchedDirectoriesByDescriptor.removeAll()
+        inotifyReadSource?.cancel()
+        inotifyReadSource = nil
+        if inotifyFileDescriptor >= 0 {
+            _ = Glibc.close(inotifyFileDescriptor)
+            inotifyFileDescriptor = -1
+        }
+        #endif
+    }
+
+    func processObservedPaths(_ paths: [String]) {
+        let normalizedPaths = paths
+            .map { URL(fileURLWithPath: $0).standardizedFileURL.path }
+            .filter { !$0.isEmpty }
+        guard !normalizedPaths.isEmpty else { return }
+
+        stateQueue.async {
+            self.pendingPaths.formUnion(normalizedPaths)
+            self.pendingWorkItem?.cancel()
+
+            let workItem = DispatchWorkItem { [weak self] in
+                self?.flushPendingPathsFromStateQueue()
+            }
+            self.pendingWorkItem = workItem
+            self.stateQueue.asyncAfter(deadline: .now() + self.debounceInterval, execute: workItem)
+        }
+    }
+
+    private func flushPendingPathsFromStateQueue() {
+        let paths = pendingPaths.sorted()
+        pendingPaths.removeAll()
+        pendingWorkItem = nil
+        guard !paths.isEmpty else { return }
+        eventHandler(paths)
+    }
+
+    #if canImport(Glibc)
+    private func installRecursiveWatches(rootPath: String) -> Bool {
+        let normalizedRoot = URL(fileURLWithPath: rootPath).standardizedFileURL.path
+        guard addWatch(forDirectory: normalizedRoot) else {
+            return false
+        }
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: URL(fileURLWithPath: normalizedRoot, isDirectory: true),
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return true
+        }
+
+        for case let url as URL in enumerator {
+            let values = try? url.resourceValues(forKeys: [.isDirectoryKey])
+            guard values?.isDirectory == true else { continue }
+            guard addWatch(forDirectory: url.standardizedFileURL.path) else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private func addWatch(forDirectory path: String) -> Bool {
+        guard inotifyFileDescriptor >= 0 else { return false }
+        guard FileManager.default.fileExists(atPath: path) else { return false }
+        if watchedDirectoriesByDescriptor.values.contains(path) {
+            return true
+        }
+
+        let mask = UInt32(
+            IN_CREATE |
+            IN_DELETE |
+            IN_DELETE_SELF |
+            IN_MODIFY |
+            IN_MOVED_FROM |
+            IN_MOVED_TO |
+            IN_MOVE_SELF |
+            IN_ATTRIB |
+            IN_CLOSE_WRITE
+        )
+
+        let descriptor = path.withCString { inotify_add_watch(inotifyFileDescriptor, $0, mask) }
+        guard descriptor >= 0 else {
+            return false
+        }
+
+        watchedDirectoriesByDescriptor[descriptor] = path
+        return true
+    }
+
+    private func drainInotifyEvents() {
+        guard inotifyFileDescriptor >= 0 else { return }
+
+        let bufferSize = 64 * 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while true {
+            let bytesRead = Glibc.read(inotifyFileDescriptor, buffer, bufferSize)
+            if bytesRead < 0 {
+                if errno == EAGAIN || errno == EWOULDBLOCK {
+                    return
+                }
+                return
+            }
+
+            if bytesRead == 0 {
+                return
+            }
+
+            var offset = 0
+            while offset + MemoryLayout<inotify_event>.size <= bytesRead {
+                let eventPointer = UnsafeRawPointer(buffer.advanced(by: offset)).assumingMemoryBound(to: inotify_event.self)
+                let event = eventPointer.pointee
+                let nameOffset = offset + MemoryLayout<inotify_event>.size
+                let nameLength = Int(event.len)
+
+                let watchedDirectory = watchedDirectoriesByDescriptor[event.wd]
+                let eventPath = resolvedInotifyEventPath(
+                    watchedDirectory: watchedDirectory,
+                    nameBaseAddress: buffer.advanced(by: nameOffset),
+                    nameLength: nameLength
+                )
+
+                if let eventPath {
+                    processObservedPaths([eventPath])
+                    if event.mask & UInt32(IN_ISDIR) != 0,
+                       event.mask & UInt32(IN_CREATE) != 0 || event.mask & UInt32(IN_MOVED_TO) != 0 {
+                        _ = installRecursiveWatches(rootPath: eventPath)
+                    }
+                }
+
+                if event.mask & UInt32(IN_IGNORED) != 0 || event.mask & UInt32(IN_DELETE_SELF) != 0 || event.mask & UInt32(IN_MOVE_SELF) != 0 {
+                    watchedDirectoriesByDescriptor.removeValue(forKey: event.wd)
+                }
+
+                offset += MemoryLayout<inotify_event>.size + nameLength
+            }
+        }
+    }
+
+    private func resolvedInotifyEventPath(
+        watchedDirectory: String?,
+        nameBaseAddress: UnsafeMutablePointer<UInt8>,
+        nameLength: Int
+    ) -> String? {
+        guard let watchedDirectory else { return nil }
+        guard nameLength > 0 else { return watchedDirectory }
+
+        let name = nameBaseAddress.withMemoryRebound(to: CChar.self, capacity: nameLength) {
+            String(cString: $0)
+        }
+        guard !name.isEmpty else { return watchedDirectory }
+
+        return URL(fileURLWithPath: watchedDirectory)
+            .appendingPathComponent(name)
+            .standardizedFileURL
+            .path
+    }
+    #endif
+}

--- a/Sources/wired3/Controllers/TrackerController.swift
+++ b/Sources/wired3/Controllers/TrackerController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import WiredSwift
 
 /// In-memory registry for servers that register against this Wired server acting as a tracker.
@@ -31,10 +32,13 @@ final class TrackerController {
     }
 
     private var serversBySourceIP: [String: TrackedServer] = [:]
+    private let databaseController: DatabaseController
     private let serversLock = Lock()
     private var purgeTask: Task<Void, Never>?
 
-    init() {
+    init(databaseController: DatabaseController) {
+        self.databaseController = databaseController
+        loadPersistedServers()
         startPurgeLoop()
     }
 
@@ -130,6 +134,7 @@ final class TrackerController {
         serversLock.exclusivelyWrite {
             serversBySourceIP[sourceIP] = trackedServer
         }
+        persist(trackedServer)
 
         return trackedServer
     }
@@ -147,7 +152,7 @@ final class TrackerController {
             throw TrackerError.invalidMessage
         }
 
-        return try serversLock.exclusivelyWrite {
+        let updatedServer = try serversLock.exclusivelyWrite {
             guard var existing = serversBySourceIP[sourceIP], existing.isActive else {
                 throw TrackerError.notRegistered
             }
@@ -161,14 +166,39 @@ final class TrackerController {
             serversBySourceIP[sourceIP] = existing
             return existing
         }
+        persist(updatedServer)
+        return updatedServer
     }
 
     func purgeExpiredServers(now: Date = Date()) {
-        serversLock.exclusivelyWrite {
-            serversBySourceIP = serversBySourceIP.filter { _, server in
-                guard server.isActive else { return false }
-                return now.timeIntervalSince(server.lastSeenAt) <= Self.entryExpirationInterval
+        let expiredSourceIPs = serversLock.exclusivelyWrite { () -> [String] in
+            var expired: [String] = []
+            serversBySourceIP = serversBySourceIP.filter { sourceIP, server in
+                let keep = server.isActive && now.timeIntervalSince(server.lastSeenAt) <= Self.entryExpirationInterval
+                if !keep {
+                    expired.append(sourceIP)
+                }
+                return keep
             }
+            return expired
+        }
+
+        if !expiredSourceIPs.isEmpty {
+            deletePersisted(sourceIPs: expiredSourceIPs)
+        }
+    }
+
+    func activeServersSnapshot(now: Date = Date()) -> [TrackedServer] {
+        purgeExpiredServers(now: now)
+        return serversLock.concurrentlyRead {
+            serversBySourceIP.values
+                .filter { $0.isActive }
+                .sorted { lhs, rhs in
+                    if lhs.name != rhs.name {
+                        return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+                    }
+                    return lhs.url.localizedStandardCompare(rhs.url) == .orderedAscending
+                }
         }
     }
 
@@ -181,6 +211,102 @@ final class TrackerController {
                 self.purgeExpiredServers()
             }
         }
+    }
+
+    private func loadPersistedServers(now: Date = Date()) {
+        do {
+            let records = try databaseController.dbQueue.read { db in
+                try TrackedServerRecord.fetchAll(db)
+            }
+
+            var activeServers: [String: TrackedServer] = [:]
+            var expiredSourceIPs: [String] = []
+            for record in records {
+                let server = record.trackedServer()
+                let isExpired = !server.isActive || now.timeIntervalSince(server.lastSeenAt) > Self.entryExpirationInterval
+                if isExpired {
+                    expiredSourceIPs.append(server.sourceIP)
+                } else {
+                    activeServers[server.sourceIP] = server
+                }
+            }
+
+            serversLock.exclusivelyWrite {
+                serversBySourceIP = activeServers
+            }
+
+            if !expiredSourceIPs.isEmpty {
+                deletePersisted(sourceIPs: expiredSourceIPs)
+            }
+        } catch {
+            Logger.error("TrackerController: failed to load persisted tracker registry: \(error)")
+        }
+    }
+
+    private func persist(_ server: TrackedServer) {
+        do {
+            try databaseController.dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                    INSERT INTO tracked_servers (
+                        source_ip, display_ip, port, url, category, is_tracker, name, description,
+                        users, files_count, files_size, registered_at, updated_at, last_seen_at, is_active
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(source_ip) DO UPDATE SET
+                        display_ip = excluded.display_ip,
+                        port = excluded.port,
+                        url = excluded.url,
+                        category = excluded.category,
+                        is_tracker = excluded.is_tracker,
+                        name = excluded.name,
+                        description = excluded.description,
+                        users = excluded.users,
+                        files_count = excluded.files_count,
+                        files_size = excluded.files_size,
+                        registered_at = excluded.registered_at,
+                        updated_at = excluded.updated_at,
+                        last_seen_at = excluded.last_seen_at,
+                        is_active = excluded.is_active
+                    """,
+                    arguments: [
+                        server.sourceIP,
+                        server.displayIP,
+                        Int64(server.port),
+                        server.url,
+                        server.category,
+                        server.isTracker,
+                        server.name,
+                        server.description,
+                        Int64(server.users),
+                        Int64(clamping: server.filesCount),
+                        Int64(clamping: server.filesSize),
+                        server.registeredAt,
+                        server.updatedAt,
+                        server.lastSeenAt,
+                        server.isActive
+                    ]
+                )
+            }
+        } catch {
+            Logger.error("TrackerController: failed to persist tracked server \(server.sourceIP): \(error)")
+        }
+    }
+
+    private func deletePersisted(sourceIPs: [String]) {
+        do {
+            try databaseController.dbQueue.write { db in
+                try db.execute(
+                    sql: "DELETE FROM tracked_servers WHERE source_ip IN (\(databaseQuestionMarks(count: sourceIPs.count)))",
+                    arguments: StatementArguments(sourceIPs)
+                )
+            }
+        } catch {
+            Logger.error("TrackerController: failed to purge persisted tracked servers: \(error)")
+        }
+    }
+
+    private func databaseQuestionMarks(count: Int) -> String {
+        Array(repeating: "?", count: count).joined(separator: ", ")
     }
 
     private func normalizedSourceIP(from client: Client) -> String? {

--- a/Sources/wired3/Core/AppController.swift
+++ b/Sources/wired3/Core/AppController.swift
@@ -46,6 +46,7 @@ public class AppController {
     var transfersController: TransfersController!
     var trackerController: TrackerController!
     var outgoingTrackersController: OutgoingTrackersController!
+    var filesystemMonitor: FilesystemMonitor?
     var bootstrapStateStore: BootstrapStateStore!
     var logsController: LogsController!
 
@@ -123,7 +124,7 @@ public class AppController {
                                                filesController: self.filesController)
 
         self.transfersController = TransfersController(filesController: filesController)
-        self.trackerController = TrackerController()
+        self.trackerController = TrackerController(databaseController: self.databaseController)
         self.outgoingTrackersController = OutgoingTrackersController()
 
         // Seed initial data (only on first run — no-op if data already exists)
@@ -145,6 +146,7 @@ public class AppController {
 
         self.indexController.indexFiles()
         self.indexController.configure(reindexInterval: resolvedReindexInterval())
+        configureFilesystemMonitoring()
         self.eventsController.configureAutoPurge(retentionPolicy: resolvedEventRetentionPolicy())
         configureSnapshotScheduling()
 
@@ -178,6 +180,8 @@ public class AppController {
         self.outgoingTrackersController?.stop()
         self.serverController?.stop()
         self.trackerController?.stop()
+        self.filesystemMonitor?.stop()
+        self.filesystemMonitor = nil
         self.indexController?.configure(reindexInterval: 0)
         self.snapshotTimer?.cancel()
         self.snapshotTimer = nil
@@ -226,6 +230,7 @@ public class AppController {
 
         // Re-arm the periodic reindex timer if the interval changed.
         self.indexController.configure(reindexInterval: resolvedReindexInterval())
+        configureFilesystemMonitoring()
         self.eventsController.configureAutoPurge(retentionPolicy: resolvedEventRetentionPolicy())
         configureSnapshotScheduling()
 
@@ -246,6 +251,21 @@ public class AppController {
             Logger.info("  log.level: \(current.description.lowercased()) → \(level.description.lowercased())")
             Logger.setMaxLevel(level)
         }
+    }
+
+    private func configureFilesystemMonitoring() {
+        filesystemMonitor?.stop()
+        filesystemMonitor = FilesystemMonitor(path: filesController.rootPath) { [weak self] realPaths in
+            guard let self else { return }
+            self.filesController.handleExternalFilesystemChanges(realPaths: realPaths)
+            self.indexController.forceReindex()
+        }
+        guard filesystemMonitor?.start() == true else {
+            Logger.info("Filesystem monitor unavailable for \(filesController.rootPath); relying on periodic reindex")
+            filesystemMonitor = nil
+            return
+        }
+        Logger.info("Filesystem monitor active for \(filesController.rootPath)")
     }
 
     /// Read the reindex interval from config.

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -38,6 +38,9 @@ enum WiredMigrations {
         migrator.registerMigration("v10_add_file_metadata_privileges") { db in
             try WiredMigrations.v10(db)
         }
+        migrator.registerMigration("v11_tracked_servers") { db in
+            try WiredMigrations.v11(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -173,6 +176,32 @@ enum WiredMigrations {
             LEFT JOIN group_privileges ref
                 ON ref.group_id = g.id AND ref.name = 'wired.account.file.set_type'
         """)
+    }
+
+    static func v11(_ db: Database) throws {
+        try db.create(table: "tracked_servers", ifNotExists: true) { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("source_ip", .text).notNull().unique()
+            t.column("display_ip", .text).notNull()
+            t.column("port", .integer).notNull()
+            t.column("url", .text).notNull()
+            t.column("category", .text).notNull()
+            t.column("is_tracker", .boolean).notNull()
+            t.column("name", .text).notNull()
+            t.column("description", .text).notNull()
+            t.column("users", .integer).notNull()
+            t.column("files_count", .integer).notNull()
+            t.column("files_size", .integer).notNull()
+            t.column("registered_at", .datetime).notNull()
+            t.column("updated_at", .datetime)
+            t.column("last_seen_at", .datetime).notNull()
+            t.column("is_active", .boolean).notNull()
+        }
+
+        try db.create(index: "tracked_servers_last_seen_at",
+                      on: "tracked_servers",
+                      columns: ["last_seen_at"],
+                      ifNotExists: true)
     }
 
     // SECURITY (FINDING_A_004): Add password_salt column for salted SHA-256 hashing

--- a/Sources/wired3/Models/TrackedServerRecord.swift
+++ b/Sources/wired3/Models/TrackedServerRecord.swift
@@ -1,0 +1,62 @@
+import Foundation
+import GRDB
+
+struct TrackedServerRecord: Codable, FetchableRecord, PersistableRecord {
+    static let databaseTableName = "tracked_servers"
+
+    var id: Int64?
+    var source_ip: String
+    var display_ip: String
+    var port: UInt32
+    var url: String
+    var category: String
+    var is_tracker: Bool
+    var name: String
+    var description: String
+    var users: UInt32
+    var files_count: UInt64
+    var files_size: UInt64
+    var registered_at: Date
+    var updated_at: Date?
+    var last_seen_at: Date
+    var is_active: Bool
+
+    init(trackedServer: TrackerController.TrackedServer) {
+        self.id = nil
+        self.source_ip = trackedServer.sourceIP
+        self.display_ip = trackedServer.displayIP
+        self.port = trackedServer.port
+        self.url = trackedServer.url
+        self.category = trackedServer.category
+        self.is_tracker = trackedServer.isTracker
+        self.name = trackedServer.name
+        self.description = trackedServer.description
+        self.users = trackedServer.users
+        self.files_count = trackedServer.filesCount
+        self.files_size = trackedServer.filesSize
+        self.registered_at = trackedServer.registeredAt
+        self.updated_at = trackedServer.updatedAt
+        self.last_seen_at = trackedServer.lastSeenAt
+        self.is_active = trackedServer.isActive
+    }
+
+    func trackedServer() -> TrackerController.TrackedServer {
+        TrackerController.TrackedServer(
+            sourceIP: source_ip,
+            displayIP: display_ip,
+            port: port,
+            url: url,
+            category: category,
+            isTracker: is_tracker,
+            name: name,
+            description: description,
+            users: users,
+            filesCount: files_count,
+            filesSize: files_size,
+            registeredAt: registered_at,
+            updatedAt: updated_at,
+            lastSeenAt: last_seen_at,
+            isActive: is_active
+        )
+    }
+}

--- a/Tests/wired3IntegrationTests/IntegrationTestSupport.swift
+++ b/Tests/wired3IntegrationTests/IntegrationTestSupport.swift
@@ -260,6 +260,25 @@ final class IntegrationServerRuntime {
         )
     }
 
+    func searchIndexContains(virtualPath: String) -> Bool {
+        do {
+            return try app.databaseController.dbQueue.read { db in
+                let count = try Int.fetchOne(
+                    db,
+                    sql: #"SELECT COUNT(*) FROM "index" WHERE virtual_path = ?"#,
+                    arguments: [virtualPath]
+                ) ?? 0
+                return count > 0
+            }
+        } catch {
+            return false
+        }
+    }
+
+    func indexedFilesCount() -> UInt64 {
+        app.indexController.totalFilesCount
+    }
+
     func connectClient(username: String, password plainPassword: String) throws -> P7Socket {
         let spec = P7Spec(withPath: specPath)
         let socket = P7Socket(hostname: "127.0.0.1", port: port, spec: spec)

--- a/Tests/wired3IntegrationTests/Lot2FeatureIntegrationTests.swift
+++ b/Tests/wired3IntegrationTests/Lot2FeatureIntegrationTests.swift
@@ -973,6 +973,34 @@ final class Lot2FeatureIntegrationTests: SerializedIntegrationTestCase {
         XCTAssertEqual(notSubscribed.string(forField: "wired.error.string"), "wired.error.not_subscribed")
     }
 
+    func testExternalFilesystemChangeTriggersDirectoryNotificationAndSearchIndexRefresh() throws {
+        let runtime = try IntegrationServerRuntime()
+        try runtime.start()
+        runtime.ensurePrivilegedUser(username: "it_admin", password: "secret")
+        defer { try? runtime.stop() }
+
+        let socket = try runtime.connectClient(username: "it_admin", password: "secret")
+        defer { socket.disconnect() }
+        try sendClientInfoAndExpectServerInfo(socket: socket)
+        _ = try sendLoginAndExpectSuccess(socket: socket, username: "it_admin", password: "secret")
+        drainMessages(socket: socket)
+
+        let subscribe = P7Message(withName: "wired.file.subscribe_directory", spec: socket.spec)
+        subscribe.addParameter(field: "wired.file.path", value: "/")
+        XCTAssertTrue(socket.write(subscribe))
+        _ = try readMessage(from: socket, expectedName: "wired.okay", maxReads: 12)
+
+        let externalFile = runtime.filesURL.appendingPathComponent("outside.txt")
+        try Data("external".utf8).write(to: externalFile)
+
+        let changed = try readMessage(from: socket, expectedName: "wired.file.directory_changed", maxReads: 80, timeout: 5)
+        XCTAssertEqual(changed.string(forField: "wired.file.path"), "/")
+
+        XCTAssertTrue(waitUntil(timeout: 5, interval: 0.1) {
+            runtime.indexedFilesCount() == 1
+        })
+    }
+
     func testAccountsSubscriberReceivesAccountsChangedBroadcastOnCreateUser() throws {
         let runtime = try IntegrationServerRuntime()
         try runtime.start()

--- a/Tests/wired3Tests/FilesystemMonitorTests.swift
+++ b/Tests/wired3Tests/FilesystemMonitorTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import wired3Lib
+
+final class FilesystemMonitorTests: XCTestCase {
+    func testObservedPathsAreDebouncedIntoSingleBatch() {
+        let expectation = expectation(description: "debounced filesystem events")
+        expectation.expectedFulfillmentCount = 1
+
+        var receivedBatches: [[String]] = []
+        let monitor = FilesystemMonitor(path: "/tmp", debounceInterval: 0.05) { paths in
+            receivedBatches.append(paths)
+            expectation.fulfill()
+        }
+        defer { monitor.stop() }
+
+        monitor.processObservedPaths(["/tmp/a.txt"])
+        monitor.processObservedPaths(["/tmp/b.txt", "/tmp/a.txt"])
+
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(receivedBatches.count, 1)
+        XCTAssertEqual(Set(receivedBatches[0]), Set(["/tmp/a.txt", "/tmp/b.txt"]))
+    }
+}

--- a/Tests/wired3Tests/TrackerControllerTests.swift
+++ b/Tests/wired3Tests/TrackerControllerTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+import WiredSwift
+@testable import wired3Lib
+
+final class TrackerControllerTests: XCTestCase {
+    func testTrackedServersPersistAcrossControllerRestart() throws {
+        let tempDir = try makeTemporaryDirectory()
+        let databaseController = makeDatabaseController(tempDir: tempDir)
+
+        let controller1 = TrackerController(databaseController: databaseController)
+        defer { controller1.stop() }
+
+        let client = makeClient(userID: 1)
+        client.ip = "203.0.113.10"
+
+        let message = makeRegisterMessage()
+        _ = try controller1.registerServer(client: client, message: message, allowedCategories: ["public"])
+
+        let controller2 = TrackerController(databaseController: databaseController)
+        defer { controller2.stop() }
+
+        let servers = controller2.activeServersSnapshot()
+        XCTAssertEqual(servers.count, 1)
+        XCTAssertEqual(servers.first?.sourceIP, "203.0.113.10")
+        XCTAssertEqual(servers.first?.category, "public")
+        XCTAssertEqual(servers.first?.name, "Tracked Server")
+    }
+
+    func testPurgingExpiredTrackedServersAlsoRemovesPersistence() throws {
+        let tempDir = try makeTemporaryDirectory()
+        let databaseController = makeDatabaseController(tempDir: tempDir)
+
+        let controller = TrackerController(databaseController: databaseController)
+        defer { controller.stop() }
+
+        let client = makeClient(userID: 1)
+        client.ip = "203.0.113.10"
+
+        let registeredAt = Date(timeIntervalSince1970: 1_000)
+        _ = try controller.registerServer(
+            client: client,
+            message: makeRegisterMessage(),
+            allowedCategories: ["public"],
+            now: registeredAt
+        )
+
+        controller.purgeExpiredServers(now: registeredAt.addingTimeInterval(TrackerController.entryExpirationInterval + 5))
+
+        XCTAssertEqual(controller.activeServersSnapshot().count, 0)
+
+        let persistedCount = try databaseController.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM tracked_servers") ?? 0
+        }
+        XCTAssertEqual(persistedCount, 0)
+    }
+
+    private func makeRegisterMessage() -> P7Message {
+        let spec = P7Spec(withPath: nil)
+        let message = P7Message(withName: "wired.tracker.send_register", spec: spec)
+        message.addParameter(field: "wired.tracker.tracker", value: false)
+        message.addParameter(field: "wired.tracker.category", value: "public")
+        message.addParameter(field: "wired.tracker.port", value: UInt32(4871))
+        message.addParameter(field: "wired.tracker.users", value: UInt32(3))
+        message.addParameter(field: "wired.info.name", value: "Tracked Server")
+        message.addParameter(field: "wired.info.description", value: "Persist me")
+        message.addParameter(field: "wired.info.files.count", value: UInt64(12))
+        message.addParameter(field: "wired.info.files.size", value: UInt64(34))
+        return message
+    }
+}


### PR DESCRIPTION
## Summary
- persist the local tracker registry in SQLite and reload active entries at startup
- add real-time out-of-band filesystem monitoring with FSEvents on macOS and inotify on Linux
- update parity documentation and add unit/integration coverage for the new behavior

## Testing
- swift test
- swiftlint lint