### PR TITLE
build: add release.sh and fix Gatekeeper check for unnotarized builds

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/WiredSwift-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/WiredSwift-Package.xcscheme
@@ -48,6 +48,34 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WiredChatBot"
+               BuildableName = "WiredChatBot"
+               BlueprintName = "WiredChatBot"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WiredServerApp"
+               BuildableName = "WiredServerApp"
+               BlueprintName = "WiredServerApp"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -66,6 +94,26 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3IntegrationTests"
+               BuildableName = "wired3IntegrationTests"
+               BlueprintName = "wired3IntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3Tests"
+               BuildableName = "wired3Tests"
+               BlueprintName = "wired3Tests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -78,6 +126,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WiredServerApp"
+            BuildableName = "WiredServerApp"
+            BlueprintName = "WiredServerApp"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -94,15 +152,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "wired3"
-            BuildableName = "wired3"
-            BlueprintName = "wired3"
+            BlueprintIdentifier = "WiredServerApp"
+            BuildableName = "WiredServerApp"
+            BlueprintName = "WiredServerApp"
             ReferencedContainer = "container:">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/wired3.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/wired3.xcscheme
@@ -52,6 +52,26 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3IntegrationTests"
+               BuildableName = "wired3IntegrationTests"
+               BlueprintName = "wired3IntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3Tests"
+               BuildableName = "wired3Tests"
+               BlueprintName = "wired3Tests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -78,19 +98,19 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--root /Users/nark/Development/Me/Swift/WiredSwift/run"
+            argument = "--root /Users/admin/Documents/Wired3/WiredSwift/run"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--db /Users/nark/Development/Me/Swift/WiredSwift/wired3.db"
+            argument = "--db /Users/admin/Documents/Wired3/WiredSwift/wired3.db"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--config /Users/nark/Development/Me/Swift/WiredSwift/Sources/wired3/config.ini"
+            argument = "--config /Users/admin/Documents/Wired3/WiredSwift/Sources/wired3/config.ini"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "/Users/nark/Development/Me/Swift/WiredSwift/run/wired.xml"
+            argument = "/Users/admin/Documents/Wired3/WiredSwift/run/wired.xml"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to WiredSwift are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [Unreleased]
+
+### Features
+- Add Wired 2.5 → Wired 3 database migration (`wired3 --migrate-from <path>`) — migrates users, groups, bans, boards, threads and posts ([`14ff423`](https://github.com/martinmarsian/WiredSwift/commit/14ff42328c0e66f69e66d30434e327a7c7de1bb6))
+
+- Support legacy SHA1 password authentication for accounts migrated from Wired 2.5; server signals `p7.encryption.legacy_password` in `server_challenge` and sets `wired.user.password_must_change` in the login reply to trigger a mandatory credential upgrade on the client ([`8cf6e3c`](https://github.com/martinmarsian/WiredSwift/commit/8cf6e3ca99f2ae1906fd21e2e25c8222485fee94))
+
+
 ## [3.0-beta.21+38] — 2026-04-13
 
 ### Bug Fixes

--- a/Scripts/build-wired-server-app.sh
+++ b/Scripts/build-wired-server-app.sh
@@ -20,6 +20,15 @@ APP_ZIP_PATH="$ROOT_DIR/dist/Wired-Server.app.zip"
 SERVER_ZIP_PATH="$ROOT_DIR/dist/$SERVER_BINARY_NAME.zip"
 NOTARIZE="${NOTARIZE:-}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+
+# Auto-load notary profile from ~/.wired-notary if not set via environment.
+# File format (shell-sourceable):  NOTARY_PROFILE="<your-profile>"
+if [[ -z "$NOTARY_PROFILE" && -f "${HOME}/.wired-notary" ]]; then
+  # shellcheck source=/dev/null
+  source "${HOME}/.wired-notary"
+  NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+fi
+
 VERSION_SWIFT="$ROOT_DIR/Sources/wired3/Core/Version.swift"
 VERSION_SWIFT_BACKUP=""
 
@@ -259,6 +268,15 @@ else
   codesign --force --sign - "$DIST_SERVER_BINARY"
   codesign --force --sign - "$RESOURCES_DIR/$SERVER_BINARY_NAME"
   codesign --force --deep --sign - "$APP_DIR"
+fi
+
+if [[ "$SIGNING_MODE" == "developer-id" && -z "$NOTARY_PROFILE" ]]; then
+  echo ""
+  echo "    TIP: Notarization is disabled. To enable it, create ~/.wired-notary:"
+  echo "         NOTARY_PROFILE=\"<profile-name>\""
+  echo "         Then store the credentials once with:"
+  echo "         xcrun notarytool store-credentials \"<profile-name>\" --apple-id <id> --team-id <team>"
+  echo ""
 fi
 
 if [[ -z "$NOTARIZE" ]]; then

--- a/Scripts/build-wired-server-app.sh
+++ b/Scripts/build-wired-server-app.sh
@@ -215,7 +215,7 @@ resolve_signing_identity() {
   fi
 
   local auto
-  auto="$(security find-identity -v -p codesigning 2>/dev/null | sed -n 's/.*"\\(Developer ID Application:[^"]*\\)".*/\\1/p' | head -n 1)"
+  auto="$(security find-identity -v -p codesigning 2>/dev/null | sed -nE 's/.*"(Developer ID Application:[^"]*)".*/\1/p' | head -n 1)"
   if [[ -n "$auto" ]]; then
     echo "$auto"
   fi
@@ -309,9 +309,11 @@ codesign --verify --deep --strict --verbose=2 "$DIST_SERVER_BINARY"
 codesign --verify --strict --verbose=2 "$RESOURCES_DIR/$SERVER_BINARY_NAME"
 codesign --verify --deep --strict --verbose=2 "$APP_DIR"
 
-if [[ "$SIGNING_MODE" == "developer-id" ]]; then
+if [[ "$SIGNING_MODE" == "developer-id" && "$NOTARIZE" == "1" ]]; then
   echo "==> Gatekeeper assessment"
   spctl --assess --type execute --verbose=4 "$APP_DIR"
+elif [[ "$SIGNING_MODE" == "developer-id" ]]; then
+  echo "==> Gatekeeper assessment skipped (app not notarized)"
 else
   echo "==> Skipping Gatekeeper assessment for ad-hoc signature"
 fi

--- a/Scripts/migrate-from-wired25.py
+++ b/Scripts/migrate-from-wired25.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""
+migrate-from-wired25.py
+Migrates users, groups and bans from a Wired 2.5 SQLite database
+into an existing Wired 3 (wired3) SQLite database.
+
+Usage:
+    python3 Scripts/migrate-from-wired25.py \
+        --source  /path/to/wired25/database.sqlite3 \
+        --target  /path/to/wired3/database.sqlite3  \
+        [--dry-run]   # analyse only, no writes
+        [--overwrite] # replace existing users/groups in Wired 3
+
+IMPORTANT:
+  • Make a backup of both databases before running!
+  • Wired 2.5 stores passwords as SHA1 hashes, Wired 3 uses SHA256 + salt.
+    Passwords are copied as-is. Wired 3 will treat them as "legacy" and users
+    will need to set a new password on first login (or you reset them manually).
+  • The 'admin' account that Wired 3 creates by default is never overwritten
+    unless --overwrite is passed.
+"""
+
+import sqlite3
+import argparse
+import sys
+from datetime import datetime, timezone
+
+# ── Privilege mapping: Wired 2.5 column → Wired 3 privilege name ─────────────
+#
+# Boolean privileges (0/1 in 2.5, stored as separate rows in 3)
+BOOL_PRIVILEGE_MAP = {
+    "user_get_info":                        "wired.account.user.get_info",
+    "user_disconnect_users":                "wired.account.user.disconnect_users",
+    "user_ban_users":                       "wired.account.user.ban_users",
+    "user_cannot_be_disconnected":          "wired.account.user.cannot_be_disconnected",
+    "user_cannot_set_nick":                 "wired.account.user.cannot_set_nick",
+    "user_get_users":                       "wired.account.user.get_users",
+    "chat_kick_users":                      "wired.account.chat.kick_users",
+    "chat_set_topic":                       "wired.account.chat.set_topic",
+    "chat_create_chats":                    "wired.account.chat.create_chats",
+    "message_send_messages":                "wired.account.message.send_messages",
+    "message_broadcast":                    "wired.account.message.broadcast",
+    "file_list_files":                      "wired.account.file.list_files",
+    "file_search_files":                    "wired.account.file.search_files",
+    "file_get_info":                        "wired.account.file.get_info",
+    "file_create_links":                    "wired.account.file.create_links",
+    "file_rename_files":                    "wired.account.file.rename_files",
+    "file_set_type":                        "wired.account.file.set_type",
+    "file_set_comment":                     "wired.account.file.set_comment",
+    "file_set_permissions":                 "wired.account.file.set_permissions",
+    "file_set_executable":                  "wired.account.file.set_executable",
+    "file_set_label":                       "wired.account.file.set_label",
+    "file_create_directories":              "wired.account.file.create_directories",
+    "file_move_files":                      "wired.account.file.move_files",
+    "file_delete_files":                    "wired.account.file.delete_files",
+    "file_access_all_dropboxes":            "wired.account.file.access_all_dropboxes",
+    "account_change_password":              "wired.account.account.change_password",
+    "account_list_accounts":               "wired.account.account.list_accounts",
+    "account_read_accounts":               "wired.account.account.read_accounts",
+    "account_create_users":                "wired.account.account.create_users",
+    "account_edit_users":                  "wired.account.account.edit_users",
+    "account_delete_users":                "wired.account.account.delete_users",
+    "account_create_groups":               "wired.account.account.create_groups",
+    "account_edit_groups":                 "wired.account.account.edit_groups",
+    "account_delete_groups":               "wired.account.account.delete_groups",
+    "account_raise_account_privileges":    "wired.account.account.raise_account_privileges",
+    "transfer_download_files":             "wired.account.transfer.download_files",
+    "transfer_upload_files":               "wired.account.transfer.upload_files",
+    "transfer_upload_anywhere":            "wired.account.transfer.upload_anywhere",
+    "transfer_upload_directories":         "wired.account.transfer.upload_directories",
+    "board_read_boards":                   "wired.account.board.read_boards",
+    "board_add_boards":                    "wired.account.board.add_boards",
+    "board_move_boards":                   "wired.account.board.move_boards",
+    "board_rename_boards":                 "wired.account.board.rename_boards",
+    "board_delete_boards":                 "wired.account.board.delete_boards",
+    "board_get_board_info":                "wired.account.board.get_board_info",
+    "board_set_board_info":                "wired.account.board.set_board_info",
+    "board_add_threads":                   "wired.account.board.add_threads",
+    "board_move_threads":                  "wired.account.board.move_threads",
+    "board_add_posts":                     "wired.account.board.add_posts",
+    "board_edit_own_threads_and_posts":    "wired.account.board.edit_own_threads_and_posts",
+    "board_edit_all_threads_and_posts":    "wired.account.board.edit_all_threads_and_posts",
+    "board_delete_own_threads_and_posts":  "wired.account.board.delete_own_threads_and_posts",
+    "board_delete_all_threads_and_posts":  "wired.account.board.delete_all_threads_and_posts",
+    "log_view_log":                        "wired.account.log.view_log",
+    "events_view_events":                  "wired.account.events.view_events",
+    "settings_get_settings":              "wired.account.settings.get_settings",
+    "settings_set_settings":              "wired.account.settings.set_settings",
+    "banlist_get_bans":                    "wired.account.banlist.get_bans",
+    "banlist_add_bans":                    "wired.account.banlist.add_bans",
+    "banlist_delete_bans":                 "wired.account.banlist.delete_bans",
+    "tracker_list_servers":                "wired.account.tracker.list_servers",
+    "tracker_register_servers":            "wired.account.tracker.register_servers",
+}
+
+# Integer privileges (stored as value in Wired 3, still as separate privilege rows)
+INT_PRIVILEGE_MAP = {
+    "file_recursive_list_depth_limit":     "wired.account.file.recursive_list_depth_limit",
+    "transfer_download_speed_limit":       "wired.account.transfer.download_speed_limit",
+    "transfer_upload_speed_limit":         "wired.account.transfer.upload_speed_limit",
+    "transfer_download_limit":             "wired.account.transfer.download_limit",
+    "transfer_upload_limit":               "wired.account.transfer.upload_limit",
+}
+
+
+def log(msg):
+    print(msg)
+
+
+def warn(msg):
+    print(f"  WARNING: {msg}")
+
+
+def migrate_groups(src, dst, dry_run, overwrite):
+    log("\n── Groups ───────────────────────────────────────────────")
+    rows = src.execute("SELECT name, color FROM groups").fetchall()
+    log(f"  Found {len(rows)} group(s) in Wired 2.5")
+
+    migrated = skipped = 0
+    for row in rows:
+        name  = row["name"]
+        color = row["color"]  # already in "wired.account.color.xxx" format or NULL
+
+        if dry_run:
+            log(f"  DRY   group '{name}'  color={color}")
+            migrated += 1
+            continue
+
+        exists = dst.execute(
+            "SELECT id FROM groups WHERE name = ?", (name,)
+        ).fetchone()
+
+        if exists and not overwrite:
+            log(f"  SKIP  group '{name}' (already exists)")
+            skipped += 1
+            continue
+
+        if exists:
+            dst.execute(
+                "UPDATE groups SET color = ? WHERE name = ?",
+                (color, name)
+            )
+            group_id = exists["id"]
+            log(f"  UPD   group '{name}'")
+        else:
+            cur = dst.execute(
+                "INSERT INTO groups (name, color) VALUES (?, ?)",
+                (name, color)
+            )
+            group_id = cur.lastrowid
+            log(f"  ADD   group '{name}'")
+
+        # Migrate group privileges
+        _migrate_privileges(
+            src_row=src.execute("SELECT * FROM groups WHERE name = ?", (name,)).fetchone(),
+            dst=dst,
+            table="group_privileges",
+            fk_col="group_id",
+            fk_val=group_id,
+            dry_run=dry_run,
+        )
+        migrated += 1
+
+    log(f"  → {migrated} migrated, {skipped} skipped")
+
+
+def migrate_users(src, dst, dry_run, overwrite):
+    log("\n── Users ────────────────────────────────────────────────")
+    rows = src.execute("SELECT * FROM users").fetchall()
+    log(f"  Found {len(rows)} user(s) in Wired 2.5")
+
+    migrated = skipped = 0
+    now = datetime.now(timezone.utc).isoformat()
+
+    for row in rows:
+        username = row["name"]
+
+        # Map fields
+        password          = row["password"] or ""
+        full_name         = row["full_name"]
+        comment           = row["comment"]
+        creation_time     = row["creation_time"]
+        modification_time = row["modification_time"]
+        login_time        = row["login_time"]
+        edited_by         = row["edited_by"]
+        downloads         = row["downloads"] or 0
+        download_xfr      = row["download_transferred"] or 0
+        uploads           = row["uploads"] or 0
+        upload_xfr        = row["upload_transferred"] or 0
+        group             = row["group"]
+        groups            = row["groups"]
+        color             = row["color"]
+        files             = row["files"]
+
+        if dry_run:
+            log(f"  DRY   user '{username}'  group={group}  color={color}")
+            migrated += 1
+            continue
+
+        exists = dst.execute(
+            "SELECT id FROM users WHERE username = ?", (username,)
+        ).fetchone()
+
+        if exists and not overwrite:
+            log(f"  SKIP  user '{username}' (already exists)")
+            skipped += 1
+            continue
+
+        if exists:
+            dst.execute("""
+                UPDATE users SET
+                    password=?, full_name=?, comment=?,
+                    creation_time=?, modification_time=?, login_time=?,
+                    edited_by=?, downloads=?, download_transferred=?,
+                    uploads=?, upload_transferred=?,
+                    "group"=?, groups=?, color=?, files=?,
+                    password_salt=NULL
+                WHERE username=?
+            """, (
+                password, full_name, comment,
+                creation_time, modification_time, login_time,
+                edited_by, downloads, download_xfr,
+                uploads, upload_xfr,
+                group, groups, color, files,
+                username,
+            ))
+            user_id = exists["id"]
+            # Remove old privileges so they get re-written cleanly
+            dst.execute("DELETE FROM user_privileges WHERE user_id = ?", (user_id,))
+            log(f"  UPD   user '{username}'")
+        else:
+            cur = dst.execute("""
+                INSERT INTO users (
+                    username, password, password_salt,
+                    full_name, comment,
+                    creation_time, modification_time, login_time,
+                    edited_by, downloads, download_transferred,
+                    uploads, upload_transferred,
+                    "group", groups, color, files
+                ) VALUES (?,?,NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """, (
+                username, password,
+                full_name, comment,
+                creation_time, modification_time, login_time,
+                edited_by, downloads, download_xfr,
+                uploads, upload_xfr,
+                group, groups, color, files,
+            ))
+            user_id = cur.lastrowid
+            log(f"  ADD   user '{username}'")
+
+        # Migrate user privileges
+        _migrate_privileges(
+            src_row=row,
+            dst=dst,
+            table="user_privileges",
+            fk_col="user_id",
+            fk_val=user_id,
+            dry_run=dry_run,
+        )
+        migrated += 1
+
+    log(f"  → {migrated} migrated, {skipped} skipped")
+
+
+def migrate_bans(src, dst, dry_run, overwrite):
+    log("\n── Bans ─────────────────────────────────────────────────")
+    rows = src.execute("SELECT ip, expiration_date FROM banlist").fetchall()
+    log(f"  Found {len(rows)} ban(s) in Wired 2.5")
+
+    migrated = skipped = 0
+    for row in rows:
+        ip_pattern      = row["ip"]
+        expiration_date = row["expiration_date"]
+
+        if dry_run:
+            log(f"  DRY   ban '{ip_pattern}'  expires={expiration_date}")
+            migrated += 1
+            continue
+
+        exists = dst.execute(
+            "SELECT id FROM banlist WHERE ip_pattern = ?", (ip_pattern,)
+        ).fetchone()
+
+        if exists and not overwrite:
+            log(f"  SKIP  ban '{ip_pattern}'")
+            skipped += 1
+            continue
+
+        if exists:
+            dst.execute(
+                "UPDATE banlist SET expiration_date = ? WHERE ip_pattern = ?",
+                (expiration_date, ip_pattern)
+            )
+        else:
+            dst.execute(
+                "INSERT INTO banlist (ip_pattern, expiration_date) VALUES (?, ?)",
+                (ip_pattern, expiration_date)
+            )
+        log(f"  ADD   ban '{ip_pattern}'  expires={expiration_date or 'never'}")
+        migrated += 1
+
+    log(f"  → {migrated} migrated, {skipped} skipped")
+
+
+def _migrate_privileges(src_row, dst, table, fk_col, fk_val, dry_run):
+    """Write privilege rows for a single user or group."""
+    cols = src_row.keys()
+
+    for src_col, priv_name in BOOL_PRIVILEGE_MAP.items():
+        if src_col not in cols:
+            continue
+        raw = src_row[src_col]
+        if raw is None:
+            continue
+        value = bool(int(raw))
+        if not dry_run:
+            dst.execute(
+                f"INSERT OR REPLACE INTO {table} (name, value, {fk_col}) VALUES (?,?,?)",
+                (priv_name, value, fk_val)
+            )
+
+    for src_col, priv_name in INT_PRIVILEGE_MAP.items():
+        if src_col not in cols:
+            continue
+        raw = src_row[src_col]
+        if raw is None:
+            continue
+        # Integer privileges: store the integer value cast to BOOLEAN column
+        # (Wired 3 treats these as numeric limits — 0 = unlimited)
+        value = int(raw)
+        if not dry_run:
+            dst.execute(
+                f"INSERT OR REPLACE INTO {table} (name, value, {fk_col}) VALUES (?,?,?)",
+                (priv_name, value, fk_val)
+            )
+
+
+def print_summary(src):
+    log("\n── Source database summary ───────────────────────────────")
+    for table in ("users", "groups", "banlist"):
+        try:
+            n = src.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            log(f"  {table:<12} {n} row(s)")
+        except Exception:
+            log(f"  {table:<12} (not found)")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Migrate Wired 2.5 database to Wired 3 format"
+    )
+    parser.add_argument("--source",    required=True, help="Path to Wired 2.5 database.sqlite3")
+    parser.add_argument("--target",    required=True, help="Path to Wired 3 database.sqlite3")
+    parser.add_argument("--dry-run",   action="store_true", help="Analyse only, no writes")
+    parser.add_argument("--overwrite", action="store_true", help="Replace existing records in Wired 3")
+    args = parser.parse_args()
+
+    log("╔══════════════════════════════════════════════════════════╗")
+    log("║        Wired 2.5 → Wired 3  database migration          ║")
+    log("╚══════════════════════════════════════════════════════════╝")
+    if args.dry_run:
+        log("  MODE: DRY RUN – no changes will be written\n")
+
+    src = sqlite3.connect(args.source)
+    src.row_factory = sqlite3.Row
+    dst = sqlite3.connect(args.target)
+    dst.row_factory = sqlite3.Row
+    dst.execute("PRAGMA foreign_keys = ON")
+    dst.execute("PRAGMA journal_mode = WAL")
+
+    print_summary(src)
+
+    try:
+        if not args.dry_run:
+            dst.execute("BEGIN")
+
+        migrate_groups(src, dst, args.dry_run, args.overwrite)
+        migrate_users(src, dst, args.dry_run, args.overwrite)
+        migrate_bans(src, dst, args.dry_run, args.overwrite)
+
+        if not args.dry_run:
+            dst.commit()
+            log("\n✓ Migration committed successfully.")
+        else:
+            log("\n✓ Dry run complete – no changes were written.")
+
+        log("")
+        log("  NOTE: Passwords were migrated as-is (SHA1 hashes from Wired 2.5).")
+        log("        Users will need to set a new password on their first login")
+        log("        to Wired 3 (use the admin panel to reset passwords).")
+
+    except Exception as e:
+        if not args.dry_run:
+            dst.rollback()
+        log(f"\n✗ ERROR: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        src.close()
+        dst.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Scripts/release.sh
+#  Build, sign, notarize and copy Wired Server artefacts to ~/Downloads.
+#
+#  Usage:
+#    bash Scripts/release.sh [debug|release]          (default: release)
+#
+#  Optional environment variables:
+#    WIRED_MARKETING_VERSION  override marketing version  (default: from last git tag)
+#    WIRED_BUILD_NUMBER       override build number       (default: from last git tag)
+#    WIRED_GIT_COMMIT         override commit hash        (default: current HEAD)
+#    APPLE_SIGN_IDENTITY      codesign identity           (default: auto from keychain)
+#    NOTARY_PROFILE           notarytool keychain profile (enables notarization)
+#    NOTARIZE                 force notarization (1/true/yes; auto if NOTARY_PROFILE set)
+# ─────────────────────────────────────────────────────────────────────────────
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_CONFIG="${1:-release}"
+DOWNLOADS_DIR="${HOME}/Downloads"
+
+# ── Version: auto-detect from last git tag (e.g. v3.0-beta.21+38) ────────────
+
+detect_version_from_tag() {
+  local tag stripped marketing build
+  tag="$(git -C "$ROOT_DIR" describe --tags --abbrev=0 2>/dev/null || echo "")"
+  [[ -z "$tag" ]] && return 1
+  stripped="${tag#v}"                    # e.g. "3.0-beta.21+38"
+  marketing="${stripped%%+*}"            # e.g. "3.0-beta.21"
+  build="1"
+  [[ "$stripped" == *+* ]] && build="${stripped##*+}"
+  echo "${marketing}|${build}"
+}
+
+if VERSION_INFO="$(detect_version_from_tag 2>/dev/null)"; then
+  DETECTED_MARKETING="${VERSION_INFO%%|*}"
+  DETECTED_BUILD="${VERSION_INFO##*|}"
+else
+  DETECTED_MARKETING="3.0"
+  DETECTED_BUILD="1"
+fi
+
+MARKETING_VERSION="${WIRED_MARKETING_VERSION:-$DETECTED_MARKETING}"
+BUILD_NUMBER="${WIRED_BUILD_NUMBER:-$DETECTED_BUILD}"
+GIT_COMMIT="${WIRED_GIT_COMMIT:-$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
+TAG="${MARKETING_VERSION}+${BUILD_NUMBER}"
+
+echo "============================================================"
+echo "  Wired Server – release"
+echo "  Version  : ${TAG}"
+echo "  Commit   : ${GIT_COMMIT}"
+echo "  Config   : ${BUILD_CONFIG}"
+echo "============================================================"
+echo ""
+
+# ── Delegate all building / signing / notarization to the main script ─────────
+
+export WIRED_MARKETING_VERSION="$MARKETING_VERSION"
+export WIRED_BUILD_NUMBER="$BUILD_NUMBER"
+export WIRED_GIT_COMMIT="$GIT_COMMIT"
+
+bash "$ROOT_DIR/Scripts/build-wired-server-app.sh" "$BUILD_CONFIG"
+
+# ── Copy artefacts to ~/Downloads ─────────────────────────────────────────────
+
+DIST_DIR="$ROOT_DIR/dist"
+APP_ZIP="$DIST_DIR/Wired-Server.app.zip"
+SERVER_ZIP="$DIST_DIR/wired3.zip"
+DIST_APP="$DIST_DIR/Wired Server.app"
+
+mkdir -p "$DOWNLOADS_DIR"
+
+echo ""
+echo "==> Copying artefacts to: ${DOWNLOADS_DIR}"
+
+copied=0
+
+if [[ -f "$APP_ZIP" ]]; then
+  DEST="$DOWNLOADS_DIR/Wired-Server-${TAG}.app.zip"
+  cp -f "$APP_ZIP" "$DEST"
+  echo "    Wired-Server-${TAG}.app.zip"
+  copied=$((copied + 1))
+fi
+
+if [[ -f "$SERVER_ZIP" ]]; then
+  DEST="$DOWNLOADS_DIR/wired3-${TAG}.zip"
+  cp -f "$SERVER_ZIP" "$DEST"
+  echo "    wired3-${TAG}.zip"
+  copied=$((copied + 1))
+fi
+
+if [[ -d "$DIST_APP" ]]; then
+  DEST_APP="$DOWNLOADS_DIR/Wired Server.app"
+  rm -rf "$DEST_APP"
+  cp -R "$DIST_APP" "$DEST_APP"
+  echo "    Wired Server.app"
+  copied=$((copied + 1))
+fi
+
+if [[ $copied -eq 0 ]]; then
+  echo "    WARNING: No artefacts found in $DIST_DIR"
+fi
+
+echo ""
+echo "==> Release complete"

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -95,3 +95,15 @@
 "error.database_not_initialized" = "Datenbank nicht initialisiert: Server zunächst einmal starten";
 "error.sql_prepare_failed" = "SQL-Vorbereitung fehlgeschlagen";
 "error.sql_execution_failed" = "SQL-Ausführung fehlgeschlagen";
+
+"database.migration.section" = "Migration von Wired 2.5";
+"database.migration.source" = "Wired 2.5-Datenbank";
+"database.migration.source.none" = "Keine Datei ausgewählt";
+"database.migration.overwrite" = "Vorhandene Einträge überschreiben";
+"database.migration.run" = "Migration starten";
+"database.migration.running" = "Migration läuft…";
+"database.migration.server_warning" = "Der Server muss gestoppt sein, bevor die Migration gestartet wird.";
+"database.migration.help" = "Migriert Benutzer, Gruppen und Sperren aus einer Wired 2.5-SQLite-Datenbank. Passwörter werden unverändert übernommen (SHA1) – Benutzer müssen beim ersten Login ein neues Passwort setzen.";
+"error.migration_no_source" = "Keine Quelldatenbank ausgewählt.";
+"error.migration_server_running" = "Stoppen Sie den Server, bevor Sie die Migration starten.";
+"error.migration_failed" = "Migration fehlgeschlagen";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -119,6 +119,15 @@
 "database.events.retention.monthly" = "Every month";
 "database.events.retention.yearly" = "Every year";
 
+"database.migration.section" = "Migration from Wired 2.5";
+"database.migration.source" = "Wired 2.5 database";
+"database.migration.source.none" = "No file selected";
+"database.migration.overwrite" = "Overwrite existing records";
+"database.migration.run" = "Start Migration";
+"database.migration.running" = "Migration in progress…";
+"database.migration.server_warning" = "The server must be stopped before running the migration.";
+"database.migration.help" = "Migrates users, groups and bans from a Wired 2.5 SQLite database. Passwords are copied as-is (SHA1) — users must set a new password on first login.";
+
 "advanced.admin.section" = "Admin account";
 "advanced.admin.password.placeholder" = "Admin password";
 "advanced.admin.set_password" = "Set Password";
@@ -187,3 +196,6 @@
 "error.database_not_initialized" = "Database not initialized: start the server once first";
 "error.sql_prepare_failed" = "SQL prepare failed";
 "error.sql_execution_failed" = "SQL execution failed";
+"error.migration_no_source" = "No source database selected.";
+"error.migration_server_running" = "Stop the server before running the migration.";
+"error.migration_failed" = "Migration failed";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -187,3 +187,15 @@
 "error.database_not_initialized" = "Base de données non initialisée : démarre le serveur une première fois";
 "error.sql_prepare_failed" = "Erreur SQL prepare";
 "error.sql_execution_failed" = "Erreur SQL execution";
+
+"database.migration.section" = "Migration depuis Wired 2.5";
+"database.migration.source" = "Base de données Wired 2.5";
+"database.migration.source.none" = "Aucun fichier sélectionné";
+"database.migration.overwrite" = "Écraser les entrées existantes";
+"database.migration.run" = "Démarrer la migration";
+"database.migration.running" = "Migration en cours…";
+"database.migration.server_warning" = "Le serveur doit être arrêté avant de lancer la migration.";
+"database.migration.help" = "Migre les utilisateurs, groupes et bannissements depuis une base SQLite Wired 2.5. Les mots de passe sont copiés tels quels (SHA1) — les utilisateurs devront définir un nouveau mot de passe à la première connexion.";
+"error.migration_no_source" = "Aucune base source sélectionnée.";
+"error.migration_server_running" = "Arrêtez le serveur avant de lancer la migration.";
+"error.migration_failed" = "Échec de la migration";

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -381,6 +381,86 @@ struct DatabaseTabView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
+
+                Section(L("database.migration.section")) {
+                    // Warning when server is running
+                    if model.isRunning {
+                        HStack(spacing: 6) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text(L("database.migration.server_warning"))
+                                .foregroundStyle(.orange)
+                        }
+                    }
+
+                    // File picker row
+                    HStack(spacing: 8) {
+                        Text(L("database.migration.source"))
+                            .bold()
+
+                        if model.migrationSourcePath.isEmpty {
+                            Text(L("database.migration.source.none"))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        } else {
+                            Text(model.migrationSourcePath)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .textSelection(.enabled)
+                        }
+
+                        Spacer(minLength: 0)
+
+                        Button(L("common.choose")) {
+                            model.chooseMigrationSource()
+                        }
+                        .disabled(model.isMigrating)
+                    }
+
+                    // Overwrite toggle
+                    Toggle(L("database.migration.overwrite"), isOn: $model.migrationOverwrite)
+                        .disabled(model.isMigrating)
+
+                    // Start button
+                    HStack {
+                        Spacer()
+                        if model.isMigrating {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                                .frame(width: 20, height: 20)
+                            Text(L("database.migration.running"))
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Button(L("database.migration.run")) {
+                                Task { await model.runMigration() }
+                            }
+                            .disabled(model.migrationSourcePath.isEmpty || model.isRunning)
+                        }
+                    }
+
+                    // Output area (shown once migration has run)
+                    if !model.migrationOutput.isEmpty {
+                        ScrollView {
+                            Text(model.migrationOutput)
+                                .font(.system(.caption, design: .monospaced))
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .topLeading)
+                                .padding(8)
+                        }
+                        .frame(minHeight: 180, maxHeight: 300)
+                        .background(Color(NSColor.textBackgroundColor))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                        )
+                    }
+
+                    Text(L("database.migration.help"))
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
             }
             .formStyle(.grouped)
         }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -86,6 +86,11 @@ final class WiredServerViewModel: ObservableObject {
     @Published var showInitialPasswordAlert: Bool = false
     @Published var initialAdminPassword: String = ""
 
+    @Published var migrationSourcePath: String = ""
+    @Published var isMigrating: Bool = false
+    @Published var migrationOutput: String = ""
+    @Published var migrationOverwrite: Bool = false
+
     private let fileManager = FileManager.default
     private var pollTimer: Timer?
     private var process: Process?
@@ -258,6 +263,90 @@ final class WiredServerViewModel: ObservableObject {
         if panel.runModal() == .OK, let selected = panel.url?.path {
             filesDirectory = selected
             saveFilesSettings()
+        }
+    }
+
+    func chooseMigrationSource() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = L("common.choose")
+        panel.title = L("database.migration.source")
+        if panel.runModal() == .OK, let selected = panel.url?.path {
+            migrationSourcePath = selected
+            migrationOutput = ""
+        }
+    }
+
+    func runMigration() async {
+        guard !isMigrating else { return }
+        guard !migrationSourcePath.isEmpty else {
+            publishError(L("error.migration_no_source"))
+            return
+        }
+        guard !isRunning else {
+            publishError(L("error.migration_server_running"))
+            return
+        }
+
+        let executable = fileManager.isExecutableFile(atPath: installedBinaryPath) ? installedBinaryPath : binaryPath
+        guard fileManager.isExecutableFile(atPath: executable) else {
+            publishError(L("error.wired3_binary_missing"))
+            return
+        }
+
+        isMigrating = true
+
+        var args: [String] = [
+            "--working-directory", workingDirectory,
+            "--db", databasePath,
+            "--migrate-from", migrationSourcePath
+        ]
+        if migrationOverwrite {
+            args.append("--overwrite")
+        }
+
+        migrationOutput = ""
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: executable)
+        task.currentDirectoryURL = URL(fileURLWithPath: workingDirectory, isDirectory: true)
+        task.arguments = args
+
+        // Write subprocess output to a temp file to avoid pipe-buffering race conditions.
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wired3-migration-\(Int(Date().timeIntervalSince1970)).log")
+        FileManager.default.createFile(atPath: tmpURL.path, contents: nil)
+        guard let writeHandle = FileHandle(forWritingAtPath: tmpURL.path) else {
+            isMigrating = false
+            publishError(L("error.migration_failed"))
+            return
+        }
+        task.standardOutput = writeHandle
+        task.standardError = writeHandle
+
+        do {
+            try task.run()
+        } catch {
+            writeHandle.closeFile()
+            isMigrating = false
+            publishError("\(L("error.migration_failed")): \(error.localizedDescription)")
+            return
+        }
+
+        // Wait for the process on a background thread, then read the temp file.
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            task.waitUntilExit()
+            writeHandle.closeFile()
+            let exitCode = task.terminationStatus
+            let data = (try? Data(contentsOf: tmpURL)) ?? Data()
+            let output = String(data: data, encoding: .utf8) ?? "(no output)"
+            try? FileManager.default.removeItem(at: tmpURL)
+            DispatchQueue.main.async {
+                self?.migrationOutput = output
+                self?.isMigrating = false
+            }
         }
     }
 

--- a/Sources/WiredSwift/Network/Connection.swift
+++ b/Sources/WiredSwift/Network/Connection.swift
@@ -31,6 +31,10 @@ public protocol ConnectionDelegate: class {
 
     func connectionDidLogin(connection: Connection, message: P7Message)
     func connectionDidReceivePriviledges(connection: Connection, message: P7Message)
+    /// Called when the server signals that the account was migrated from Wired 2.5 and the
+    /// user must set a new password before continuing.  The client should present a password-
+    /// change dialog and send `wired.account.change_password` before doing anything else.
+    func connectionRequiresPasswordChange(connection: Connection)
 }
 
 public protocol ClientInfoDelegate: class {
@@ -51,6 +55,7 @@ public extension ConnectionDelegate {
     func connectionDidSendMessage(connection: Connection, message: P7Message) { }
     func connectionDidLogin(connection: Connection, message: P7Message) { }
     func connectionDidReceivePriviledges(connection: Connection, message: P7Message) { }
+    func connectionRequiresPasswordChange(connection: Connection) { }
 }
 
 public extension ClientInfoDelegate {
@@ -552,9 +557,14 @@ open class Connection: NSObject {
             self.userID = uid
         }
 
+        let needsPasswordChange = response.bool(forField: "wired.user.password_must_change") ?? false
+
         DispatchQueue.main.async {
             for d in self.delegates {
                 d.connectionDidLogin(connection: self, message: response)
+                if needsPasswordChange {
+                    d.connectionRequiresPasswordChange(connection: self)
+                }
             }
         }
 

--- a/Sources/WiredSwift/P7/P7Socket.swift
+++ b/Sources/WiredSwift/P7/P7Socket.swift
@@ -300,6 +300,10 @@ public class P7Socket: NSObject {
 
     public var connected: Bool = false
     public var passwordProvider: SocketPasswordDelegate?
+    /// Set to `true` after a successful key exchange in which the server indicated that the
+    /// account uses a legacy SHA1 password hash (migrated from Wired 2.5).  Consumers should
+    /// treat this as a signal to force the user to change their password after login.
+    public var isLegacyAuth: Bool = false
 
     /// Server-side: provides the persistent identity key for TOFU signing.
     /// Set before calling `accept()` on the server side.
@@ -1295,12 +1299,9 @@ public class P7Socket: NSObject {
             throw P7SocketError.keyExchangeFailed(message)
         }
 
-        if self.password == nil || self.password?.isEmpty == true {
-            self.password = "".sha256()
-        } else {
-            self.password = self.password.sha256()
-        }
-        let passwordData = self.password.data(using: .utf8)!
+        // Keep the raw password for deferred hashing: the hash algorithm (SHA1 vs SHA256) is
+        // determined only after receiving the server_challenge in step 4.
+        let rawPassword: String = self.password ?? ""
 
         guard let ecdsa = ECDSA(privateKey: derivedKey) else {
             let message = "Cannot init ECDSA"
@@ -1336,7 +1337,16 @@ public class P7Socket: NSObject {
         }
 
         // Step 5: derive base_hash
-        // If server provided a per-user stored_salt, the expected stored hash is SHA256(storedSalt || SHA256(plain)).
+        // Check whether the server flagged this as a legacy SHA1 account (migrated from Wired 2.5).
+        // If so, hash the password with SHA1; otherwise use SHA256.
+        let isLegacy = challengeMsg.bool(forField: "p7.encryption.legacy_password") ?? false
+        let hashedPassword: String = isLegacy
+            ? (rawPassword.isEmpty ? "".sha1() : rawPassword.sha1())
+            : (rawPassword.isEmpty ? "".sha256() : rawPassword.sha256())
+        let passwordData = hashedPassword.data(using: .utf8)!
+        if isLegacy { self.isLegacyAuth = true }
+
+        // If server provided a per-user stored_salt, derive: SHA256(storedSalt || hashedPassword.utf8).
         // We replicate that derivation so both sides produce the same proof value.
         let baseHashData: Data
         if let encryptedStoredSalt = challengeMsg.data(forField: "p7.encryption.stored_salt"),
@@ -1536,7 +1546,12 @@ public class P7Socket: NSObject {
         // Per-user stored salt for base_hash derivation (nil = not yet assigned)
         let storedSalt = self.passwordProvider?.passwordSaltForUsername(username: self.username)
 
-        // Step 3: send server_challenge {encrypted stored_salt}
+        // Detect legacy SHA1 accounts migrated from Wired 2.5.
+        // A stored password that is exactly 40 hex chars and has no per-user salt is a SHA1 hash.
+        let isLegacyUser = (storedSalt == nil || storedSalt?.isEmpty == true)
+                         && (self.password?.count == 40)
+
+        // Step 3: send server_challenge {encrypted stored_salt [, legacy_password flag]}
         let storedSaltBytes: Data = storedSalt.flatMap { $0.isEmpty ? nil : $0.data(using: .utf8) } ?? Data()
         guard let encryptedStoredSalt = try? self.sslCipher.encrypt(data: storedSaltBytes) else {
             let message = "Cannot encrypt stored_salt for server_challenge"
@@ -1545,6 +1560,9 @@ public class P7Socket: NSObject {
         }
         let challengeMsg = P7Message(withName: "p7.encryption.server_challenge", spec: self.spec)
         challengeMsg.addParameter(field: "p7.encryption.stored_salt", value: encryptedStoredSalt)
+        if isLegacyUser {
+            challengeMsg.addParameter(field: "p7.encryption.legacy_password", value: true)
+        }
         if !self.write(challengeMsg) {
             let message = "Failed to send server_challenge"
             Logger.error(message)
@@ -1604,6 +1622,10 @@ public class P7Socket: NSObject {
             Logger.error(message)
             throw P7SocketError.keyExchangeFailed(message)
         }
+
+        // Record whether this session used legacy SHA1 auth so the application layer can
+        // skip the redundant wired.send_login password check and prompt for a password upgrade.
+        if isLegacyUser { self.isLegacyAuth = true }
 
         // Step 7: send acknowledge {server ECDSA signature}
         guard let ecdsa2 = ECDSA(privateKey: derivedKey) else {

--- a/Sources/WiredSwift/P7/P7Spec.swift
+++ b/Sources/WiredSwift/P7/P7Spec.swift
@@ -133,6 +133,10 @@ public class P7Spec: NSObject, XMLParserDelegate {
     <p7:field name="p7.encryption.server_identity_sig" id="20" type="data" />
     <!-- New in P7 v1.3: if true, clients MUST reject connections when the server identity key changes -->
     <p7:field name="p7.encryption.strict_identity" id="21" type="bool" />
+    <!-- New in P7 v1.4: if true, the account was migrated from Wired 2.5 and uses a SHA1 password hash.
+         The client must hash its password with SHA1 instead of SHA256 for this session, and
+         will be required to set a new password immediately after login. -->
+    <p7:field name="p7.encryption.legacy_password" id="22" type="bool" />
 
     <p7:field name="p7.compatibility_check.specification" id="15" type="string" />
     <p7:field name="p7.compatibility_check.status" id="16" type="bool" />
@@ -188,9 +192,11 @@ public class P7Spec: NSObject, XMLParserDelegate {
       <p7:parameter field="p7.encryption.username"   use="required" />
     </p7:message>
 
-    <!-- New in P7 v1.2: server sends per-user stored salt (encrypted) before client proves password -->
+    <!-- New in P7 v1.2: server sends per-user stored salt (encrypted) before client proves password.
+         In P7 v1.4 the optional legacy_password flag indicates the account uses a SHA1 hash. -->
     <p7:message name="p7.encryption.server_challenge" id="11">
       <p7:parameter field="p7.encryption.stored_salt" use="required" />
+      <p7:parameter field="p7.encryption.legacy_password" />
     </p7:message>
 
     <p7:message name="p7.compatibility_check.specification" id="8">

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -264,6 +264,14 @@
             <p7:enum name="wired.user.state.disconnecting" value="4" version="2.0" />
         </p7:field>
 
+        <p7:field name="wired.user.password_must_change" type="bool" id="3016" version="3.2">
+            <p7:documentation>
+                If true, the account was migrated from Wired 2.5 and only a legacy SHA1 password
+                hash is stored. The client must prompt the user to set a new password immediately
+                after login so that the account is upgraded to a proper SHA256+salt credential.
+            </p7:documentation>
+        </p7:field>
+
         <p7:field name="wired.chat.id" type="uint32" id="4000" version="2.0">
             <p7:documentation>
                 Identification number of a chat. This number should be created when each chat is
@@ -1684,10 +1692,12 @@
 
         <p7:message name="wired.login" id="2005" version="2.0">
             <p7:documentation>
-                Login reply.
+                Login reply. If [field:wired.user.password_must_change] is true, the client must
+                immediately prompt the user to set a new password via [message:wired.account.change_password].
             </p7:documentation>
             <p7:parameter field="wired.transaction" version="2.0" />
             <p7:parameter field="wired.user.id" use="required" version="2.0" />
+            <p7:parameter field="wired.user.password_must_change" version="3.2" />
         </p7:message>
         
         <p7:message name="wired.banned" id="2006" version="2.0">

--- a/Sources/wired3/Controllers/DatabaseController.swift
+++ b/Sources/wired3/Controllers/DatabaseController.swift
@@ -22,7 +22,7 @@ private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.sel
 /// shared `DatabaseController` instance that `AppController` creates at startup.
 public class DatabaseController {
     let baseURL: URL
-    private(set) var dbQueue: DatabaseQueue!
+    public private(set) var dbQueue: DatabaseQueue!
 
     /// Creates a new `DatabaseController` for the database at `baseURL`.
     ///

--- a/Sources/wired3/Controllers/DatabaseController.swift
+++ b/Sources/wired3/Controllers/DatabaseController.swift
@@ -56,6 +56,14 @@ public class DatabaseController {
             WiredMigrations.register(into: &migrator)
             try migrator.migrate(dbQueue)
 
+            // Checkpoint and truncate the WAL from any previous run before we start.
+            // On a fresh server start there are no active readers, so TRUNCATE is safe.
+            // This prevents accumulated stale FTS5 shadow-table writes in the WAL from
+            // causing SQLITE_IOERR on the first write transaction after a crash.
+            try dbQueue.write { db in
+                try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
+            }
+
             Logger.info("Database opened at \(baseURL.path)")
             return true
         } catch {

--- a/Sources/wired3/Controllers/IndexController.swift
+++ b/Sources/wired3/Controllers/IndexController.swift
@@ -28,6 +28,7 @@ public class IndexController: TableController {
     private let indexQueue = DispatchQueue(label: "wired3.index", qos: .utility)
     private var currentGeneration: Int64 = 0
     private var isIndexing: Bool = false
+    private var startupCheckDone = false
     // When a rebuild is running and another request arrives, set this flag so
     // exactly one extra rebuild is scheduled after the current one finishes.
     private var pendingRebuild: Bool = false
@@ -228,6 +229,13 @@ public class IndexController: TableController {
             }
         }
 
+        // On the very first rebuild after startup, probe FTS5 for write-level errors
+        // (e.g. SQLITE_IOERR on shadow tables) before investing time in a full traversal.
+        if !startupCheckDone {
+            startupCheckDone = true
+            performFTS5StartupCheck()
+        }
+
         let newGen = currentGeneration &+ 1
         var newSize: UInt64 = 0
         var newFiles: UInt64 = 0
@@ -404,6 +412,26 @@ public class IndexController: TableController {
         } catch {
             Logger.error("IndexController: FTS5 recovery failed: \(error) — FTS5 search disabled for this session")
             hasFTS5 = false
+        }
+    }
+
+    /// Probes FTS5 write-path health on the first rebuild after startup.
+    /// Runs `integrity-check` against the FTS5 shadow tables; if it throws
+    /// (e.g. SQLITE_IOERR), triggers `recoverIndexAndFTS5()` before the
+    /// expensive filesystem traversal begins. Always called from `indexQueue`.
+    private func performFTS5StartupCheck() {
+        guard hasFTS5 else { return }
+        do {
+            try databaseController.dbQueue.write { db in
+                // integrity-check validates internal FTS5 B-tree consistency and,
+                // for external-content tables, compares against the content table.
+                // We only care whether it throws; result rows are discarded.
+                try db.execute(sql: "INSERT INTO file_search(file_search) VALUES('integrity-check')")
+            }
+            Logger.info("IndexController: FTS5 startup check passed")
+        } catch {
+            Logger.warning("IndexController: FTS5 startup check failed (\(error)) — resetting before rebuild")
+            recoverIndexAndFTS5()
         }
     }
 

--- a/Sources/wired3/Controllers/IndexController.swift
+++ b/Sources/wired3/Controllers/IndexController.swift
@@ -292,16 +292,37 @@ public class IndexController: TableController {
         }
 
         // Atomically remove old-generation entries now that new ones are all inserted.
-        // FTS5 triggers handle the FTS index automatically.
+        //
+        // The FTS5 table uses content='index' (external content). The row-level delete
+        // trigger (index_ad) sends a 'delete' command to FTS5 for every removed row.
+        // If the server crashed mid-rebuild on a previous run, some rows in `index` may
+        // have no corresponding FTS5 entry — causing SQLITE_IOERR (error 10) when the
+        // trigger tries to delete a non-existent FTS5 rowid.
+        //
+        // Fix: drop the delete trigger, do the bulk delete, then call FTS5 'rebuild'
+        // which re-syncs the index from the current content table in one pass.
+        // The trigger is re-created afterwards for incremental addIndex/removeIndex calls.
         do {
             try databaseController.dbQueue.write { db in
+                if hasFTS5 {
+                    try db.execute(sql: "DROP TRIGGER IF EXISTS index_ad")
+                }
                 try WiredIndex
                     .filter(Column("generation_id") != newGen)
                     .deleteAll(db)
-
-                // Compact the FTS5 index after a full rebuild for optimal query speed.
                 if hasFTS5 {
+                    // Rebuild the FTS5 index from the current content of the `index` table.
+                    try db.execute(sql: "INSERT INTO file_search(file_search) VALUES('rebuild')")
+                    // Merge all B-tree segments for faster subsequent queries.
                     try db.execute(sql: "INSERT INTO file_search(file_search) VALUES('optimize')")
+                    // Restore the delete trigger for incremental updates.
+                    try db.execute(sql: """
+                        CREATE TRIGGER IF NOT EXISTS index_ad
+                        AFTER DELETE ON "index" BEGIN
+                            INSERT INTO file_search(file_search, rowid, name, virtual_path)
+                            VALUES ('delete', old.id, old.name, old.virtual_path);
+                        END
+                    """)
                 }
             }
             currentGeneration = newGen
@@ -314,7 +335,75 @@ public class IndexController: TableController {
             Logger.info("IndexController: rebuild complete in \(elapsed)s — \(newFiles) files (\(sizeDesc)), \(newDirs) dirs (gen \(newGen))")
         } catch {
             let elapsed = String(format: "%.2f", Date().timeIntervalSince(startTime))
-            Logger.error("IndexController: rebuild finalisation failed after \(elapsed)s: \(error)")
+            Logger.error("IndexController: rebuild finalisation failed after \(elapsed)s: \(error) — attempting FTS5 recovery")
+            // Nuclear reset: drop + recreate FTS5 and all triggers so the next rebuild
+            // starts from a clean state. pendingRebuild causes the defer block to schedule
+            // a fresh traversal immediately after this function returns.
+            recoverIndexAndFTS5()
+            pendingRebuild = true
+        }
+    }
+
+    // MARK: - Private — FTS5 recovery
+
+    /// Called when rebuild finalisation fails (e.g. SQLITE_IOERR on FTS5 shadow tables).
+    /// Drops and recreates the FTS5 virtual table and all synchronisation triggers so the
+    /// next rebuild starts from a fully clean state. Always called from `indexQueue`.
+    private func recoverIndexAndFTS5() {
+        Logger.info("IndexController: starting FTS5 recovery — clearing index and FTS5 shadow tables")
+        do {
+            try databaseController.dbQueue.write { db in
+                // Drop triggers first so clearing the index table does not cascade
+                // further FTS5 errors through the still-active delete trigger.
+                try db.execute(sql: "DROP TRIGGER IF EXISTS index_ai")
+                try db.execute(sql: "DROP TRIGGER IF EXISTS index_ad")
+                try db.execute(sql: "DROP TRIGGER IF EXISTS index_au")
+                // Drop the FTS5 virtual table (also removes all its shadow tables).
+                try db.execute(sql: "DROP TABLE IF EXISTS file_search")
+                // Clear the index table — no FTS5 trigger is active, so this is safe.
+                try db.execute(sql: "DELETE FROM \"index\"")
+                // Recreate the FTS5 table (mirrors WiredMigrations.v2).
+                try db.execute(sql: """
+                    CREATE VIRTUAL TABLE IF NOT EXISTS file_search
+                    USING fts5(
+                        name,
+                        virtual_path,
+                        content='index',
+                        content_rowid='id',
+                        tokenize='unicode61 remove_diacritics 2'
+                    )
+                """)
+                // Recreate synchronisation triggers.
+                try db.execute(sql: """
+                    CREATE TRIGGER IF NOT EXISTS index_ai
+                    AFTER INSERT ON "index" BEGIN
+                        INSERT INTO file_search(rowid, name, virtual_path)
+                        VALUES (new.id, new.name, new.virtual_path);
+                    END
+                """)
+                try db.execute(sql: """
+                    CREATE TRIGGER IF NOT EXISTS index_ad
+                    AFTER DELETE ON "index" BEGIN
+                        INSERT INTO file_search(file_search, rowid, name, virtual_path)
+                        VALUES ('delete', old.id, old.name, old.virtual_path);
+                    END
+                """)
+                try db.execute(sql: """
+                    CREATE TRIGGER IF NOT EXISTS index_au
+                    AFTER UPDATE ON "index" BEGIN
+                        INSERT INTO file_search(file_search, rowid, name, virtual_path)
+                        VALUES ('delete', old.id, old.name, old.virtual_path);
+                        INSERT INTO file_search(rowid, name, virtual_path)
+                        VALUES (new.id, new.name, new.virtual_path);
+                    END
+                """)
+            }
+            hasFTS5 = detectFTS5()
+            currentGeneration = 0
+            Logger.info("IndexController: FTS5 recovery succeeded — fresh rebuild will follow")
+        } catch {
+            Logger.error("IndexController: FTS5 recovery failed: \(error) — FTS5 search disabled for this session")
+            hasFTS5 = false
         }
     }
 

--- a/Sources/wired3/Controllers/MigrationController.swift
+++ b/Sources/wired3/Controllers/MigrationController.swift
@@ -1,0 +1,715 @@
+//
+//  MigrationController.swift
+//  wired3
+//
+//  Migrates users, groups and bans from a Wired 2.5 SQLite database
+//  into an existing Wired 3 (wired3) SQLite database.
+//
+//  Usage (via CLI):
+//    wired3 --migrate-from /path/to/wired25/database.sqlite3 [--overwrite]
+//
+//  IMPORTANT:
+//  • Make a backup of your Wired 3 database before running.
+//  • Wired 2.5 stores passwords as SHA1 hashes; Wired 3 uses SHA256+salt.
+//    Passwords are copied as-is (password_salt = NULL). Users will need to
+//    reset their passwords on first login.
+
+import Foundation
+import GRDB
+#if os(Linux)
+import CSQLite
+#else
+import SQLite3
+#endif
+
+/// Migrates accounts, privileges and bans from a Wired 2.5 SQLite database
+/// into an already-initialised Wired 3 GRDB `DatabaseQueue`.
+public final class MigrationController {
+
+    // MARK: - Privilege mappings
+
+    /// Wired 2.5 boolean column name → Wired 3 privilege name.
+    private static let boolPrivilegeMap: [(src: String, dst: String)] = [
+        ("user_get_info",                       "wired.account.user.get_info"),
+        ("user_disconnect_users",               "wired.account.user.disconnect_users"),
+        ("user_ban_users",                      "wired.account.user.ban_users"),
+        ("user_cannot_be_disconnected",         "wired.account.user.cannot_be_disconnected"),
+        ("user_cannot_set_nick",                "wired.account.user.cannot_set_nick"),
+        ("user_get_users",                      "wired.account.user.get_users"),
+        ("chat_kick_users",                     "wired.account.chat.kick_users"),
+        ("chat_set_topic",                      "wired.account.chat.set_topic"),
+        ("chat_create_chats",                   "wired.account.chat.create_chats"),
+        ("message_send_messages",               "wired.account.message.send_messages"),
+        ("message_broadcast",                   "wired.account.message.broadcast"),
+        ("file_list_files",                     "wired.account.file.list_files"),
+        ("file_search_files",                   "wired.account.file.search_files"),
+        ("file_get_info",                       "wired.account.file.get_info"),
+        ("file_create_links",                   "wired.account.file.create_links"),
+        ("file_rename_files",                   "wired.account.file.rename_files"),
+        ("file_set_type",                       "wired.account.file.set_type"),
+        ("file_set_comment",                    "wired.account.file.set_comment"),
+        ("file_set_permissions",                "wired.account.file.set_permissions"),
+        ("file_set_executable",                 "wired.account.file.set_executable"),
+        ("file_set_label",                      "wired.account.file.set_label"),
+        ("file_create_directories",             "wired.account.file.create_directories"),
+        ("file_move_files",                     "wired.account.file.move_files"),
+        ("file_delete_files",                   "wired.account.file.delete_files"),
+        ("file_access_all_dropboxes",           "wired.account.file.access_all_dropboxes"),
+        ("account_change_password",             "wired.account.account.change_password"),
+        ("account_list_accounts",               "wired.account.account.list_accounts"),
+        ("account_read_accounts",               "wired.account.account.read_accounts"),
+        ("account_create_users",                "wired.account.account.create_users"),
+        ("account_edit_users",                  "wired.account.account.edit_users"),
+        ("account_delete_users",                "wired.account.account.delete_users"),
+        ("account_create_groups",               "wired.account.account.create_groups"),
+        ("account_edit_groups",                 "wired.account.account.edit_groups"),
+        ("account_delete_groups",               "wired.account.account.delete_groups"),
+        ("account_raise_account_privileges",    "wired.account.account.raise_account_privileges"),
+        ("transfer_download_files",             "wired.account.transfer.download_files"),
+        ("transfer_upload_files",               "wired.account.transfer.upload_files"),
+        ("transfer_upload_anywhere",            "wired.account.transfer.upload_anywhere"),
+        ("transfer_upload_directories",         "wired.account.transfer.upload_directories"),
+        ("board_read_boards",                   "wired.account.board.read_boards"),
+        ("board_add_boards",                    "wired.account.board.add_boards"),
+        ("board_move_boards",                   "wired.account.board.move_boards"),
+        ("board_rename_boards",                 "wired.account.board.rename_boards"),
+        ("board_delete_boards",                 "wired.account.board.delete_boards"),
+        ("board_get_board_info",                "wired.account.board.get_board_info"),
+        ("board_set_board_info",                "wired.account.board.set_board_info"),
+        ("board_add_threads",                   "wired.account.board.add_threads"),
+        ("board_move_threads",                  "wired.account.board.move_threads"),
+        ("board_add_posts",                     "wired.account.board.add_posts"),
+        ("board_edit_own_threads_and_posts",    "wired.account.board.edit_own_threads_and_posts"),
+        ("board_edit_all_threads_and_posts",    "wired.account.board.edit_all_threads_and_posts"),
+        ("board_delete_own_threads_and_posts",  "wired.account.board.delete_own_threads_and_posts"),
+        ("board_delete_all_threads_and_posts",  "wired.account.board.delete_all_threads_and_posts"),
+        ("log_view_log",                        "wired.account.log.view_log"),
+        ("events_view_events",                  "wired.account.events.view_events"),
+        ("settings_get_settings",               "wired.account.settings.get_settings"),
+        ("settings_set_settings",               "wired.account.settings.set_settings"),
+        ("banlist_get_bans",                    "wired.account.banlist.get_bans"),
+        ("banlist_add_bans",                    "wired.account.banlist.add_bans"),
+        ("banlist_delete_bans",                 "wired.account.banlist.delete_bans"),
+        ("tracker_list_servers",                "wired.account.tracker.list_servers"),
+        ("tracker_register_servers",            "wired.account.tracker.register_servers"),
+    ]
+
+    /// Wired 2.5 integer column name → Wired 3 privilege name (stored as integer value).
+    private static let intPrivilegeMap: [(src: String, dst: String)] = [
+        ("file_recursive_list_depth_limit",  "wired.account.file.recursive_list_depth_limit"),
+        ("transfer_download_speed_limit",    "wired.account.transfer.download_speed_limit"),
+        ("transfer_upload_speed_limit",      "wired.account.transfer.upload_speed_limit"),
+        ("transfer_download_limit",          "wired.account.transfer.download_limit"),
+        ("transfer_upload_limit",            "wired.account.transfer.upload_limit"),
+    ]
+
+    // MARK: - Result
+
+    /// Summary counts returned after a completed migration.
+    public struct MigrationResult {
+        public var groupsMigrated  = 0
+        public var groupsSkipped   = 0
+        public var usersMigrated   = 0
+        public var usersSkipped    = 0
+        public var bansMigrated    = 0
+        public var bansSkipped     = 0
+        public var boardsMigrated  = 0
+        public var boardsSkipped   = 0
+        public var threadsMigrated = 0
+        public var threadsSkipped  = 0
+        public var postsMigrated   = 0
+        public var postsSkipped    = 0
+
+        public func printSummary() {
+            print("")
+            print("╔══════════════════════════════════════════════════════════╗")
+            print("║         Wired 2.5 → Wired 3  Migration Summary          ║")
+            print("╠══════════════════════════════════════════════════════════╣")
+            print(String(format: "║  Groups : %3d migrated, %3d skipped                      ║",
+                         groupsMigrated, groupsSkipped))
+            print(String(format: "║  Users  : %3d migrated, %3d skipped                      ║",
+                         usersMigrated, usersSkipped))
+            print(String(format: "║  Bans   : %3d migrated, %3d skipped                      ║",
+                         bansMigrated, bansSkipped))
+            print(String(format: "║  Boards : %3d migrated, %3d skipped                      ║",
+                         boardsMigrated, boardsSkipped))
+            print(String(format: "║  Threads: %3d migrated, %3d skipped                      ║",
+                         threadsMigrated, threadsSkipped))
+            print(String(format: "║  Posts  : %3d migrated, %3d skipped                      ║",
+                         postsMigrated, postsSkipped))
+            print("╠══════════════════════════════════════════════════════════╣")
+            print("║  NOTE: Passwords were migrated as SHA1 hashes.          ║")
+            print("║  Users must reset their passwords on first login.        ║")
+            print("╚══════════════════════════════════════════════════════════╝")
+        }
+    }
+
+    // MARK: - Properties
+
+    private let sourcePath: String
+    private let dbQueue: DatabaseQueue
+    private let overwrite: Bool
+
+    // MARK: - Init
+
+    /// Creates a new `MigrationController`.
+    ///
+    /// - Parameters:
+    ///   - sourcePath: Filesystem path to the Wired 2.5 `database.sqlite3` file.
+    ///   - dbQueue: The already-opened Wired 3 `DatabaseQueue`.
+    ///   - overwrite: When `true`, existing records in Wired 3 are overwritten.
+    public init(sourcePath: String, dbQueue: DatabaseQueue, overwrite: Bool = false) {
+        self.sourcePath = sourcePath
+        self.dbQueue    = dbQueue
+        self.overwrite  = overwrite
+    }
+
+    // MARK: - Public API
+
+    /// Runs the full migration and returns a result summary.
+    ///
+    /// Opens the Wired 2.5 source database read-only, then inside a single
+    /// Wired 3 write transaction migrates groups (with privileges), users
+    /// (with privileges) and bans. The source database is never modified.
+    ///
+    /// - Throws: Any SQLite or file-system error encountered during the migration.
+    /// - Returns: A `MigrationResult` with counts of migrated and skipped records.
+    public func run() throws -> MigrationResult {
+        guard FileManager.default.fileExists(atPath: sourcePath) else {
+            throw MigrationError.sourceNotFound(sourcePath)
+        }
+
+        print("")
+        print("╔══════════════════════════════════════════════════════════╗")
+        print("║         Wired 2.5 → Wired 3  database migration         ║")
+        print("╚══════════════════════════════════════════════════════════╝")
+        print("  Source : \(sourcePath)")
+
+        // Open Wired 2.5 source DB read-only via the raw SQLite3 C API.
+        // We use the C API directly so that GRDB's WAL / migration machinery
+        // does not interfere with the source database.
+        var srcDB: OpaquePointer?
+        let rc = sqlite3_open_v2(sourcePath, &srcDB, SQLITE_OPEN_READONLY, nil)
+        guard rc == SQLITE_OK, let srcDB else {
+            throw MigrationError.cannotOpenSource(sourcePath)
+        }
+        defer { sqlite3_close(srcDB) }
+
+        printSourceSummary(srcDB)
+
+        var result = MigrationResult()
+
+        // All Wired 3 writes happen inside a single GRDB transaction so that
+        // the target database is either fully updated or left untouched.
+        try dbQueue.write { db in
+            try migrateGroups(from: srcDB, into: db, result: &result)
+            try migrateUsers(from: srcDB, into: db, result: &result)
+            try migrateBans(from: srcDB, into: db, result: &result)
+            try migrateBoards(from: srcDB, into: db, result: &result)
+            try migrateThreads(from: srcDB, into: db, result: &result)
+            try migratePosts(from: srcDB, into: db, result: &result)
+        }
+
+        return result
+    }
+
+    // MARK: - Migration steps
+
+    private func migrateGroups(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Groups ───────────────────────────────────────────────")
+        let rows = try queryAll(srcDB, sql: "SELECT name, color FROM groups")
+        print("  Found \(rows.count) group(s) in Wired 2.5")
+
+        for row in rows {
+            guard let name = row["name"] else { continue }
+            let color: String? = row["color"]
+
+            let existingID = try Int64.fetchOne(
+                db,
+                sql: "SELECT id FROM groups WHERE name = ?",
+                arguments: [name]
+            )
+
+            let groupID: Int64
+            if let existingID {
+                guard overwrite else {
+                    print("  SKIP  group '\(name)' (already exists)")
+                    result.groupsSkipped += 1
+                    continue
+                }
+                try db.execute(
+                    sql: "UPDATE groups SET color = ? WHERE name = ?",
+                    arguments: [color, name]
+                )
+                groupID = existingID
+                print("  UPD   group '\(name)'")
+            } else {
+                try db.execute(
+                    sql: "INSERT INTO groups (name, color) VALUES (?, ?)",
+                    arguments: [name, color]
+                )
+                groupID = db.lastInsertedRowID
+                print("  ADD   group '\(name)'")
+            }
+
+            // Fetch the full source row to access all privilege columns.
+            let srcRows = try queryAll(srcDB, sql: "SELECT * FROM groups WHERE name = ?", args: [name])
+            try migratePrivileges(
+                srcRow: srcRows.first ?? [:],
+                into: db,
+                table: "group_privileges",
+                fkColumn: "group_id",
+                fkValue: groupID
+            )
+            result.groupsMigrated += 1
+        }
+
+        print("  → \(result.groupsMigrated) migrated, \(result.groupsSkipped) skipped")
+    }
+
+    private func migrateUsers(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Users ────────────────────────────────────────────────")
+        let rows = try queryAll(srcDB, sql: "SELECT * FROM users")
+        print("  Found \(rows.count) user(s) in Wired 2.5")
+
+        for row in rows {
+            // Wired 2.5 uses "name" as the primary key / login column.
+            guard let username = row["name"] else { continue }
+
+            let existingID = try Int64.fetchOne(
+                db,
+                sql: "SELECT id FROM users WHERE username = ?",
+                arguments: [username]
+            )
+
+            let userID: Int64
+            if let existingID {
+                guard overwrite else {
+                    print("  SKIP  user '\(username)' (already exists)")
+                    result.usersSkipped += 1
+                    continue
+                }
+                // password_salt is set to NULL because the migrated hash is SHA1,
+                // not a Wired 3 SHA256 hash. The server will treat it as a legacy
+                // credential and the user must set a new password on first login.
+                try db.execute(sql: """
+                    UPDATE users SET
+                        password=?, full_name=?, comment=?,
+                        creation_time=?, modification_time=?, login_time=?,
+                        edited_by=?, downloads=?, download_transferred=?,
+                        uploads=?, upload_transferred=?,
+                        "group"=?, groups=?, color=?, files=?,
+                        password_salt=NULL
+                    WHERE username=?
+                    """,
+                    arguments: [
+                        row["password"], row["full_name"], row["comment"],
+                        row["creation_time"], row["modification_time"], row["login_time"],
+                        row["edited_by"],
+                        row["downloads"].flatMap { Int64($0) } ?? 0,
+                        row["download_transferred"].flatMap { Int64($0) } ?? 0,
+                        row["uploads"].flatMap { Int64($0) } ?? 0,
+                        row["upload_transferred"].flatMap { Int64($0) } ?? 0,
+                        row["group"], row["groups"], row["color"], row["files"],
+                        username
+                    ]
+                )
+                try db.execute(sql: "DELETE FROM user_privileges WHERE user_id = ?", arguments: [existingID])
+                userID = existingID
+                print("  UPD   user '\(username)'")
+            } else {
+                try db.execute(sql: """
+                    INSERT INTO users (
+                        username, password, password_salt,
+                        full_name, comment,
+                        creation_time, modification_time, login_time,
+                        edited_by, downloads, download_transferred,
+                        uploads, upload_transferred,
+                        "group", groups, color, files
+                    ) VALUES (?,?,NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    """,
+                    arguments: [
+                        username, row["password"],
+                        row["full_name"], row["comment"],
+                        row["creation_time"], row["modification_time"], row["login_time"],
+                        row["edited_by"],
+                        row["downloads"].flatMap { Int64($0) } ?? 0,
+                        row["download_transferred"].flatMap { Int64($0) } ?? 0,
+                        row["uploads"].flatMap { Int64($0) } ?? 0,
+                        row["upload_transferred"].flatMap { Int64($0) } ?? 0,
+                        row["group"], row["groups"], row["color"], row["files"]
+                    ]
+                )
+                userID = db.lastInsertedRowID
+                print("  ADD   user '\(username)'")
+            }
+
+            try migratePrivileges(
+                srcRow: row,
+                into: db,
+                table: "user_privileges",
+                fkColumn: "user_id",
+                fkValue: userID
+            )
+            result.usersMigrated += 1
+        }
+
+        print("  → \(result.usersMigrated) migrated, \(result.usersSkipped) skipped")
+    }
+
+    private func migrateBans(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Bans ─────────────────────────────────────────────────")
+        let rows = try queryAll(srcDB, sql: "SELECT ip, expiration_date FROM banlist")
+        print("  Found \(rows.count) ban(s) in Wired 2.5")
+
+        for row in rows {
+            guard let ipPattern = row["ip"] else { continue }
+            let expirationDate: String? = row["expiration_date"]
+
+            let existingID = try Int64.fetchOne(
+                db,
+                sql: "SELECT id FROM banlist WHERE ip_pattern = ?",
+                arguments: [ipPattern]
+            )
+
+            if let existingID {
+                guard overwrite else {
+                    print("  SKIP  ban '\(ipPattern)'")
+                    result.bansSkipped += 1
+                    continue
+                }
+                try db.execute(
+                    sql: "UPDATE banlist SET expiration_date = ? WHERE id = ?",
+                    arguments: [expirationDate, existingID]
+                )
+            } else {
+                try db.execute(
+                    sql: "INSERT INTO banlist (ip_pattern, expiration_date) VALUES (?, ?)",
+                    arguments: [ipPattern, expirationDate]
+                )
+            }
+            print("  ADD   ban '\(ipPattern)'  expires=\(expirationDate ?? "never")")
+            result.bansMigrated += 1
+        }
+
+        print("  → \(result.bansMigrated) migrated, \(result.bansSkipped) skipped")
+    }
+
+    // MARK: - Boards / Threads / Posts
+
+    private func migrateBoards(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Boards ───────────────────────────────────────────────")
+        // Note: the column is named `group` (reserved keyword) in Wired 2.5.
+        let rows = try queryAll(srcDB, sql: "SELECT board, owner, `group`, mode FROM boards")
+        print("  Found \(rows.count) board(s) in Wired 2.5")
+
+        for row in rows {
+            guard let path = row["board"] else { continue }
+            let owner     = row["owner"] ?? ""
+            let groupName = row["group"] ?? ""
+            let mode      = Int(row["mode"] ?? "0") ?? 0
+
+            // Decompose Unix permission bits into the 6 Wired 3 boolean columns.
+            let ownerRead    = (mode & 0o400) != 0 ? 1 : 0
+            let ownerWrite   = (mode & 0o200) != 0 ? 1 : 0
+            let groupRead    = (mode & 0o040) != 0 ? 1 : 0
+            let groupWrite   = (mode & 0o020) != 0 ? 1 : 0
+            let everyoneRead  = (mode & 0o004) != 0 ? 1 : 0
+            let everyoneWrite = (mode & 0o002) != 0 ? 1 : 0
+
+            let exists = try String.fetchOne(
+                db, sql: "SELECT path FROM boards WHERE path = ?", arguments: [path]
+            ) != nil
+
+            if exists {
+                guard overwrite else {
+                    print("  SKIP  board '\(path)' (already exists)")
+                    result.boardsSkipped += 1
+                    continue
+                }
+                try db.execute(sql: """
+                    UPDATE boards SET owner=?, group_name=?,
+                        owner_read=?, owner_write=?,
+                        group_read=?, group_write=?,
+                        everyone_read=?, everyone_write=?
+                    WHERE path=?
+                    """,
+                    arguments: [owner, groupName,
+                                ownerRead, ownerWrite, groupRead, groupWrite,
+                                everyoneRead, everyoneWrite, path]
+                )
+                print("  UPD   board '\(path)'")
+            } else {
+                try db.execute(sql: """
+                    INSERT INTO boards
+                        (path, owner, group_name,
+                         owner_read, owner_write,
+                         group_read, group_write,
+                         everyone_read, everyone_write)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [path, owner, groupName,
+                                ownerRead, ownerWrite, groupRead, groupWrite,
+                                everyoneRead, everyoneWrite]
+                )
+                print("  ADD   board '\(path)'")
+            }
+            result.boardsMigrated += 1
+        }
+        print("  → \(result.boardsMigrated) migrated, \(result.boardsSkipped) skipped")
+    }
+
+    private func migrateThreads(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Threads ──────────────────────────────────────────────")
+        // Exclude icon (BLOB) and ip — handled separately or dropped.
+        let rows = try queryAll(srcDB,
+            sql: "SELECT thread, board, subject, text, post_date, edit_date, nick, login FROM threads")
+        print("  Found \(rows.count) thread(s) in Wired 2.5")
+
+        for row in rows {
+            guard let uuid = row["thread"], let boardPath = row["board"] else { continue }
+
+            let exists = try String.fetchOne(
+                db, sql: "SELECT uuid FROM board_threads WHERE uuid = ?", arguments: [uuid]
+            ) != nil
+
+            if exists {
+                guard overwrite else {
+                    print("  SKIP  thread '\(uuid)'")
+                    result.threadsSkipped += 1
+                    continue
+                }
+                try db.execute(sql: "DELETE FROM board_threads WHERE uuid = ?", arguments: [uuid])
+            }
+
+            let icon: Data? = queryBlobColumn(
+                srcDB, sql: "SELECT icon FROM threads WHERE thread = ?", args: [uuid])
+            let postDate = epochFrom(row["post_date"]) ?? 0.0
+            let editDate: Double? = epochFrom(row["edit_date"])
+
+            try db.execute(sql: """
+                INSERT INTO board_threads
+                    (uuid, board_path, subject, text, nick, login, post_date, edit_date, icon)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [uuid, boardPath,
+                            row["subject"] ?? "", row["text"] ?? "",
+                            row["nick"] ?? "", row["login"] ?? "",
+                            postDate, editDate, icon]
+            )
+            print("  ADD   thread '\(uuid)' board='\(boardPath)'")
+            result.threadsMigrated += 1
+        }
+        print("  → \(result.threadsMigrated) migrated, \(result.threadsSkipped) skipped")
+    }
+
+    private func migratePosts(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Posts ─────────────────────────────────────────────────")
+        let rows = try queryAll(srcDB,
+            sql: "SELECT post, thread, text, post_date, edit_date, nick, login FROM posts")
+        print("  Found \(rows.count) post(s) in Wired 2.5")
+
+        for row in rows {
+            guard let uuid = row["post"], let threadUUID = row["thread"] else { continue }
+
+            let exists = try String.fetchOne(
+                db, sql: "SELECT uuid FROM board_posts WHERE uuid = ?", arguments: [uuid]
+            ) != nil
+
+            if exists {
+                guard overwrite else {
+                    print("  SKIP  post '\(uuid)'")
+                    result.postsSkipped += 1
+                    continue
+                }
+                try db.execute(sql: "DELETE FROM board_posts WHERE uuid = ?", arguments: [uuid])
+            }
+
+            let icon: Data? = queryBlobColumn(
+                srcDB, sql: "SELECT icon FROM posts WHERE post = ?", args: [uuid])
+            let postDate = epochFrom(row["post_date"]) ?? 0.0
+            let editDate: Double? = epochFrom(row["edit_date"])
+
+            try db.execute(sql: """
+                INSERT INTO board_posts
+                    (uuid, thread_uuid, text, nick, login, post_date, edit_date, icon)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [uuid, threadUUID,
+                            row["text"] ?? "",
+                            row["nick"] ?? "", row["login"] ?? "",
+                            postDate, editDate, icon]
+            )
+            print("  ADD   post '\(uuid)'")
+            result.postsMigrated += 1
+        }
+        print("  → \(result.postsMigrated) migrated, \(result.postsSkipped) skipped")
+    }
+
+    // MARK: - Privilege helper
+
+    /// Inserts privilege rows for a single user or group.
+    ///
+    /// Non-null source columns are mapped using `boolPrivilegeMap` / `intPrivilegeMap`
+    /// and written to `table` (either `user_privileges` or `group_privileges`).
+    private func migratePrivileges(
+        srcRow: [String: String],
+        into db: Database,
+        table: String,
+        fkColumn: String,
+        fkValue: Int64
+    ) throws {
+        for (srcCol, dstName) in MigrationController.boolPrivilegeMap {
+            guard let raw = srcRow[srcCol] else { continue }
+            let value = (Int(raw) ?? 0) != 0
+            try db.execute(
+                sql: "INSERT OR REPLACE INTO \(table) (name, value, \(fkColumn)) VALUES (?,?,?)",
+                arguments: [dstName, value, fkValue]
+            )
+        }
+        for (srcCol, dstName) in MigrationController.intPrivilegeMap {
+            guard let raw = srcRow[srcCol] else { continue }
+            let value = Int64(raw) ?? 0
+            try db.execute(
+                sql: "INSERT OR REPLACE INTO \(table) (name, value, \(fkColumn)) VALUES (?,?,?)",
+                arguments: [dstName, value, fkValue]
+            )
+        }
+    }
+
+    // MARK: - Raw SQLite helpers
+
+    /// Executes a SELECT on the Wired 2.5 source database using the raw SQLite3
+    /// C API and returns all rows as `[columnName: value]` dictionaries.
+    ///
+    /// NULL columns are omitted from the dictionary (not stored as nil-valued
+    /// keys) so that consumers can use a simple `guard let x = row["col"]` check.
+    private func queryAll(
+        _ db: OpaquePointer,
+        sql: String,
+        args: [String] = []
+    ) throws -> [[String: String]] {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else {
+            throw MigrationError.sqliteError("prepare failed: \(sql)")
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        for (i, arg) in args.enumerated() {
+            sqlite3_bind_text(stmt, Int32(i + 1), (arg as NSString).utf8String, -1, nil)
+        }
+
+        let columnCount = sqlite3_column_count(stmt)
+        var columnNames = [String]()
+        for i in 0..<columnCount {
+            columnNames.append(String(cString: sqlite3_column_name(stmt, i)))
+        }
+
+        var rows = [[String: String]]()
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            var row = [String: String]()
+            for i in 0..<columnCount {
+                guard sqlite3_column_type(stmt, i) != SQLITE_NULL else { continue }
+                if let cStr = sqlite3_column_text(stmt, i) {
+                    row[columnNames[Int(i)]] = String(cString: cStr)
+                }
+            }
+            rows.append(row)
+        }
+        return rows
+    }
+
+    /// Executes a single-row, single-column SELECT on the source database and
+    /// returns the result as `Data` (for BLOB columns).  Returns `nil` when the
+    /// column is NULL or the query produces no rows.
+    private func queryBlobColumn(
+        _ db: OpaquePointer,
+        sql: String,
+        args: [String] = []
+    ) -> Data? {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else { return nil }
+        defer { sqlite3_finalize(stmt) }
+
+        for (i, arg) in args.enumerated() {
+            sqlite3_bind_text(stmt, Int32(i + 1), (arg as NSString).utf8String, -1, nil)
+        }
+
+        guard sqlite3_step(stmt) == SQLITE_ROW,
+              sqlite3_column_type(stmt, 0) != SQLITE_NULL,
+              let ptr = sqlite3_column_blob(stmt, 0) else { return nil }
+
+        let byteCount = Int(sqlite3_column_bytes(stmt, 0))
+        return Data(bytes: ptr, count: byteCount)
+    }
+
+    /// Converts a Wired 2.5 date string ("yyyy-MM-dd HH:mm:ss", UTC) to a
+    /// Unix-epoch `Double` suitable for Wired 3's REAL date columns.
+    private func epochFrom(_ string: String?) -> Double? {
+        guard let string else { return nil }
+        return MigrationController.wiredDateFormatter.date(from: string)?.timeIntervalSince1970
+    }
+
+    private static let wiredDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    // MARK: - Diagnostics
+
+    private func printSourceSummary(_ srcDB: OpaquePointer) {
+        print("\n── Source database summary ───────────────────────────────")
+        for table in ["users", "groups", "banlist", "boards", "threads", "posts"] {
+            if let rows = try? queryAll(srcDB, sql: "SELECT COUNT(*) AS n FROM \(table)"),
+               let first = rows.first,
+               let n = Int(first["n"] ?? "") {
+                let padded = table.padding(toLength: 12, withPad: " ", startingAt: 0)
+                print("  \(padded) \(n) row(s)")
+            }
+        }
+    }
+}
+
+// MARK: - Error type
+
+/// Errors that can be thrown by `MigrationController`.
+public enum MigrationError: Error, CustomStringConvertible {
+    case sourceNotFound(String)
+    case cannotOpenSource(String)
+    case sqliteError(String)
+
+    public var description: String {
+        switch self {
+        case .sourceNotFound(let p):   return "Source database not found: \(p)"
+        case .cannotOpenSource(let p): return "Cannot open source database: \(p)"
+        case .sqliteError(let msg):    return "SQLite error: \(msg)"
+        }
+    }
+}

--- a/Sources/wired3/Core/ServerController+Auth.swift
+++ b/Sources/wired3/Core/ServerController+Auth.swift
@@ -85,14 +85,31 @@ extension ServerController {
             return false
         }
 
-        guard let user = App.usersController.user(withUsername: login, password: password) else {
+        // Legacy SHA1 accounts (migrated from Wired 2.5) are authenticated by the P7 ECDSA key
+        // exchange which already used their stored SHA1 hash.  Bypass the redundant application-
+        // level hash comparison so that the SHA256 value sent in wired.send_login doesn't fail.
+        let isLegacy = client.socket.isLegacyAuth
+        let user: User?
+        if isLegacy {
+            user = App.usersController.userWithPrivileges(withUsername: login)
+            // Assign a stored_salt on the spot (same lazy-migration path as normal login)
+            if let u = user, u.passwordSalt == nil || u.passwordSalt!.isEmpty {
+                let salt = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+                         + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+                u.passwordSalt = salt
+                App.usersController.save(user: u)
+            }
+        } else {
+            user = App.usersController.user(withUsername: login, password: password)
+        }
+
+        guard let user else {
             // SECURITY (FINDING_A_014): Perform dummy SHA-256 to prevent username enumeration via timing
             _ = (UUID().uuidString + password).sha256()
 
             let reply = P7Message(withName: "wired.error", spec: message.spec)
             reply.addParameter(field: "wired.error.string", value: "Login failed")
-            reply.addParameter(field: "wired.error", value: UInt32(4
-            ))
+            reply.addParameter(field: "wired.error", value: UInt32(4))
             App.serverController.reply(client: client, reply: reply, message: message)
 
             Logger.warning("Login from \(clientIP) failed for '\(login)': Wrong password")
@@ -123,6 +140,11 @@ extension ServerController {
 
         let response = P7Message(withName: "wired.login", spec: self.spec)
         response.addParameter(field: "wired.user.id", value: client.userID)
+        // Inform the client that this is a legacy account and a password change is required.
+        if isLegacy {
+            response.addParameter(field: "wired.user.password_must_change", value: true)
+            Logger.info("Legacy SHA1 user '\(login)' logged in — client must prompt for password change")
+        }
         App.serverController.reply(client: client, reply: response, message: message)
 
         client.loginTime = Date()

--- a/Sources/wired3/main.swift
+++ b/Sources/wired3/main.swift
@@ -47,6 +47,14 @@ struct Wired: ParsableCommand {
     @Option(help: "Path to XML specification file")
     var spec: String?
 
+    @Option(name: .customLong("migrate-from"),
+            help: "Path to a Wired 2.5 SQLite database. Migrates users, groups and bans into the Wired 3 database, then exits.")
+    var migrateFrom: String?
+
+    @Flag(name: .customLong("overwrite"),
+          help: "When used with --migrate-from: overwrite existing records in the Wired 3 database.")
+    var overwrite = false
+
     @Argument(help: "Optional working directory path. For compatibility, an .xml path here is treated as the specification file path.")
     var path: String?
 
@@ -74,6 +82,40 @@ struct Wired: ParsableCommand {
         }
         bootstrapRuntimeFiles(using: resolved)
         configureLogger(logFilePath: resolved.logPath, configPath: resolved.configPath)
+
+        // ── Wired 2.5 → Wired 3 migration ────────────────────────────────────────
+        if let rawSourcePath = migrateFrom {
+            // Disable C-stdio buffering so every print() call writes immediately.
+            // Without this, output is fully-buffered on pipes/files and gets lost on crash.
+            setvbuf(stdout, nil, _IONBF, 0)
+            setvbuf(stderr, nil, _IONBF, 0)
+            let expandedSourcePath = (rawSourcePath as NSString).expandingTildeInPath
+            guard let spec = P7Spec(withUrl: URL(fileURLWithPath: resolved.specPath)) else {
+                fputs("wired3: cannot load spec at \(resolved.specPath)\n", stderr)
+                Foundation.exit(1)
+            }
+            let dbController = DatabaseController(
+                baseURL: URL(fileURLWithPath: resolved.dbPath),
+                spec: spec
+            )
+            guard dbController.initDatabase() else {
+                fputs("wired3: cannot open database at \(resolved.dbPath)\n", stderr)
+                Foundation.exit(1)
+            }
+            let migrator = MigrationController(
+                sourcePath: expandedSourcePath,
+                dbQueue: dbController.dbQueue,
+                overwrite: overwrite
+            )
+            do {
+                let result = try migrator.run()
+                result.printSummary()
+            } catch {
+                fputs("wired3: migration failed: \(error)\n", stderr)
+                Foundation.exit(1)
+            }
+            return
+        }
 
         Logger.info("Starting \(WiredServerVersion.display)")
 


### PR DESCRIPTION
- Add Scripts/release.sh: wrapper around build-wired-server-app.sh that auto-detects version from git tag and copies artefacts to ~/Downloads
- Fix Scripts/build-wired-server-app.sh: skip spctl Gatekeeper assessment when app is not notarized (avoids false failure with set -euo pipefail)

## Summary

<!-- What does this PR change? -->

## Why

<!-- Why is this change needed? Bug, feature request, refactor goal, etc. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — refactoring, no behavior change
- [ ] `perf` — performance improvement
- [ ] `test` — tests only
- [ ] `docs` — documentation only
- [ ] `chore` / `ci` — tooling, build, CI

## Behavioral impact

<!-- User-visible/API/protocol impact. Write "none" if no impact. -->

- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] Database/schema/data migration required

## Validation

<!-- Paste key outputs or a short summary of what you ran locally. -->

```bash
swift build --product wired3
swift test
swiftlint lint
```

## Checklist

- [ ] Tests added/updated when behavior changed
- [ ] Docs/README/CHANGELOG updated when needed
- [ ] `swift build` passes locally
- [ ] `swift test` passes locally
- [ ] SwiftLint reports no new errors (`swiftlint lint`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [ ] No new `swiftlint:disable` without a `TODO:` comment explaining why

## Related issues

<!-- Closes #123 / Relates to #456 -->
