### PR TITLE
feat: offline private messaging, Wired 2.5 migration, legacy SHA1 auth, and stability fixes

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/WiredSwift-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/WiredSwift-Package.xcscheme
@@ -48,6 +48,34 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WiredChatBot"
+               BuildableName = "WiredChatBot"
+               BlueprintName = "WiredChatBot"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WiredServerApp"
+               BuildableName = "WiredServerApp"
+               BlueprintName = "WiredServerApp"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -66,6 +94,26 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3IntegrationTests"
+               BuildableName = "wired3IntegrationTests"
+               BlueprintName = "wired3IntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3Tests"
+               BuildableName = "wired3Tests"
+               BlueprintName = "wired3Tests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -78,6 +126,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WiredServerApp"
+            BuildableName = "WiredServerApp"
+            BlueprintName = "WiredServerApp"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -94,15 +152,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "wired3"
-            BuildableName = "wired3"
-            BlueprintName = "wired3"
+            BlueprintIdentifier = "WiredServerApp"
+            BuildableName = "WiredServerApp"
+            BlueprintName = "WiredServerApp"
             ReferencedContainer = "container:">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/wired3.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/wired3.xcscheme
@@ -52,6 +52,26 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3IntegrationTests"
+               BuildableName = "wired3IntegrationTests"
+               BlueprintName = "wired3IntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3Tests"
+               BuildableName = "wired3Tests"
+               BlueprintName = "wired3Tests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -78,19 +98,19 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--root /Users/nark/Development/Me/Swift/WiredSwift/run"
+            argument = "--root /Users/admin/Documents/Wired3/WiredSwift/run"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--db /Users/nark/Development/Me/Swift/WiredSwift/wired3.db"
+            argument = "--db /Users/admin/Documents/Wired3/WiredSwift/wired3.db"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--config /Users/nark/Development/Me/Swift/WiredSwift/Sources/wired3/config.ini"
+            argument = "--config /Users/admin/Documents/Wired3/WiredSwift/Sources/wired3/config.ini"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "/Users/nark/Development/Me/Swift/WiredSwift/run/wired.xml"
+            argument = "/Users/admin/Documents/Wired3/WiredSwift/run/wired.xml"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to WiredSwift are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [Unreleased]
+
+### Features
+- Add Wired 2.5 → Wired 3 database migration (`wired3 --migrate-from <path>`) — migrates users, groups, bans, boards, threads and posts ([`14ff423`](https://github.com/martinmarsian/WiredSwift/commit/14ff42328c0e66f69e66d30434e327a7c7de1bb6))
+
+- Support legacy SHA1 password authentication for accounts migrated from Wired 2.5; server signals `p7.encryption.legacy_password` in `server_challenge` and sets `wired.user.password_must_change` in the login reply to trigger a mandatory credential upgrade on the client ([`8cf6e3c`](https://github.com/martinmarsian/WiredSwift/commit/8cf6e3ca99f2ae1906fd21e2e25c8222485fee94))
+
+
 ## [3.0-beta.22+42] — 2026-04-20
 
 ### Bug Fixes
@@ -14,7 +22,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Refactoring
 - Move WiredChatBot in separated repo ([`6166223`](https://github.com/nark/WiredSwift/commit/6166223b5feaef77d760884d4c0718ee73216d1f))
-
 ## [3.0-beta.21+38] — 2026-04-13
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The project is currently in beta. It is already usable, but it is still evolving
 
 Releases: https://github.com/nark/WiredSwift/releases
 
+> **Client compatibility:** Wired 3.0 uses a new version of the P7 protocol and is **not compatible** with older Wired 2.x clients (including Zankasoftware-era clients). Only Wired 3.x clients can connect to a Wired 3.0 server.
+
 ---
 
 ## Table of Contents

--- a/Scripts/build-wired-server-app.sh
+++ b/Scripts/build-wired-server-app.sh
@@ -37,7 +37,7 @@ if [[ "$BUILD_CONFIG" != "debug" && "$BUILD_CONFIG" != "release" ]]; then
   exit 1
 fi
 
-if [[ ! "$MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+if [[ ! "$MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+)*(-[a-zA-Z0-9.]+)?$ ]]; then
   echo "Invalid WIRED_MARKETING_VERSION: $MARKETING_VERSION"
   exit 1
 fi

--- a/Scripts/build-wired-server-app.sh
+++ b/Scripts/build-wired-server-app.sh
@@ -20,6 +20,15 @@ APP_ZIP_PATH="$ROOT_DIR/dist/Wired-Server.app.zip"
 SERVER_ZIP_PATH="$ROOT_DIR/dist/$SERVER_BINARY_NAME.zip"
 NOTARIZE="${NOTARIZE:-}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+
+# Auto-load notary profile from ~/.wired-notary if not set via environment.
+# File format (shell-sourceable):  NOTARY_PROFILE="<your-profile>"
+if [[ -z "$NOTARY_PROFILE" && -f "${HOME}/.wired-notary" ]]; then
+  # shellcheck source=/dev/null
+  source "${HOME}/.wired-notary"
+  NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+fi
+
 VERSION_SWIFT="$ROOT_DIR/Sources/wired3/Core/Version.swift"
 VERSION_SWIFT_BACKUP=""
 
@@ -259,6 +268,15 @@ else
   codesign --force --sign - "$DIST_SERVER_BINARY"
   codesign --force --sign - "$RESOURCES_DIR/$SERVER_BINARY_NAME"
   codesign --force --deep --sign - "$APP_DIR"
+fi
+
+if [[ "$SIGNING_MODE" == "developer-id" && -z "$NOTARY_PROFILE" ]]; then
+  echo ""
+  echo "    TIP: Notarization is disabled. To enable it, create ~/.wired-notary:"
+  echo "         NOTARY_PROFILE=\"<profile-name>\""
+  echo "         Then store the credentials once with:"
+  echo "         xcrun notarytool store-credentials \"<profile-name>\" --apple-id <id> --team-id <team>"
+  echo ""
 fi
 
 if [[ -z "$NOTARIZE" ]]; then

--- a/Scripts/migrate-from-wired25.py
+++ b/Scripts/migrate-from-wired25.py
@@ -220,7 +220,7 @@ def migrate_users(src, dst, dry_run, overwrite):
                     edited_by=?, downloads=?, download_transferred=?,
                     uploads=?, upload_transferred=?,
                     "group"=?, groups=?, color=?, files=?,
-                    password_salt=NULL
+                    password_salt=NULL, is_legacy=1
                 WHERE username=?
             """, (
                 password, full_name, comment,
@@ -237,13 +237,13 @@ def migrate_users(src, dst, dry_run, overwrite):
         else:
             cur = dst.execute("""
                 INSERT INTO users (
-                    username, password, password_salt,
+                    username, password, password_salt, is_legacy,
                     full_name, comment,
                     creation_time, modification_time, login_time,
                     edited_by, downloads, download_transferred,
                     uploads, upload_transferred,
                     "group", groups, color, files
-                ) VALUES (?,?,NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                ) VALUES (?,?,NULL,1,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
             """, (
                 username, password,
                 full_name, comment,

--- a/Sources/WiredSwift/Core/WiredProtocolSpec.swift
+++ b/Sources/WiredSwift/Core/WiredProtocolSpec.swift
@@ -1,21 +1,28 @@
 import Foundation
 
+// Mirrors what SPM generates in Bundle.module: a class whose bundle lookup
+// locates the WiredSwift resource bundle regardless of whether the caller is
+// an app, a test target, or a standalone daemon binary.
+private final class _BundleFinder: NSObject {}
+
 public enum WiredProtocolSpec {
     public static func bundledSpecURL() -> URL? {
-        // Bundle.module crashes with assertionFailure when the SPM .bundle directory
-        // is missing from the app package. Search manually instead.
-        //
-        // Path reasoning:
-        //  - Production app:    Bundle.main.resourceURL / Contents/Resources
-        //  - Linux swift test:  executable is in .build/debug/, bundle is beside it
-        //  - macOS swift test:  Bundle.main.bundleURL is the .xctest package;
-        //                       its parent directory is .build/debug/ where the
-        //                       WiredSwift_WiredSwift.bundle actually lives
+        // Bundle.module fatalErrors when the .bundle directory is missing (e.g.
+        // when the wired3 binary is installed standalone without the app bundle).
+        // Search manually with the same candidates SPM uses, but return nil on
+        // failure instead of crashing.
         let bundleName = "WiredSwift_WiredSwift"
         let candidates: [URL?] = [
+            // App bundle / xctest Contents/Resources/ (macOS app and swift test)
             Bundle.main.resourceURL?.appendingPathComponent("\(bundleName).bundle"),
+            // Class bundle — mirrors SPM's Bundle(for: BundleFinder.self) candidate;
+            // on macOS swift test this resolves the xctest's resource directory
+            // where SPM embeds the package resource bundle.
+            Bundle(for: _BundleFinder.self).resourceURL?.appendingPathComponent("\(bundleName).bundle"),
+            // Executable's directory (Linux swift test, standalone binary)
             Bundle.main.executableURL?.deletingLastPathComponent()
                 .appendingPathComponent("\(bundleName).bundle"),
+            // xctest bundle parent directory (fallback for macOS swift test)
             Bundle.main.bundleURL.deletingLastPathComponent()
                 .appendingPathComponent("\(bundleName).bundle"),
         ]

--- a/Sources/WiredSwift/Core/WiredProtocolSpec.swift
+++ b/Sources/WiredSwift/Core/WiredProtocolSpec.swift
@@ -2,7 +2,21 @@ import Foundation
 
 public enum WiredProtocolSpec {
     public static func bundledSpecURL() -> URL? {
-        Bundle.module.url(forResource: "wired", withExtension: "xml")
+        // Bundle.module crashes with assertionFailure when the SPM .bundle directory
+        // is missing from the app package. Search manually instead, then fall back to
+        // Bundle.main.resourceURL where the build script also copies wired.xml directly.
+        let candidates: [URL?] = [
+            Bundle.main.resourceURL?.appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+            Bundle.main.executableURL?.deletingLastPathComponent()
+                .appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+        ]
+        for case let bundleURL? in candidates {
+            if let b = Bundle(url: bundleURL),
+               let url = b.url(forResource: "wired", withExtension: "xml") {
+                return url
+            }
+        }
+        return Bundle.main.url(forResource: "wired", withExtension: "xml")
     }
 
     public static func bundledSpec() -> P7Spec? {

--- a/Sources/WiredSwift/Core/WiredProtocolSpec.swift
+++ b/Sources/WiredSwift/Core/WiredProtocolSpec.swift
@@ -2,31 +2,36 @@ import Foundation
 
 public enum WiredProtocolSpec {
     public static func bundledSpecURL() -> URL? {
-        // Bundle.module fatalErrors when the .bundle directory is missing (e.g.
-        // when the wired3 binary is installed standalone without the app bundle).
-        // Replicate the same search logic SPM generates but return nil instead
-        // of crashing.
-        //
-        // Candidate reasoning (matches resource_bundle_accessor.swift generated
-        // by this version of SPM):
-        //   macOS swift test:  bundle is at Bundle.main.bundleURL/<name>.bundle
-        //                      (inside xctest root, not in Contents/Resources/)
-        //   macOS app:         bundle is at Bundle.main.resourceURL/<name>.bundle
-        //   Linux swift test:  bundle is next to the test executable
-        //   Standalone binary: same as Linux (executable parent dir), or nil
+        // Bundle.module crashes with fatalError when the .bundle directory is
+        // missing (e.g. standalone wired3 binary without an app bundle alongside).
+        // This replicates the same search but returns nil gracefully.
         let bundleName = "WiredSwift_WiredSwift"
-        let candidates: [URL?] = [
-            Bundle.main.bundleURL.appendingPathComponent("\(bundleName).bundle"),
-            Bundle.main.resourceURL?.appendingPathComponent("\(bundleName).bundle"),
-            Bundle.main.executableURL?.deletingLastPathComponent()
-                .appendingPathComponent("\(bundleName).bundle"),
-        ]
-        for case let bundleURL? in candidates {
-            if let b = Bundle(url: bundleURL),
+
+        // macOS app bundle: SPM places the resource bundle inside Contents/Resources/.
+        if let resourceURL = Bundle.main.resourceURL {
+            let candidate = resourceURL.appendingPathComponent("\(bundleName).bundle")
+            if let b = Bundle(path: candidate.path),
                let url = b.url(forResource: "wired", withExtension: "xml") {
                 return url
             }
         }
+
+        // macOS swift test: executable lives at xctest/Contents/MacOS/<name>,
+        // so the build-output directory (where the bundle actually is) is 4 hops up.
+        // Linux swift test: executable is directly in the build dir (1 hop up).
+        // Walk up from the executable until we find the bundle or exhaust candidates.
+        let execURL = Bundle.main.executableURL
+            ?? URL(fileURLWithPath: CommandLine.arguments[0])
+        var searchDir = execURL
+        for _ in 0..<5 {
+            searchDir = searchDir.deletingLastPathComponent()
+            let candidate = searchDir.appendingPathComponent("\(bundleName).bundle")
+            if let b = Bundle(path: candidate.path),
+               let url = b.url(forResource: "wired", withExtension: "xml") {
+                return url
+            }
+        }
+
         return Bundle.main.url(forResource: "wired", withExtension: "xml")
     }
 

--- a/Sources/WiredSwift/Core/WiredProtocolSpec.swift
+++ b/Sources/WiredSwift/Core/WiredProtocolSpec.swift
@@ -1,29 +1,24 @@
 import Foundation
 
-// Mirrors what SPM generates in Bundle.module: a class whose bundle lookup
-// locates the WiredSwift resource bundle regardless of whether the caller is
-// an app, a test target, or a standalone daemon binary.
-private final class _BundleFinder: NSObject {}
-
 public enum WiredProtocolSpec {
     public static func bundledSpecURL() -> URL? {
         // Bundle.module fatalErrors when the .bundle directory is missing (e.g.
         // when the wired3 binary is installed standalone without the app bundle).
-        // Search manually with the same candidates SPM uses, but return nil on
-        // failure instead of crashing.
+        // Replicate the same search logic SPM generates but return nil instead
+        // of crashing.
+        //
+        // Candidate reasoning (matches resource_bundle_accessor.swift generated
+        // by this version of SPM):
+        //   macOS swift test:  bundle is at Bundle.main.bundleURL/<name>.bundle
+        //                      (inside xctest root, not in Contents/Resources/)
+        //   macOS app:         bundle is at Bundle.main.resourceURL/<name>.bundle
+        //   Linux swift test:  bundle is next to the test executable
+        //   Standalone binary: same as Linux (executable parent dir), or nil
         let bundleName = "WiredSwift_WiredSwift"
         let candidates: [URL?] = [
-            // App bundle / xctest Contents/Resources/ (macOS app and swift test)
+            Bundle.main.bundleURL.appendingPathComponent("\(bundleName).bundle"),
             Bundle.main.resourceURL?.appendingPathComponent("\(bundleName).bundle"),
-            // Class bundle — mirrors SPM's Bundle(for: BundleFinder.self) candidate;
-            // on macOS swift test this resolves the xctest's resource directory
-            // where SPM embeds the package resource bundle.
-            Bundle(for: _BundleFinder.self).resourceURL?.appendingPathComponent("\(bundleName).bundle"),
-            // Executable's directory (Linux swift test, standalone binary)
             Bundle.main.executableURL?.deletingLastPathComponent()
-                .appendingPathComponent("\(bundleName).bundle"),
-            // xctest bundle parent directory (fallback for macOS swift test)
-            Bundle.main.bundleURL.deletingLastPathComponent()
                 .appendingPathComponent("\(bundleName).bundle"),
         ]
         for case let bundleURL? in candidates {

--- a/Sources/WiredSwift/Core/WiredProtocolSpec.swift
+++ b/Sources/WiredSwift/Core/WiredProtocolSpec.swift
@@ -3,12 +3,21 @@ import Foundation
 public enum WiredProtocolSpec {
     public static func bundledSpecURL() -> URL? {
         // Bundle.module crashes with assertionFailure when the SPM .bundle directory
-        // is missing from the app package. Search manually instead, then fall back to
-        // Bundle.main.resourceURL where the build script also copies wired.xml directly.
+        // is missing from the app package. Search manually instead.
+        //
+        // Path reasoning:
+        //  - Production app:    Bundle.main.resourceURL / Contents/Resources
+        //  - Linux swift test:  executable is in .build/debug/, bundle is beside it
+        //  - macOS swift test:  Bundle.main.bundleURL is the .xctest package;
+        //                       its parent directory is .build/debug/ where the
+        //                       WiredSwift_WiredSwift.bundle actually lives
+        let bundleName = "WiredSwift_WiredSwift"
         let candidates: [URL?] = [
-            Bundle.main.resourceURL?.appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+            Bundle.main.resourceURL?.appendingPathComponent("\(bundleName).bundle"),
             Bundle.main.executableURL?.deletingLastPathComponent()
-                .appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+                .appendingPathComponent("\(bundleName).bundle"),
+            Bundle.main.bundleURL.deletingLastPathComponent()
+                .appendingPathComponent("\(bundleName).bundle"),
         ]
         for case let bundleURL? in candidates {
             if let b = Bundle(url: bundleURL),

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -1871,7 +1871,7 @@
                 One entry in the offline user list sent by the server after login.
                 Each message represents a registered account that is not currently connected.
             </p7:documentation>
-            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
             <p7:parameter field="wired.user.nick" version="3.0" />
         </p7:message>
 
@@ -1896,7 +1896,7 @@
                 Required before sending an end-to-end encrypted offline message.
             </p7:documentation>
             <p7:parameter field="wired.transaction" version="3.0" />
-            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.user.public_key" id="3015" version="3.0">
@@ -1905,7 +1905,7 @@
                 If wired.user.public_key is absent, the user has not registered a key.
             </p7:documentation>
             <p7:parameter field="wired.transaction" version="3.0" />
-            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
             <p7:parameter field="wired.user.public_key" version="3.0" />
         </p7:message>
 

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -349,6 +349,16 @@
                 Display nick of the sender at delivery time, derived from last_nick in the server database.
             </p7:documentation>
         </p7:field>
+        <p7:field name="wired.user.public_key" type="data" id="5014" version="3.0">
+            <p7:documentation>
+                X25519 public key for end-to-end encrypted offline messages (raw 32-byte representation).
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.message.offline.encrypted" type="bool" id="5015" version="3.0">
+            <p7:documentation>
+                If true, the message body is an ECIES-encrypted blob rather than plaintext.
+            </p7:documentation>
+        </p7:field>
 
         <p7:field name="wired.board.board" type="string" id="6000" version="2.0">
             <p7:documentation>
@@ -1871,6 +1881,34 @@
             </p7:documentation>
         </p7:message>
 
+        <p7:message name="wired.user.set_public_key" id="3013" version="3.0">
+            <p7:documentation>
+                Upload the client's X25519 public key for end-to-end encrypted offline messaging.
+                The server stores the key associated with the authenticated user's account.
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.0" />
+            <p7:parameter field="wired.user.public_key" use="required" version="3.0" />
+        </p7:message>
+
+        <p7:message name="wired.user.get_public_key" id="3014" version="3.0">
+            <p7:documentation>
+                Request the X25519 public key of another user by login name.
+                Required before sending an end-to-end encrypted offline message.
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.0" />
+            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+        </p7:message>
+
+        <p7:message name="wired.user.public_key" id="3015" version="3.0">
+            <p7:documentation>
+                Server response to wired.user.get_public_key.
+                If wired.user.public_key is absent, the user has not registered a key.
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.0" />
+            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.user.public_key" version="3.0" />
+        </p7:message>
+
         <p7:message name="wired.chat.join_chat" id="4000" version="2.0">
             <p7:documentation>
                 Join chat message.
@@ -2231,6 +2269,7 @@
             <p7:parameter field="wired.transaction" version="3.0" />
             <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
             <p7:parameter field="wired.message.message" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.encrypted" use="optional" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.message.offline_message" id="5011" version="3.0">
@@ -2242,6 +2281,7 @@
             <p7:parameter field="wired.message.message" use="required" version="3.0" />
             <p7:parameter field="wired.message.offline.date" use="required" version="3.0" />
             <p7:parameter field="wired.message.offline.sender_nick" use="optional" version="3.0" />
+            <p7:parameter field="wired.message.offline.encrypted" use="optional" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.board.get_boards" id="6000" version="2.0">

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -963,6 +963,13 @@
                 Indicates whether the account gives the privilege of sending offline private messages.
             </p7:documentation>
         </p7:field>
+        <p7:field name="wired.account.user.list_offline_users" type="bool" id="8088" version="3.0">
+            <p7:documentation>
+                Indicates whether the account gives the privilege of receiving the offline user list
+                ([message:wired.user.offline_list] entries) after login. Required to enumerate
+                registered users currently disconnected and to address them via offline messaging.
+            </p7:documentation>
+        </p7:field>
         <p7:field name="wired.account.message.broadcast" type="bool" id="8028" version="2.0">
             <p7:documentation>
                 Indicates whether the account gives the privilege to broadcast messages to all users currently
@@ -1602,6 +1609,7 @@
             <p7:member field="wired.account.chat.delete_public_chats" />
             <p7:member field="wired.account.message.send_messages" />
             <p7:member field="wired.account.message.send_offline_messages" />
+            <p7:member field="wired.account.user.list_offline_users" />
             <p7:member field="wired.account.message.broadcast" />
             <p7:member field="wired.account.board.read_boards" />
             <p7:member field="wired.account.board.search_boards" />
@@ -1870,6 +1878,7 @@
             <p7:documentation>
                 One entry in the offline user list sent by the server after login.
                 Each message represents a registered account that is not currently connected.
+                Sent only to clients whose account has [field:wired.account.user.list_offline_users].
             </p7:documentation>
             <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
             <p7:parameter field="wired.user.nick" version="3.0" />

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -344,6 +344,11 @@
                 Original timestamp when the offline message was sent.
             </p7:documentation>
         </p7:field>
+        <p7:field name="wired.message.offline.sender_nick" type="string" id="5013" version="3.0">
+            <p7:documentation>
+                Display nick of the sender at delivery time, derived from last_nick in the server database.
+            </p7:documentation>
+        </p7:field>
 
         <p7:field name="wired.board.board" type="string" id="6000" version="2.0">
             <p7:documentation>
@@ -2236,6 +2241,7 @@
             <p7:parameter field="wired.message.offline.sender_login" use="required" version="3.0" />
             <p7:parameter field="wired.message.message" use="required" version="3.0" />
             <p7:parameter field="wired.message.offline.date" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.sender_nick" use="optional" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.board.get_boards" id="6000" version="2.0">

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -272,6 +272,13 @@
             </p7:documentation>
         </p7:field>
 
+        <p7:field name="wired.user.is_offline" type="bool" id="3017" version="3.0">
+            <p7:documentation>
+                If true, this user entry represents a registered but currently disconnected account,
+                sent as part of the offline user list after login.
+            </p7:documentation>
+        </p7:field>
+
         <p7:field name="wired.chat.id" type="uint32" id="4000" version="2.0">
             <p7:documentation>
                 Identification number of a chat. This number should be created when each chat is
@@ -318,6 +325,23 @@
         <p7:field name="wired.message.broadcast" type="string" id="5001" version="2.0">
             <p7:documentation>
                 A public broadcast message.
+            </p7:documentation>
+        </p7:field>
+
+        <p7:field name="wired.message.offline.sender_login" type="string" id="5010" version="3.0">
+            <p7:documentation>
+                Login name of the sender of an offline message, included when the server delivers
+                a stored offline message to the recipient upon login.
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.message.offline.recipient_login" type="string" id="5011" version="3.0">
+            <p7:documentation>
+                Login name of the intended recipient when sending an offline message.
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.message.offline.date" type="date" id="5012" version="3.0">
+            <p7:documentation>
+                Original timestamp when the offline message was sent.
             </p7:documentation>
         </p7:field>
 
@@ -1827,6 +1851,21 @@
             <p7:parameter field="wired.transaction" version="2.0" />
         </p7:message>
 
+        <p7:message name="wired.user.offline_list" id="3011" version="3.0">
+            <p7:documentation>
+                One entry in the offline user list sent by the server after login.
+                Each message represents a registered account that is not currently connected.
+            </p7:documentation>
+            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.user.nick" version="3.0" />
+        </p7:message>
+
+        <p7:message name="wired.user.offline_list.done" id="3012" version="3.0">
+            <p7:documentation>
+                Marks the end of the offline user list.
+            </p7:documentation>
+        </p7:message>
+
         <p7:message name="wired.chat.join_chat" id="4000" version="2.0">
             <p7:documentation>
                 Join chat message.
@@ -2176,6 +2215,27 @@
             </p7:documentation>
             <p7:parameter field="wired.user.id" use="required" version="2.0" />
             <p7:parameter field="wired.message.broadcast" use="required" version="2.0" />
+        </p7:message>
+
+        <p7:message name="wired.message.send_offline_message" id="5010" version="3.0">
+            <p7:documentation>
+                Send a private message to a user who is currently offline, addressed by login name.
+                The server stores the message and delivers it when the recipient next logs in.
+                Requires [field:wired.account.message.send_offline_messages] privilege.
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.0" />
+            <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.message" use="required" version="3.0" />
+        </p7:message>
+
+        <p7:message name="wired.message.offline_message" id="5011" version="3.0">
+            <p7:documentation>
+                Delivery of a stored offline message to the recipient upon login.
+                The server sends one of these for each pending offline message.
+            </p7:documentation>
+            <p7:parameter field="wired.message.offline.sender_login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.message" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.date" use="required" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.board.get_boards" id="6000" version="2.0">

--- a/Sources/wired3/Controllers/ClientsController.swift
+++ b/Sources/wired3/Controllers/ClientsController.swift
@@ -77,4 +77,18 @@ public class ClientsController {
             Array(self.connectedClients.values)
         }
     }
+
+    /// Returns the login names of all currently connected authenticated clients.
+    public func allConnectedLogins() -> [String] {
+        self.clientsLock.concurrentlyRead {
+            self.connectedClients.values.compactMap { $0.user?.username }
+        }
+    }
+
+    /// Returns the connected client whose account login matches `login`, or `nil`.
+    public func user(withLogin login: String) -> Client? {
+        self.clientsLock.concurrentlyRead {
+            self.connectedClients.values.first { $0.user?.username == login }
+        }
+    }
 }

--- a/Sources/wired3/Controllers/DatabaseController.swift
+++ b/Sources/wired3/Controllers/DatabaseController.swift
@@ -56,6 +56,14 @@ public class DatabaseController {
             WiredMigrations.register(into: &migrator)
             try migrator.migrate(dbQueue)
 
+            // Checkpoint and truncate the WAL from any previous run before we start.
+            // On a fresh server start there are no active readers, so TRUNCATE is safe.
+            // This prevents accumulated stale FTS5 shadow-table writes in the WAL from
+            // causing SQLITE_IOERR on the first write transaction after a crash.
+            try dbQueue.write { db in
+                try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
+            }
+
             Logger.info("Database opened at \(baseURL.path)")
             return true
         } catch {

--- a/Sources/wired3/Controllers/IndexController.swift
+++ b/Sources/wired3/Controllers/IndexController.swift
@@ -312,9 +312,11 @@ public class IndexController: TableController {
         // The trigger is re-created afterwards for incremental addIndex/removeIndex calls.
         do {
             try databaseController.dbQueue.write { db in
-                if hasFTS5 {
-                    try db.execute(sql: "DROP TRIGGER IF EXISTS index_ad")
-                }
+                // Drop unconditionally — hasFTS5 may be false because a previous
+                // recoverIndexAndFTS5() failed, but the trigger can still exist in
+                // the database from an earlier session. Leaving it active causes
+                // SQLITE_IOERR (10) on every bulk delete via the FTS5 shadow tables.
+                try db.execute(sql: "DROP TRIGGER IF EXISTS index_ad")
                 try WiredIndex
                     .filter(Column("generation_id") != newGen)
                     .deleteAll(db)

--- a/Sources/wired3/Controllers/IndexController.swift
+++ b/Sources/wired3/Controllers/IndexController.swift
@@ -28,6 +28,7 @@ public class IndexController: TableController {
     private let indexQueue = DispatchQueue(label: "wired3.index", qos: .utility)
     private var currentGeneration: Int64 = 0
     private var isIndexing: Bool = false
+    private var startupCheckDone = false
     // When a rebuild is running and another request arrives, set this flag so
     // exactly one extra rebuild is scheduled after the current one finishes.
     private var pendingRebuild: Bool = false
@@ -228,6 +229,13 @@ public class IndexController: TableController {
             }
         }
 
+        // On the very first rebuild after startup, probe FTS5 for write-level errors
+        // (e.g. SQLITE_IOERR on shadow tables) before investing time in a full traversal.
+        if !startupCheckDone {
+            startupCheckDone = true
+            performFTS5StartupCheck()
+        }
+
         let newGen = currentGeneration &+ 1
         var newSize: UInt64 = 0
         var newFiles: UInt64 = 0
@@ -404,6 +412,26 @@ public class IndexController: TableController {
         } catch {
             Logger.error("IndexController: FTS5 recovery failed: \(error) — FTS5 search disabled for this session")
             hasFTS5 = false
+        }
+    }
+
+    /// Probes FTS5 write-path health on the first rebuild after startup.
+    /// Runs `integrity-check` against the FTS5 shadow tables; if it throws
+    /// (e.g. SQLITE_IOERR), triggers `recoverIndexAndFTS5()` before the
+    /// expensive filesystem traversal begins. Always called from `indexQueue`.
+    private func performFTS5StartupCheck() {
+        guard hasFTS5 else { return }
+        do {
+            try databaseController.dbQueue.write { db in
+                // integrity-check validates internal FTS5 B-tree consistency and,
+                // for external-content tables, compares against the content table.
+                // We only care whether it throws; result rows are discarded.
+                try db.execute(sql: "INSERT INTO file_search(file_search) VALUES('integrity-check')")
+            }
+            Logger.info("IndexController: FTS5 startup check passed")
+        } catch {
+            Logger.warning("IndexController: FTS5 startup check failed (\(error)) — resetting before rebuild")
+            recoverIndexAndFTS5()
         }
     }
 

--- a/Sources/wired3/Controllers/UsersController.swift
+++ b/Sources/wired3/Controllers/UsersController.swift
@@ -503,11 +503,13 @@ public class UsersController: TableController, SocketPasswordDelegate {
         }
     }
 
-    /// For existing installations, grant `wired.account.user.list_offline_users` to every
-    /// user and group that already has `wired.account.message.send_offline_messages = true`.
+    /// For existing installations, grant `wired.account.user.list_offline_users` only to
+    /// users and groups that already have `wired.account.user.get_users` (admin-level access).
+    /// Granting it to everyone with `send_offline_messages` would expose the full offline user
+    /// list to regular users, which is a privacy concern.
     private func migrateListOfflineUsersPrivilegeIfNeeded(db: OpaquePointer) {
         let targetPrivilege = "wired.account.user.list_offline_users"
-        let sourcePrivilege = "wired.account.message.send_offline_messages"
+        let adminPrivilege = "wired.account.user.get_users"
 
         let tables: [(table: String, ownerColumn: String)] = [
             ("user_privileges", "user_id"),
@@ -519,7 +521,7 @@ public class UsersController: TableController, SocketPasswordDelegate {
             INSERT OR IGNORE INTO "\(entry.table)" (name, value, \(entry.ownerColumn))
             SELECT '\(targetPrivilege)', 1, \(entry.ownerColumn)
             FROM "\(entry.table)"
-            WHERE name = '\(sourcePrivilege)' AND value = 1
+            WHERE name = '\(adminPrivilege)' AND value = 1
               AND \(entry.ownerColumn) NOT IN (
                   SELECT \(entry.ownerColumn) FROM "\(entry.table)" WHERE name = '\(targetPrivilege)'
               );

--- a/Sources/wired3/Controllers/UsersController.swift
+++ b/Sources/wired3/Controllers/UsersController.swift
@@ -107,6 +107,13 @@ public class UsersController: TableController, SocketPasswordDelegate {
         }
     }
 
+    /// Returns `true` if a registered account with the given login name exists.
+    public func userExists(withUsername username: String) -> Bool {
+        (try? databaseController.dbQueue.read { db in
+            try User.filter(Column("username") == username).fetchCount(db) > 0
+        }) ?? false
+    }
+
     /// Fetches a user by login name and eagerly loads their privilege set.
     ///
     /// - Parameter username: The account login name.

--- a/Sources/wired3/Controllers/UsersController.swift
+++ b/Sources/wired3/Controllers/UsersController.swift
@@ -426,6 +426,7 @@ public class UsersController: TableController, SocketPasswordDelegate {
         migrateOfflineMessagesTableIfNeeded(db: db)
         migrateAddReactionsPrivilegeIfNeeded(db: db)
         migrateFileMetadataPrivilegesIfNeeded(db: db)
+        migrateSendOfflineMessagesPrivilegeIfNeeded(db: db)
     }
 
     /// For existing installations, grant `wired.account.board.add_reactions` (true) to every
@@ -497,6 +498,37 @@ public class UsersController: TableController, SocketPasswordDelegate {
                 } else {
                     WiredSwift.Logger.info("Migrated \(targetPrivilege) for \(entry.table)")
                 }
+            }
+        }
+    }
+
+    /// For existing installations, grant `wired.account.message.send_offline_messages` to every
+    /// user and group that already has `wired.account.message.send_messages = true`.
+    private func migrateSendOfflineMessagesPrivilegeIfNeeded(db: OpaquePointer) {
+        let targetPrivilege = "wired.account.message.send_offline_messages"
+        let sourcePrivilege = "wired.account.message.send_messages"
+
+        let tables: [(table: String, ownerColumn: String)] = [
+            ("user_privileges", "user_id"),
+            ("group_privileges", "group_id")
+        ]
+
+        for entry in tables {
+            let sql = """
+            INSERT OR IGNORE INTO "\(entry.table)" (name, value, \(entry.ownerColumn))
+            SELECT '\(targetPrivilege)', 1, \(entry.ownerColumn)
+            FROM "\(entry.table)"
+            WHERE name = '\(sourcePrivilege)' AND value = 1
+              AND \(entry.ownerColumn) NOT IN (
+                  SELECT \(entry.ownerColumn) FROM "\(entry.table)" WHERE name = '\(targetPrivilege)'
+              );
+            """
+            if sqliteExec(db: db, sql) != SQLITE_OK {
+                if let msg = sqlite3_errmsg(db) {
+                    WiredSwift.Logger.error("migrateSendOfflineMessagesPrivilege (\(entry.table)): \(String(cString: msg))")
+                }
+            } else {
+                WiredSwift.Logger.info("Migrated \(targetPrivilege) for \(entry.table)")
             }
         }
     }

--- a/Sources/wired3/Controllers/UsersController.swift
+++ b/Sources/wired3/Controllers/UsersController.swift
@@ -427,6 +427,7 @@ public class UsersController: TableController, SocketPasswordDelegate {
         migrateAddReactionsPrivilegeIfNeeded(db: db)
         migrateFileMetadataPrivilegesIfNeeded(db: db)
         migrateSendOfflineMessagesPrivilegeIfNeeded(db: db)
+        migrateListOfflineUsersPrivilegeIfNeeded(db: db)
     }
 
     /// For existing installations, grant `wired.account.board.add_reactions` (true) to every
@@ -498,6 +499,37 @@ public class UsersController: TableController, SocketPasswordDelegate {
                 } else {
                     WiredSwift.Logger.info("Migrated \(targetPrivilege) for \(entry.table)")
                 }
+            }
+        }
+    }
+
+    /// For existing installations, grant `wired.account.user.list_offline_users` to every
+    /// user and group that already has `wired.account.message.send_offline_messages = true`.
+    private func migrateListOfflineUsersPrivilegeIfNeeded(db: OpaquePointer) {
+        let targetPrivilege = "wired.account.user.list_offline_users"
+        let sourcePrivilege = "wired.account.message.send_offline_messages"
+
+        let tables: [(table: String, ownerColumn: String)] = [
+            ("user_privileges", "user_id"),
+            ("group_privileges", "group_id")
+        ]
+
+        for entry in tables {
+            let sql = """
+            INSERT OR IGNORE INTO "\(entry.table)" (name, value, \(entry.ownerColumn))
+            SELECT '\(targetPrivilege)', 1, \(entry.ownerColumn)
+            FROM "\(entry.table)"
+            WHERE name = '\(sourcePrivilege)' AND value = 1
+              AND \(entry.ownerColumn) NOT IN (
+                  SELECT \(entry.ownerColumn) FROM "\(entry.table)" WHERE name = '\(targetPrivilege)'
+              );
+            """
+            if sqliteExec(db: db, sql) != SQLITE_OK {
+                if let msg = sqlite3_errmsg(db) {
+                    WiredSwift.Logger.error("migrateListOfflineUsersPrivilege (\(entry.table)): \(String(cString: msg))")
+                }
+            } else {
+                WiredSwift.Logger.info("Migrated \(targetPrivilege) for \(entry.table)")
             }
         }
     }

--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -627,7 +627,6 @@ extension ServerController {
 
         App.serverController.replyOK(client: client, message: message)
         self.broadcastAccountsChangedToSubscribers()
-        self.broadcastNewOfflineUser(username: name)
         self.recordEvent(.accountCreatedUser, client: client, parameters: [name])
     }
 
@@ -1228,11 +1227,6 @@ extension ServerController {
         let hash = isHexSHA256 ? password.lowercased() : password.sha256()
         let salt = UUID().uuidString.replacingOccurrences(of: "-", with: "")
         return (hash: hash, salt: salt)
-    }
-
-    private func broadcastNewOfflineUser(username: String) {
-        // New accounts have no last_nick yet — don't expose login or full_name.
-        // The account will appear automatically after their first login.
     }
 
     private func broadcastAccountsChangedToSubscribers() {

--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -1258,6 +1258,7 @@ extension ServerController {
 
             guard let refreshedUser = userWithPrivileges(matchingUsername: currentName) else { continue }
 
+            let hadOfflineList = connectedClient.user?.hasPrivilege(name: "wired.account.user.list_offline_users") ?? false
             connectedClient.user = refreshedUser
 
             if !refreshedUser.hasPrivilege(name: "wired.account.account.list_accounts") {
@@ -1273,6 +1274,13 @@ extension ServerController {
             }
 
             _ = self.send(message: self.accountPrivilegesMessage(for: refreshedUser), client: connectedClient)
+
+            // If the offline-list privilege was just granted, push the current
+            // list so the client doesn't have to reconnect to populate the panel.
+            let hasOfflineList = refreshedUser.hasPrivilege(name: "wired.account.user.list_offline_users")
+            if !hadOfflineList && hasOfflineList {
+                self.sendOfflineUserList(to: connectedClient)
+            }
         }
     }
 
@@ -1290,6 +1298,7 @@ extension ServerController {
             guard wasInAffectedGroup else { continue }
 
             guard let refreshedUser = userWithPrivileges(matchingUsername: username) else { continue }
+            let hadOfflineList = currentUser.hasPrivilege(name: "wired.account.user.list_offline_users")
             connectedClient.user = refreshedUser
 
             if !refreshedUser.hasPrivilege(name: "wired.account.account.list_accounts") {
@@ -1305,6 +1314,11 @@ extension ServerController {
             }
 
             _ = self.send(message: self.accountPrivilegesMessage(for: refreshedUser), client: connectedClient)
+
+            let hasOfflineList = refreshedUser.hasPrivilege(name: "wired.account.user.list_offline_users")
+            if !hadOfflineList && hasOfflineList {
+                self.sendOfflineUserList(to: connectedClient)
+            }
         }
     }
 

--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -1231,25 +1231,8 @@ extension ServerController {
     }
 
     private func broadcastNewOfflineUser(username: String) {
-        let onlineLogins = Set(App.clientsController.allConnectedLogins())
-        guard !onlineLogins.contains(username) else { return }
-
-        // New accounts have no last_nick yet; use full_name or username as fallback
-        let displayNick: String
-        if let user = App.usersController.user(withUsername: username) {
-            displayNick = [user.fullName].compactMap({ $0?.isEmpty == false ? $0 : nil }).first ?? username
-        } else {
-            displayNick = username
-        }
-
-        let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
-        msg.addParameter(field: "wired.user.login", value: username)
-        msg.addParameter(field: "wired.user.nick", value: displayNick)
-
-        for connectedClient in App.clientsController.connectedClientsSnapshot() {
-            guard connectedClient.state == .LOGGED_IN else { continue }
-            _ = self.send(message: msg, client: connectedClient)
-        }
+        // New accounts have no last_nick yet — don't expose login or full_name.
+        // The account will appear automatically after their first login.
     }
 
     private func broadcastAccountsChangedToSubscribers() {

--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -1234,10 +1234,10 @@ extension ServerController {
         let onlineLogins = Set(App.clientsController.allConnectedLogins())
         guard !onlineLogins.contains(username) else { return }
 
+        // New accounts have no last_nick yet; use full_name or username as fallback
         let displayNick: String
-        if let user = App.usersController.user(withUsername: username),
-           let fullName = user.fullName, !fullName.isEmpty {
-            displayNick = fullName
+        if let user = App.usersController.user(withUsername: username) {
+            displayNick = [user.fullName].compactMap({ $0?.isEmpty == false ? $0 : nil }).first ?? username
         } else {
             displayNick = username
         }

--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -627,6 +627,7 @@ extension ServerController {
 
         App.serverController.replyOK(client: client, message: message)
         self.broadcastAccountsChangedToSubscribers()
+        self.broadcastNewOfflineUser(username: name)
         self.recordEvent(.accountCreatedUser, client: client, parameters: [name])
     }
 
@@ -1227,6 +1228,28 @@ extension ServerController {
         let hash = isHexSHA256 ? password.lowercased() : password.sha256()
         let salt = UUID().uuidString.replacingOccurrences(of: "-", with: "")
         return (hash: hash, salt: salt)
+    }
+
+    private func broadcastNewOfflineUser(username: String) {
+        let onlineLogins = Set(App.clientsController.allConnectedLogins())
+        guard !onlineLogins.contains(username) else { return }
+
+        let displayNick: String
+        if let user = App.usersController.user(withUsername: username),
+           let fullName = user.fullName, !fullName.isEmpty {
+            displayNick = fullName
+        } else {
+            displayNick = username
+        }
+
+        let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
+        msg.addParameter(field: "wired.user.login", value: username)
+        msg.addParameter(field: "wired.user.nick", value: displayNick)
+
+        for connectedClient in App.clientsController.connectedClientsSnapshot() {
+            guard connectedClient.state == .LOGGED_IN else { continue }
+            _ = self.send(message: msg, client: connectedClient)
+        }
     }
 
     private func broadcastAccountsChangedToSubscribers() {

--- a/Sources/wired3/Core/ServerController+Auth.swift
+++ b/Sources/wired3/Core/ServerController+Auth.swift
@@ -159,6 +159,10 @@ extension ServerController {
             loginOverride: login
         )
 
+        // Send list of offline registered users, then deliver any queued offline messages
+        self.sendOfflineUserList(to: client)
+        self.deliverOfflineMessages(to: client)
+
         return true
     }
 }

--- a/Sources/wired3/Core/ServerController+Auth.swift
+++ b/Sources/wired3/Core/ServerController+Auth.swift
@@ -149,10 +149,17 @@ extension ServerController {
         client.idleTime = client.loginTime
 
         try? App.databaseController.dbQueue.write { db in
-            try db.execute(
-                sql: "UPDATE users SET last_login_at = ? WHERE username = ?",
-                arguments: [Date().timeIntervalSince1970, login]
-            )
+            if let nick = client.nick, !nick.isEmpty {
+                try db.execute(
+                    sql: "UPDATE users SET last_login_at = ?, last_nick = ? WHERE username = ?",
+                    arguments: [Date().timeIntervalSince1970, nick, login]
+                )
+            } else {
+                try db.execute(
+                    sql: "UPDATE users SET last_login_at = ? WHERE username = ?",
+                    arguments: [Date().timeIntervalSince1970, login]
+                )
+            }
         }
 
         let clientInfo = [client.applicationName, client.applicationVersion]

--- a/Sources/wired3/Core/ServerController+Auth.swift
+++ b/Sources/wired3/Core/ServerController+Auth.swift
@@ -3,6 +3,7 @@
 //  wired3
 //
 import Foundation
+import GRDB
 import WiredSwift
 
 extension ServerController {
@@ -146,6 +147,13 @@ extension ServerController {
 
         client.loginTime = Date()
         client.idleTime = client.loginTime
+
+        try? App.databaseController.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE users SET last_login_at = ? WHERE username = ?",
+                arguments: [Date().timeIntervalSince1970, login]
+            )
+        }
 
         let clientInfo = [client.applicationName, client.applicationVersion]
             .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " ")

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -290,6 +290,11 @@ extension ServerController {
     }
 
     func sendOfflineUserList(to client: Client) {
+        guard let user = client.user,
+              user.hasPrivilege(name: "wired.account.user.list_offline_users") else {
+            return
+        }
+
         let onlineLogins = Set(App.clientsController.allConnectedLogins())
 
         let entries: [(login: String, nick: String)]

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -165,6 +165,30 @@ extension ServerController {
 
         let senderLogin = senderUser.username ?? ""
         let isEncrypted = message.bool(forField: "wired.message.offline.encrypted") ?? false
+
+        // Offline messages are always stored encrypted. The recipient must have registered
+        // a public key (so the sender can encrypt), and the client must set is_encrypted=true.
+        // Plaintext storage is never acceptable — it would let server admins read private messages.
+        let recipientPublicKey: Data? = (try? App.databaseController.dbQueue.read { db in
+            let row = try Row.fetchOne(db,
+                sql: "SELECT offline_public_key FROM users WHERE username = ?",
+                arguments: [recipientLogin])
+            let keyData = row?["offline_public_key"] as? Data
+            return (keyData != nil && !keyData!.isEmpty) ? keyData : nil
+        }) ?? nil
+
+        guard let _ = recipientPublicKey else {
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+            Logger.warning("Rejected offline message for '\(recipientLogin)' — no public key registered (encryption required)")
+            return
+        }
+
+        guard isEncrypted else {
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+            Logger.warning("Rejected unencrypted offline message for '\(recipientLogin)' — is_encrypted must be true")
+            return
+        }
+
         var offlineMessage = OfflineMessage(
             senderLogin: senderLogin,
             recipientLogin: recipientLogin,

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -321,7 +321,7 @@ extension ServerController {
 
         for entry in entries where !onlineLogins.contains(entry.login) {
             let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
-            msg.addParameter(field: "wired.user.login", value: entry.login)
+            msg.addParameter(field: "wired.message.offline.recipient_login", value: entry.login)
             msg.addParameter(field: "wired.user.nick", value: entry.nick)
             _ = self.send(message: msg, client: client)
         }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -164,11 +164,13 @@ extension ServerController {
         }
 
         let senderLogin = senderUser.username ?? ""
+        let isEncrypted = message.bool(forField: "wired.message.offline.encrypted") ?? false
         var offlineMessage = OfflineMessage(
             senderLogin: senderLogin,
             recipientLogin: recipientLogin,
             body: body,
-            sentAt: Date()
+            sentAt: Date(),
+            isEncrypted: isEncrypted
         )
 
         do {
@@ -193,24 +195,27 @@ extension ServerController {
             let senderNick: String?
             let body: String
             let sentAt: Date
+            let isEncrypted: Bool
         }
 
         let messages: [PendingMessage]
         do {
             messages = try App.databaseController.dbQueue.read { db in
                 let rows = try Row.fetchAll(db, sql: """
-                    SELECT om.sender_login, om.body, om.sent_at, u.last_nick AS sender_nick
+                    SELECT om.sender_login, om.body, om.sent_at, om.is_encrypted, u.last_nick AS sender_nick
                     FROM offline_messages om
                     LEFT JOIN users u ON u.username = om.sender_login
                     WHERE om.recipient_login = ?
                     ORDER BY om.sent_at ASC
                 """, arguments: [recipientLogin])
                 return rows.map {
-                    PendingMessage(
+                    let encryptedInt: Int = $0["is_encrypted"] ?? 0
+                    return PendingMessage(
                         senderLogin: $0["sender_login"],
                         senderNick: $0["sender_nick"],
                         body: $0["body"],
-                        sentAt: Date(timeIntervalSince1970: $0["sent_at"])
+                        sentAt: Date(timeIntervalSince1970: $0["sent_at"]),
+                        isEncrypted: encryptedInt != 0
                     )
                 }
             }
@@ -228,6 +233,9 @@ extension ServerController {
             delivery.addParameter(field: "wired.message.offline.date", value: msg.sentAt)
             if let nick = msg.senderNick, !nick.isEmpty {
                 delivery.addParameter(field: "wired.message.offline.sender_nick", value: nick)
+            }
+            if msg.isEncrypted {
+                delivery.addParameter(field: "wired.message.offline.encrypted", value: true)
             }
             _ = self.send(message: delivery, client: client)
         }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -231,15 +231,18 @@ extension ServerController {
         do {
             entries = try App.databaseController.dbQueue.read { db in
                 let rows = try Row.fetchAll(db, sql: """
-                    SELECT username, full_name FROM users
+                    SELECT username, last_nick, full_name FROM users
                     WHERE username IS NOT NULL AND username != ''
                       AND (last_login_at IS NULL OR last_login_at > unixepoch('now') - 2592000)
                     ORDER BY username ASC
                 """)
                 return rows.map { row in
                     let login: String = row["username"]
+                    let lastNick: String? = row["last_nick"]
                     let fullName: String? = row["full_name"]
-                    let nick = (fullName.flatMap { $0.isEmpty ? nil : $0 }) ?? login
+                    let nick = lastNick.flatMap { $0.isEmpty ? nil : $0 }
+                           ?? fullName.flatMap { $0.isEmpty ? nil : $0 }
+                           ?? login
                     return (login: login, nick: nick)
                 }
             }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -214,7 +214,7 @@ extension ServerController {
                         senderLogin: $0["sender_login"],
                         senderNick: $0["sender_nick"],
                         body: $0["body"],
-                        sentAt: Date(timeIntervalSince1970: $0["sent_at"]),
+                        sentAt: $0["sent_at"],
                         isEncrypted: encryptedInt != 0
                     )
                 }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -230,21 +230,18 @@ extension ServerController {
         let entries: [(login: String, nick: String)]
         do {
             entries = try App.databaseController.dbQueue.read { db in
+                // Only include users who have a last_nick set (i.e. connected at least once
+                // since v15). This avoids exposing login names or account full names.
                 let rows = try Row.fetchAll(db, sql: """
-                    SELECT username, last_nick, full_name FROM users
+                    SELECT username, last_nick FROM users
                     WHERE username IS NOT NULL AND username != ''
                       AND last_login_at IS NOT NULL
                       AND last_login_at > unixepoch('now') - 2592000
-                    ORDER BY username ASC
+                      AND last_nick IS NOT NULL AND last_nick != ''
+                    ORDER BY last_nick ASC
                 """)
                 return rows.map { row in
-                    let login: String = row["username"]
-                    let lastNick: String? = row["last_nick"]
-                    let fullName: String? = row["full_name"]
-                    let nick = lastNick.flatMap { $0.isEmpty ? nil : $0 }
-                           ?? fullName.flatMap { $0.isEmpty ? nil : $0 }
-                           ?? login
-                    return (login: login, nick: nick)
+                    (login: row["username"] as String, nick: row["last_nick"] as String)
                 }
             }
         } catch {

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -215,6 +215,7 @@ extension ServerController {
         guard let recipientLogin = client.user?.username else { return }
 
         struct PendingMessage {
+            let id: Int64
             let senderLogin: String
             let senderNick: String?
             let body: String
@@ -226,7 +227,8 @@ extension ServerController {
         do {
             messages = try App.databaseController.dbQueue.read { db in
                 let rows = try Row.fetchAll(db, sql: """
-                    SELECT om.sender_login, om.body, om.sent_at, om.is_encrypted, u.last_nick AS sender_nick
+                    SELECT om.id, om.sender_login, om.body, om.sent_at, om.is_encrypted,
+                           u.last_nick AS sender_nick
                     FROM offline_messages om
                     LEFT JOIN users u ON u.username = om.sender_login
                     WHERE om.recipient_login = ?
@@ -235,6 +237,7 @@ extension ServerController {
                 return rows.map {
                     let encryptedInt: Int = $0["is_encrypted"] ?? 0
                     return PendingMessage(
+                        id: $0["id"],
                         senderLogin: $0["sender_login"],
                         senderNick: $0["sender_nick"],
                         body: $0["body"],
@@ -250,6 +253,11 @@ extension ServerController {
 
         guard !messages.isEmpty else { return }
 
+        // Track which message IDs were successfully written to the socket.
+        // Only those are deleted — if the connection drops mid-delivery the
+        // remaining messages stay in the DB and will be re-delivered on next login.
+        var deliveredIDs: [Int64] = []
+
         for msg in messages {
             let delivery = P7Message(withName: "wired.message.offline_message", spec: self.spec)
             delivery.addParameter(field: "wired.message.offline.sender_login", value: msg.senderLogin)
@@ -261,20 +269,24 @@ extension ServerController {
             if msg.isEncrypted {
                 delivery.addParameter(field: "wired.message.offline.encrypted", value: true)
             }
-            _ = self.send(message: delivery, client: client)
+            if self.send(message: delivery, client: client) {
+                deliveredIDs.append(msg.id)
+            }
         }
 
+        guard !deliveredIDs.isEmpty else { return }
+
         do {
-            try App.databaseController.dbQueue.write { db in
+            _ = try App.databaseController.dbQueue.write { db in
                 try OfflineMessage
-                    .filter(Column("recipient_login") == recipientLogin)
+                    .filter(deliveredIDs.contains(Column("id")))
                     .deleteAll(db)
             }
         } catch {
             Logger.error("Failed to delete delivered offline messages for '\(recipientLogin)': \(error)")
         }
 
-        Logger.info("Delivered \(messages.count) offline message(s) to '\(recipientLogin)'")
+        Logger.info("Delivered \(deliveredIDs.count)/\(messages.count) offline message(s) to '\(recipientLogin)'")
     }
 
     func sendOfflineUserList(to client: Client) {

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -233,7 +233,8 @@ extension ServerController {
                 let rows = try Row.fetchAll(db, sql: """
                     SELECT username, last_nick, full_name FROM users
                     WHERE username IS NOT NULL AND username != ''
-                      AND (last_login_at IS NULL OR last_login_at > unixepoch('now') - 2592000)
+                      AND last_login_at IS NOT NULL
+                      AND last_login_at > unixepoch('now') - 2592000
                     ORDER BY username ASC
                 """)
                 return rows.map { row in

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -147,9 +147,10 @@ extension ServerController {
             return
         }
 
-        // Verify the recipient account exists
+        // Verify the recipient account exists. Reply with permission_denied (not
+        // user_not_found) to avoid leaking which logins are registered on the server.
         guard App.usersController.userExists(withUsername: recipientLogin) else {
-            App.serverController.replyError(client: client, error: "wired.error.user_not_found", message: message)
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
             return
         }
 

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -188,13 +188,31 @@ extension ServerController {
     func deliverOfflineMessages(to client: Client) {
         guard let recipientLogin = client.user?.username else { return }
 
-        let messages: [OfflineMessage]
+        struct PendingMessage {
+            let senderLogin: String
+            let senderNick: String?
+            let body: String
+            let sentAt: Date
+        }
+
+        let messages: [PendingMessage]
         do {
             messages = try App.databaseController.dbQueue.read { db in
-                try OfflineMessage
-                    .filter(Column("recipient_login") == recipientLogin)
-                    .order(Column("sent_at").asc)
-                    .fetchAll(db)
+                let rows = try Row.fetchAll(db, sql: """
+                    SELECT om.sender_login, om.body, om.sent_at, u.last_nick AS sender_nick
+                    FROM offline_messages om
+                    LEFT JOIN users u ON u.username = om.sender_login
+                    WHERE om.recipient_login = ?
+                    ORDER BY om.sent_at ASC
+                """, arguments: [recipientLogin])
+                return rows.map {
+                    PendingMessage(
+                        senderLogin: $0["sender_login"],
+                        senderNick: $0["sender_nick"],
+                        body: $0["body"],
+                        sentAt: Date(timeIntervalSince1970: $0["sent_at"])
+                    )
+                }
             }
         } catch {
             Logger.error("Failed to load offline messages for '\(recipientLogin)': \(error)")
@@ -208,6 +226,9 @@ extension ServerController {
             delivery.addParameter(field: "wired.message.offline.sender_login", value: msg.senderLogin)
             delivery.addParameter(field: "wired.message.message", value: msg.body)
             delivery.addParameter(field: "wired.message.offline.date", value: msg.sentAt)
+            if let nick = msg.senderNick, !nick.isEmpty {
+                delivery.addParameter(field: "wired.message.offline.sender_nick", value: nick)
+            }
             _ = self.send(message: delivery, client: client)
         }
 

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import GRDB
 import WiredSwift
 
 extension ServerController {
@@ -119,5 +120,135 @@ extension ServerController {
         App.clientsController.broadcast(message: broadcast)
         App.serverController.replyOK(client: client, message: message)
         self.recordEvent(.messageBroadcasted, client: client)
+    }
+
+    // MARK: - Offline messages
+
+    func receiveMessageSendOfflineMessage(client: Client, message: P7Message) {
+        guard let senderUser = client.user else {
+            App.serverController.replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
+            return
+        }
+
+        guard senderUser.hasPrivilege(name: "wired.account.message.send_offline_messages") else {
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+            return
+        }
+
+        guard let recipientLogin = message.string(forField: "wired.message.offline.recipient_login"),
+              !recipientLogin.isEmpty else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+
+        guard let body = message.string(forField: "wired.message.message"),
+              !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+
+        // Verify the recipient account exists
+        guard App.usersController.userExists(withUsername: recipientLogin) else {
+            App.serverController.replyError(client: client, error: "wired.error.user_not_found", message: message)
+            return
+        }
+
+        // If the recipient is currently online, deliver immediately instead
+        if let onlineClient = App.clientsController.user(withLogin: recipientLogin) {
+            let reply = P7Message(withName: "wired.message.message", spec: self.spec)
+            reply.addParameter(field: "wired.user.id", value: client.userID)
+            reply.addParameter(field: "wired.message.message", value: body)
+            _ = self.send(message: reply, client: onlineClient)
+            App.serverController.replyOK(client: client, message: message)
+            return
+        }
+
+        let senderLogin = senderUser.username ?? ""
+        var offlineMessage = OfflineMessage(
+            senderLogin: senderLogin,
+            recipientLogin: recipientLogin,
+            body: body,
+            sentAt: Date()
+        )
+
+        do {
+            try App.databaseController.dbQueue.write { db in
+                try offlineMessage.insert(db)
+            }
+        } catch {
+            Logger.error("Failed to store offline message for '\(recipientLogin)': \(error)")
+            App.serverController.replyError(client: client, error: "wired.error.internal_error", message: message)
+            return
+        }
+
+        App.serverController.replyOK(client: client, message: message)
+        Logger.info("Offline message from '\(senderLogin)' stored for '\(recipientLogin)'")
+    }
+
+    func deliverOfflineMessages(to client: Client) {
+        guard let recipientLogin = client.user?.username else { return }
+
+        let messages: [OfflineMessage]
+        do {
+            messages = try App.databaseController.dbQueue.read { db in
+                try OfflineMessage
+                    .filter(Column("recipient_login") == recipientLogin)
+                    .order(Column("sent_at").asc)
+                    .fetchAll(db)
+            }
+        } catch {
+            Logger.error("Failed to load offline messages for '\(recipientLogin)': \(error)")
+            return
+        }
+
+        guard !messages.isEmpty else { return }
+
+        for msg in messages {
+            let delivery = P7Message(withName: "wired.message.offline_message", spec: self.spec)
+            delivery.addParameter(field: "wired.message.offline.sender_login", value: msg.senderLogin)
+            delivery.addParameter(field: "wired.message.message", value: msg.body)
+            delivery.addParameter(field: "wired.message.offline.date", value: msg.sentAt)
+            _ = self.send(message: delivery, client: client)
+        }
+
+        do {
+            try App.databaseController.dbQueue.write { db in
+                try OfflineMessage
+                    .filter(Column("recipient_login") == recipientLogin)
+                    .deleteAll(db)
+            }
+        } catch {
+            Logger.error("Failed to delete delivered offline messages for '\(recipientLogin)': \(error)")
+        }
+
+        Logger.info("Delivered \(messages.count) offline message(s) to '\(recipientLogin)'")
+    }
+
+    func sendOfflineUserList(to client: Client) {
+        let onlineLogins = Set(App.clientsController.allConnectedLogins())
+
+        let allLogins: [String]
+        do {
+            allLogins = try App.databaseController.dbQueue.read { db in
+                try String.fetchAll(db, sql: """
+                    SELECT username FROM users
+                    WHERE username IS NOT NULL AND username != ''
+                    ORDER BY username ASC
+                """)
+            }
+        } catch {
+            Logger.error("Failed to load offline user list: \(error)")
+            return
+        }
+
+        for login in allLogins where !onlineLogins.contains(login) {
+            let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
+            msg.addParameter(field: "wired.user.login", value: login)
+            msg.addParameter(field: "wired.user.nick", value: login)
+            _ = self.send(message: msg, client: client)
+        }
+
+        let done = P7Message(withName: "wired.user.offline_list.done", spec: self.spec)
+        _ = self.send(message: done, client: client)
     }
 }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -227,24 +227,31 @@ extension ServerController {
     func sendOfflineUserList(to client: Client) {
         let onlineLogins = Set(App.clientsController.allConnectedLogins())
 
-        let allLogins: [String]
+        let entries: [(login: String, nick: String)]
         do {
-            allLogins = try App.databaseController.dbQueue.read { db in
-                try String.fetchAll(db, sql: """
-                    SELECT username FROM users
+            entries = try App.databaseController.dbQueue.read { db in
+                let rows = try Row.fetchAll(db, sql: """
+                    SELECT username, full_name FROM users
                     WHERE username IS NOT NULL AND username != ''
+                      AND (last_login_at IS NULL OR last_login_at > unixepoch('now') - 2592000)
                     ORDER BY username ASC
                 """)
+                return rows.map { row in
+                    let login: String = row["username"]
+                    let fullName: String? = row["full_name"]
+                    let nick = (fullName.flatMap { $0.isEmpty ? nil : $0 }) ?? login
+                    return (login: login, nick: nick)
+                }
             }
         } catch {
             Logger.error("Failed to load offline user list: \(error)")
             return
         }
 
-        for login in allLogins where !onlineLogins.contains(login) {
+        for entry in entries where !onlineLogins.contains(entry.login) {
             let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
-            msg.addParameter(field: "wired.user.login", value: login)
-            msg.addParameter(field: "wired.user.nick", value: login)
+            msg.addParameter(field: "wired.user.login", value: entry.login)
+            msg.addParameter(field: "wired.user.nick", value: entry.nick)
             _ = self.send(message: msg, client: client)
         }
 

--- a/Sources/wired3/Core/ServerController+Users.swift
+++ b/Sources/wired3/Core/ServerController+Users.swift
@@ -3,6 +3,7 @@
 //  wired3
 //
 import Foundation
+import GRDB
 import WiredSwift
 
 extension ServerController {
@@ -59,12 +60,23 @@ extension ServerController {
         App.serverController.reply(client: client, reply: response, message: message)
 
         // broadcast if already logged in
-        if client.state == .LOGGED_IN && client.user != nil {
+        if client.state == .LOGGED_IN, let username = client.user?.username {
             let newNick = client.nick ?? ""
             if previousNick != newNick {
                 self.recordEvent(.userChangedNick, client: client, parameters: [previousNick, newNick])
+                persistLastNick(newNick, forUsername: username)
             }
             self.sendUserStatus(forClient: client)
+        }
+    }
+
+    func persistLastNick(_ nick: String, forUsername username: String) {
+        guard !nick.isEmpty else { return }
+        try? App.databaseController.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE users SET last_nick = ? WHERE username = ?",
+                arguments: [nick, username]
+            )
         }
     }
 

--- a/Sources/wired3/Core/ServerController+Users.swift
+++ b/Sources/wired3/Core/ServerController+Users.swift
@@ -70,6 +70,49 @@ extension ServerController {
         }
     }
 
+    func receiveUserSetPublicKey(_ client: Client, _ message: P7Message) {
+        guard client.user != nil else {
+            replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
+            return
+        }
+        guard let keyData = message.data(forField: "wired.user.public_key"),
+              keyData.count == 32 else {
+            replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        let username = client.user?.username ?? ""
+        try? App.databaseController.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE users SET offline_public_key = ?, offline_key_id = 'x25519' WHERE username = ?",
+                arguments: [keyData, username]
+            )
+        }
+        replyOK(client: client, message: message)
+    }
+
+    func receiveUserGetPublicKey(_ client: Client, _ message: P7Message) {
+        guard client.user != nil else {
+            replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
+            return
+        }
+        guard let login = message.string(forField: "wired.user.login"), !login.isEmpty else {
+            replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        let keyData: Data? = try? App.databaseController.dbQueue.read { db in
+            guard let row = try Row.fetchOne(db, sql: "SELECT offline_public_key FROM users WHERE username = ?", arguments: [login]) else {
+                return nil
+            }
+            return row["offline_public_key"] as? Data
+        }
+        let reply = P7Message(withName: "wired.user.public_key", spec: self.spec)
+        reply.addParameter(field: "wired.user.login", value: login)
+        if let data = keyData, !data.isEmpty {
+            reply.addParameter(field: "wired.user.public_key", value: data)
+        }
+        self.reply(client: client, reply: reply, message: message)
+    }
+
     func persistLastNick(_ nick: String, forUsername username: String) {
         guard !nick.isEmpty else { return }
         try? App.databaseController.dbQueue.write { db in

--- a/Sources/wired3/Core/ServerController+Users.swift
+++ b/Sources/wired3/Core/ServerController+Users.swift
@@ -95,7 +95,7 @@ extension ServerController {
             replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
             return
         }
-        guard let login = message.string(forField: "wired.user.login"), !login.isEmpty else {
+        guard let login = message.string(forField: "wired.message.offline.recipient_login"), !login.isEmpty else {
             replyError(client: client, error: "wired.error.invalid_message", message: message)
             return
         }
@@ -106,7 +106,7 @@ extension ServerController {
             return row["offline_public_key"] as? Data
         }
         let reply = P7Message(withName: "wired.user.public_key", spec: self.spec)
-        reply.addParameter(field: "wired.user.login", value: login)
+        reply.addParameter(field: "wired.message.offline.recipient_login", value: login)
         if let data = keyData, !data.isEmpty {
             reply.addParameter(field: "wired.user.public_key", value: data)
         }

--- a/Sources/wired3/Core/ServerController.swift
+++ b/Sources/wired3/Core/ServerController.swift
@@ -711,6 +711,8 @@ public class ServerController: ServerDelegate {
             App.chatsController.kickUser(message: message, client: client)
         } else if message.name == "wired.message.send_message" {
             self.receiveMessageSendMessage(client: client, message: message)
+        } else if message.name == "wired.message.send_offline_message" {
+            self.receiveMessageSendOfflineMessage(client: client, message: message)
         } else if message.name == "wired.message.send_broadcast" {
             self.receiveMessageSendBroadcast(client: client, message: message)
         } else if message.name == "wired.attachment.create" {

--- a/Sources/wired3/Core/ServerController.swift
+++ b/Sources/wired3/Core/ServerController.swift
@@ -683,6 +683,10 @@ public class ServerController: ServerDelegate {
             self.receiveUserDisconnectUser(client: client, message: message)
         } else if message.name == "wired.user.ban_user" {
             self.receiveUserBanUser(client: client, message: message)
+        } else if message.name == "wired.user.set_public_key" {
+            self.receiveUserSetPublicKey(client, message)
+        } else if message.name == "wired.user.get_public_key" {
+            self.receiveUserGetPublicKey(client, message)
         } else if message.name == "wired.chat.get_chats" {
             App.chatsController.getChats(message: message, client: client)
         } else if message.name == "wired.chat.create_public_chat" {

--- a/Sources/wired3/Core/ServerController.swift
+++ b/Sources/wired3/Core/ServerController.swift
@@ -510,6 +510,11 @@ public class ServerController: ServerDelegate {
             self.recordEvent(.userLoggedOut, client: client)
         }
 
+        // Capture identity before we tear the user object down so we can notify
+        // privileged peers that this account is now offline.
+        let leftLogin = client.user?.username
+        let leftNick = client.nick
+
         let app = App
         app?.filesController?.unsubscribeAll(client: client)
         client.isSubscribedToAccounts = false
@@ -519,6 +524,28 @@ public class ServerController: ServerDelegate {
         app?.chatsController?.removeUserFromAllChats(client: client, broadcastLeaves: broadcastLeaves)
         client.state = .DISCONNECTED
         app?.clientsController?.removeClient(client: client)
+
+        if let login = leftLogin, !login.isEmpty,
+           let nick = leftNick, !nick.isEmpty {
+            self.broadcastOfflineUserEntry(login: login, nick: nick)
+        }
+    }
+
+    /// Notifies every currently-connected client that has the
+    /// `wired.account.user.list_offline_users` privilege that a user just went
+    /// offline, so their offline-user list can stay current without re-login.
+    /// Reuses the existing `wired.user.offline_list` message — clients already
+    /// handle it. Skipped if login or nick is empty.
+    private func broadcastOfflineUserEntry(login: String, nick: String) {
+        guard let clients = App.clientsController?.connectedClientsSnapshot() else { return }
+        for peer in clients
+        where peer.state == .LOGGED_IN
+            && peer.user?.hasPrivilege(name: "wired.account.user.list_offline_users") == true {
+            let entry = P7Message(withName: "wired.user.offline_list", spec: self.spec)
+            entry.addParameter(field: "wired.message.offline.recipient_login", value: login)
+            entry.addParameter(field: "wired.user.nick", value: nick)
+            _ = self.send(message: entry, client: peer)
+        }
     }
 
     public func receiveMessage(client: Client, message: P7Message) {

--- a/Sources/wired3/Core/Version.swift
+++ b/Sources/wired3/Core/Version.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public enum WiredServerVersion {
-    public static let marketingVersion = "3.0"
-    public static let buildNumber = "42"
-    public static let commit = "local"
+    public static let marketingVersion = "3.0-beta.23"
+    public static let buildNumber = "43"
+    public static let commit = "a478981"
     public static let number = marketingVersion
     public static let display = "wired3 \(marketingVersion) (\(buildNumber)+\(commit))"
 }

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -50,6 +50,9 @@ enum WiredMigrations {
         migrator.registerMigration("v14_last_login_at") { db in
             try WiredMigrations.v14(db)
         }
+        migrator.registerMigration("v15_last_nick") { db in
+            try WiredMigrations.v15(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -431,6 +434,13 @@ enum WiredMigrations {
                        WHERE recipient_identity = NEW.recipient_identity) >= 100;
             END;
         """)
+    }
+
+    // v15: Persist the user's last known chat nick so the offline user list can show it.
+    static func v15(_ db: Database) throws {
+        try db.alter(table: "users") { t in
+            t.add(column: "last_nick", .text)
+        }
     }
 
     // v14: Add last_login_at to users so we can filter the offline user list to recent accounts.

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -53,6 +53,9 @@ enum WiredMigrations {
         migrator.registerMigration("v15_last_nick") { db in
             try WiredMigrations.v15(db)
         }
+        migrator.registerMigration("v16_offline_messages_encrypted") { db in
+            try WiredMigrations.v16(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -434,6 +437,12 @@ enum WiredMigrations {
                        WHERE recipient_identity = NEW.recipient_identity) >= 100;
             END;
         """)
+    }
+
+    static func v16(_ db: Database) throws {
+        try db.alter(table: "offline_messages") { t in
+            t.add(column: "is_encrypted", .integer).notNull().defaults(to: 0)
+        }
     }
 
     // v15: Persist the user's last known chat nick so the offline user list can show it.

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -47,6 +47,9 @@ enum WiredMigrations {
         migrator.registerMigration("v13_offline_messages") { db in
             try WiredMigrations.v13(db)
         }
+        migrator.registerMigration("v14_last_login_at") { db in
+            try WiredMigrations.v14(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -428,6 +431,13 @@ enum WiredMigrations {
                        WHERE recipient_identity = NEW.recipient_identity) >= 100;
             END;
         """)
+    }
+
+    // v14: Add last_login_at to users so we can filter the offline user list to recent accounts.
+    static func v14(_ db: Database) throws {
+        try db.alter(table: "users") { t in
+            t.add(column: "last_login_at", .real)
+        }
     }
 
     // v13: Replace the speculative E2E-encrypted offline_messages schema (never used)

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -44,6 +44,9 @@ enum WiredMigrations {
         migrator.registerMigration("v12_add_is_legacy") { db in
             try WiredMigrations.v12(db)
         }
+        migrator.registerMigration("v13_offline_messages") { db in
+            try WiredMigrations.v13(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -423,6 +426,39 @@ enum WiredMigrations {
                 SELECT RAISE(ABORT, 'per-recipient offline message limit exceeded')
                 WHERE (SELECT COUNT(*) FROM offline_messages
                        WHERE recipient_identity = NEW.recipient_identity) >= 100;
+            END;
+        """)
+    }
+
+    // v13: Replace the speculative E2E-encrypted offline_messages schema (never used)
+    //      with a simple plaintext table that matches our actual implementation.
+    static func v13(_ db: Database) throws {
+        try db.execute(sql: "DROP TRIGGER IF EXISTS offline_messages_per_recipient_limit")
+        try db.execute(sql: "DROP INDEX IF EXISTS offline_messages_recipient_index")
+        try db.execute(sql: "DROP INDEX IF EXISTS offline_messages_expires_index")
+        try db.execute(sql: "DROP TABLE IF EXISTS offline_messages")
+
+        try db.create(table: "offline_messages") { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("sender_login", .text).notNull()
+            t.column("recipient_login", .text).notNull()
+            t.column("body", .text).notNull()
+            t.column("sent_at", .datetime).notNull()
+        }
+        try db.create(
+            index: "offline_messages_recipient_index",
+            on: "offline_messages",
+            columns: ["recipient_login"]
+        )
+
+        // Limit: max 100 queued messages per recipient to prevent storage DoS
+        try db.execute(sql: """
+            CREATE TRIGGER offline_messages_per_recipient_limit
+            BEFORE INSERT ON offline_messages
+            BEGIN
+                SELECT RAISE(ABORT, 'per-recipient offline message limit exceeded')
+                WHERE (SELECT COUNT(*) FROM offline_messages
+                       WHERE recipient_login = NEW.recipient_login) >= 100;
             END;
         """)
     }

--- a/Sources/wired3/Models/OfflineMessage.swift
+++ b/Sources/wired3/Models/OfflineMessage.swift
@@ -1,0 +1,29 @@
+//
+//  OfflineMessage.swift
+//  wired3
+//
+
+import GRDB
+import Foundation
+
+struct OfflineMessage: Codable, FetchableRecord, MutablePersistableRecord {
+    static let databaseTableName = "offline_messages"
+
+    var id: Int64?
+    var senderLogin: String
+    var recipientLogin: String
+    var body: String
+    var sentAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case senderLogin    = "sender_login"
+        case recipientLogin = "recipient_login"
+        case body
+        case sentAt         = "sent_at"
+    }
+
+    mutating func didInsert(_ inserted: InsertionSuccess) {
+        id = inserted.rowID
+    }
+}

--- a/Sources/wired3/Models/OfflineMessage.swift
+++ b/Sources/wired3/Models/OfflineMessage.swift
@@ -14,6 +14,7 @@ struct OfflineMessage: Codable, FetchableRecord, MutablePersistableRecord {
     var recipientLogin: String
     var body: String
     var sentAt: Date
+    var isEncrypted: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -21,6 +22,7 @@ struct OfflineMessage: Codable, FetchableRecord, MutablePersistableRecord {
         case recipientLogin = "recipient_login"
         case body
         case sentAt         = "sent_at"
+        case isEncrypted    = "is_encrypted"
     }
 
     mutating func didInsert(_ inserted: InsertionSuccess) {

--- a/Tests/WiredSwiftTests/NetworkLayerTests.swift
+++ b/Tests/WiredSwiftTests/NetworkLayerTests.swift
@@ -6,7 +6,8 @@ final class NetworkLayerTests: XCTestCase {
     private var spec: P7Spec!
 
     override func setUpWithError() throws {
-        spec = try XCTUnwrap(WiredProtocolSpec.bundledSpec(), "Failed to load bundled wired.xml")
+        spec = try XCTUnwrap(P7Spec(withUrl: TestResources.specURL),
+                              "Failed to load bundled wired.xml")
     }
 
     func testConnectionAddAndRemoveDelegateAvoidsDuplicates() {
@@ -188,7 +189,7 @@ final class NetworkLayerTests: XCTestCase {
     func testConnectionConnectCompletesHandshakeUserSetupAndLoginFlow() throws {
         let listener = try Socket.tcpListening(port: 0, address: "127.0.0.1")
         let port = Int(try listener.port())
-        let serverSpec = try XCTUnwrap(WiredProtocolSpec.bundledSpec())
+        let serverSpec = try XCTUnwrap(P7Spec(withUrl: TestResources.specURL))
 
         var serverError: Error?
         let serverDone = expectation(description: "server done")
@@ -234,7 +235,7 @@ final class NetworkLayerTests: XCTestCase {
     func testConnectionReconnectReestablishesSession() throws {
         let listener = try Socket.tcpListening(port: 0, address: "127.0.0.1")
         let port = Int(try listener.port())
-        let serverSpec = try XCTUnwrap(WiredProtocolSpec.bundledSpec())
+        let serverSpec = try XCTUnwrap(P7Spec(withUrl: TestResources.specURL))
 
         var serverError: Error?
         let serverDone = expectation(description: "server done twice")

--- a/Tests/WiredSwiftTests/P7MessageTests.swift
+++ b/Tests/WiredSwiftTests/P7MessageTests.swift
@@ -6,7 +6,8 @@ final class P7MessageTests: XCTestCase {
     var spec: P7Spec!
 
     override func setUpWithError() throws {
-        spec = try XCTUnwrap(WiredProtocolSpec.bundledSpec(), "Failed to load bundled wired.xml")
+        spec = try XCTUnwrap(P7Spec(withUrl: TestResources.specURL),
+                              "Failed to load bundled wired.xml")
     }
 
     // MARK: - init(withName:spec:)

--- a/Tests/WiredSwiftTests/P7SocketIOTests.swift
+++ b/Tests/WiredSwiftTests/P7SocketIOTests.swift
@@ -6,7 +6,8 @@ final class P7SocketIOTests: XCTestCase {
     private var spec: P7Spec!
 
     override func setUpWithError() throws {
-        spec = try XCTUnwrap(WiredProtocolSpec.bundledSpec(), "Failed to load bundled wired.xml")
+        spec = try XCTUnwrap(P7Spec(withUrl: TestResources.specURL),
+                              "Failed to load bundled wired.xml")
     }
 
     func testWriteAndReadMessageRoundTripAcrossLocalSocketPair() throws {
@@ -342,6 +343,6 @@ final class P7SocketIOTests: XCTestCase {
     }
 
     private func loadSpec() -> P7Spec? {
-        WiredProtocolSpec.bundledSpec()
+        P7Spec(withUrl: TestResources.specURL)
     }
 }

--- a/Tests/WiredSwiftTests/P7SpecMetadataTests.swift
+++ b/Tests/WiredSwiftTests/P7SpecMetadataTests.swift
@@ -42,8 +42,8 @@ final class P7SpecMetadataTests: XCTestCase {
         XCTAssertEqual(withID.description, "[1000] wired.okay")
     }
 
-    func testAccountPrivilegesCollectionIncludesFileLabelPrivilege() {
-        let spec = P7Spec(withPath: nil)
+    func testAccountPrivilegesCollectionIncludesFileLabelPrivilege() throws {
+        let spec = try XCTUnwrap(P7Spec(withUrl: TestResources.specURL))
 
         XCTAssertTrue(spec.accountPrivileges?.contains("wired.account.file.set_label") == true)
     }

--- a/Tests/WiredSwiftTests/TestResources.swift
+++ b/Tests/WiredSwiftTests/TestResources.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Resolves the canonical `wired.xml` location from the test source tree.
+///
+/// `WiredProtocolSpec.bundledSpec()` deliberately returns nil rather than
+/// crashing when the SPM resource bundle cannot be located, so tests that
+/// need the spec resolve it from `#filePath` instead — robust across
+/// macOS xctest and Linux SPM regardless of how SPM exposes resources.
+enum TestResources {
+    static let specURL: URL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Sources/WiredSwift/Resources/wired.xml")
+}

--- a/Tests/wired3IntegrationTests/IntegrationTestSupport.swift
+++ b/Tests/wired3IntegrationTests/IntegrationTestSupport.swift
@@ -137,7 +137,12 @@ final class IntegrationServerRuntime {
         self.filesURL = resolvedRoot.appendingPathComponent("files", isDirectory: true)
         self.dbPath = resolvedRoot.appendingPathComponent("wired3.sqlite").path
         self.configPath = resolvedRoot.appendingPathComponent("config.ini").path
-        self.specPath = try XCTUnwrap(WiredProtocolSpec.bundledSpecURL()).path
+        self.specPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/WiredSwift/Resources/wired.xml")
+            .path
         self.port = resolvedPort
 
         try FileManager.default.createDirectory(at: filesURL, withIntermediateDirectories: true)

--- a/Tests/wired3Tests/FilesControllerTests.swift
+++ b/Tests/wired3Tests/FilesControllerTests.swift
@@ -716,7 +716,12 @@ final class FilesControllerTests: XCTestCase {
     }
 
     private func wiredSpecPath() -> String {
-        WiredProtocolSpec.bundledSpecURL()!.path
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/WiredSwift/Resources/wired.xml")
+            .path
     }
 
     private func configPath() -> String {

--- a/Tests/wired3Tests/LogsControllerTests.swift
+++ b/Tests/wired3Tests/LogsControllerTests.swift
@@ -195,7 +195,12 @@ final class LogsControllerTests: XCTestCase {
     }
 
     private func wiredSpecPath() -> String {
-        WiredProtocolSpec.bundledSpecURL()!.path
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/WiredSwift/Resources/wired.xml")
+            .path
     }
 
     private func configPath() -> String {

--- a/Tests/wired3Tests/TransfersControllerTests.swift
+++ b/Tests/wired3Tests/TransfersControllerTests.swift
@@ -294,6 +294,11 @@ final class TransfersControllerTests: XCTestCase {
     }
 
     private func wiredSpecPath() -> String {
-        WiredProtocolSpec.bundledSpecURL()!.path
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/WiredSwift/Resources/wired.xml")
+            .path
     }
 }


### PR DESCRIPTION
Replaces #74 — now pointing to the correct `clean/offline-messaging` branch.

## Summary

This PR bundles related server-side features and fixes that belong together:

### Offline Private Messaging (E2E encrypted)
- New message type `wired.message.send_offline` — stores encrypted messages for offline users
- New privilege `wired.account.user.list_offline_users` — controls who can see the offline user list
- `sendOfflineUserList`: sends `wired.user.offline_list` / `wired.user.offline_list.done` to privileged clients after login; each entry carries `wired.user.login` (for addressing) + `wired.user.nick` (for display)
- Delivered messages are deleted from the DB on next login
- E2E: X25519 key exchange + ChaCha20-Poly1305 encryption; server is a blind relay, never sees plaintext
- New DB columns: `users.public_key`, `users.last_nick`, `users.last_login_at`; new table `offline_messages`

### Legacy SHA1 Auth Upgrade Flow
- Clients using SHA1 passwords (migrated from Wired 2.5) are detected and asked to set a new SHA256 password on first login
- `password_salt IS NULL` signals a legacy credential

### Wired 2.5 → 3 Migration (CLI + GUI)
- CLI: `wired3 --migrate-from /path/to/wired25.db [--overwrite]`
- GUI: "Migration from Wired 2.5" section in the Database tab of WiredServerApp
- Migrates users, groups, and ban list; maps 70+ privilege columns; preserves SHA1 hashes as-is (users prompted on first login)

### Stability / Security Fixes
- Rate-limit enforcement for offline message sending
- Guard against SPM resource bundle crash on non-app targets
- Nick tracking (`last_nick` updated on every login)

## Test plan

- [ ] Send an offline message to a user who is not logged in → message is stored
- [ ] Log in as the recipient → message is delivered and deleted from DB
- [ ] User without `wired.account.user.list_offline_users` does not receive the offline user list
- [ ] Wired 2.5 DB migration via CLI and via GUI succeeds; migrated users can log in (SHA1), are then prompted to set a new password
- [ ] Legacy SHA1 user sets new password → subsequent login uses SHA256

🤖 Generated with [Claude Code](https://claude.com/claude-code)