### PR TITLE
feat(server-app): manual database snapshot trigger + snapshot safety fix

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/WiredSwift-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/WiredSwift-Package.xcscheme
@@ -48,6 +48,34 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WiredChatBot"
+               BuildableName = "WiredChatBot"
+               BlueprintName = "WiredChatBot"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WiredServerApp"
+               BuildableName = "WiredServerApp"
+               BlueprintName = "WiredServerApp"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -66,6 +94,26 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3IntegrationTests"
+               BuildableName = "wired3IntegrationTests"
+               BlueprintName = "wired3IntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3Tests"
+               BuildableName = "wired3Tests"
+               BlueprintName = "wired3Tests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -78,6 +126,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WiredServerApp"
+            BuildableName = "WiredServerApp"
+            BlueprintName = "WiredServerApp"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -94,15 +152,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "wired3"
-            BuildableName = "wired3"
-            BlueprintName = "wired3"
+            BlueprintIdentifier = "WiredServerApp"
+            BuildableName = "WiredServerApp"
+            BlueprintName = "WiredServerApp"
             ReferencedContainer = "container:">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/wired3.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/wired3.xcscheme
@@ -52,6 +52,26 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3IntegrationTests"
+               BuildableName = "wired3IntegrationTests"
+               BlueprintName = "wired3IntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "wired3Tests"
+               BuildableName = "wired3Tests"
+               BlueprintName = "wired3Tests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -78,19 +98,19 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--root /Users/nark/Development/Me/Swift/WiredSwift/run"
+            argument = "--root /Users/admin/Documents/Wired3/WiredSwift/run"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--db /Users/nark/Development/Me/Swift/WiredSwift/wired3.db"
+            argument = "--db /Users/admin/Documents/Wired3/WiredSwift/wired3.db"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--config /Users/nark/Development/Me/Swift/WiredSwift/Sources/wired3/config.ini"
+            argument = "--config /Users/admin/Documents/Wired3/WiredSwift/Sources/wired3/config.ini"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "/Users/nark/Development/Me/Swift/WiredSwift/run/wired.xml"
+            argument = "/Users/admin/Documents/Wired3/WiredSwift/run/wired.xml"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to WiredSwift are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [Unreleased]
+
+### Features
+- Add Wired 2.5 → Wired 3 database migration (`wired3 --migrate-from <path>`) — migrates users, groups, bans, boards, threads and posts ([`14ff423`](https://github.com/martinmarsian/WiredSwift/commit/14ff42328c0e66f69e66d30434e327a7c7de1bb6))
+
+- Support legacy SHA1 password authentication for accounts migrated from Wired 2.5; server signals `p7.encryption.legacy_password` in `server_challenge` and sets `wired.user.password_must_change` in the login reply to trigger a mandatory credential upgrade on the client ([`8cf6e3c`](https://github.com/martinmarsian/WiredSwift/commit/8cf6e3ca99f2ae1906fd21e2e25c8222485fee94))
+
+
 ## [3.0-beta.22+42] — 2026-04-20
 
 ### Bug Fixes
@@ -14,7 +22,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Refactoring
 - Move WiredChatBot in separated repo ([`6166223`](https://github.com/nark/WiredSwift/commit/6166223b5feaef77d760884d4c0718ee73216d1f))
-
 ## [3.0-beta.21+38] — 2026-04-13
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The project is currently in beta. It is already usable, but it is still evolving
 
 Releases: https://github.com/nark/WiredSwift/releases
 
+> **Client compatibility:** Wired 3.0 uses a new version of the P7 protocol and is **not compatible** with older Wired 2.x clients (including Zankasoftware-era clients). Only Wired 3.x clients can connect to a Wired 3.0 server.
+
 ---
 
 ## Table of Contents

--- a/Scripts/build-wired-server-app.sh
+++ b/Scripts/build-wired-server-app.sh
@@ -37,7 +37,7 @@ if [[ "$BUILD_CONFIG" != "debug" && "$BUILD_CONFIG" != "release" ]]; then
   exit 1
 fi
 
-if [[ ! "$MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+if [[ ! "$MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+)*(-[a-zA-Z0-9.]+)?$ ]]; then
   echo "Invalid WIRED_MARKETING_VERSION: $MARKETING_VERSION"
   exit 1
 fi

--- a/Scripts/build-wired-server-app.sh
+++ b/Scripts/build-wired-server-app.sh
@@ -3,6 +3,16 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_CONFIG="${1:-release}"
+
+# Command Line Tools lack x86_64 Swift compatibility libs; prefer full Xcode.
+if [[ -z "${DEVELOPER_DIR:-}" ]]; then
+  for _xcode in /Applications/Xcode.app /Applications/Xcode-beta.app; do
+    if [[ -d "$_xcode/Contents/Developer" ]]; then
+      export DEVELOPER_DIR="$_xcode/Contents/Developer"
+      break
+    fi
+  done
+fi
 APP_NAME="Wired Server"
 EXECUTABLE_NAME="WiredServerApp"
 SERVER_BINARY_NAME="wired3"
@@ -248,7 +258,13 @@ notarize_zip() {
   local label="$3"
 
   echo "==> Notarizing $label"
-  xcrun notarytool submit "$zip_path" --keychain-profile "$profile" --wait
+  local output
+  output="$(xcrun notarytool submit "$zip_path" --keychain-profile "$profile" --wait 2>&1)"
+  echo "$output"
+  if ! echo "$output" | grep -q "status: Accepted"; then
+    echo "Notarization was not accepted for $label — aborting." >&2
+    exit 1
+  fi
 }
 
 SIGNING_IDENTITY="$(resolve_signing_identity || true)"
@@ -320,6 +336,13 @@ if [[ "$NOTARIZE" == "1" ]]; then
   xcrun stapler validate "$APP_DIR"
   rm -f "$APP_ZIP_PATH"
   ditto -c -k --keepParent "$APP_DIR" "$APP_ZIP_PATH"
+
+  # Flat executables cannot have notarization tickets stapled (xcrun stapler
+  # only supports .app/.dmg/.pkg). The ticket is registered in Apple's CDN;
+  # Gatekeeper verifies it online at first launch when the quarantine flag is
+  # present. The app install flow re-signs wired3 with ad-hoc after copying
+  # it to /Library/Wired3/bin/, which removes the Hardened Runtime flag and
+  # makes it launchable by the LaunchDaemon without a stapled ticket.
 fi
 
 echo "==> Verifying signatures"

--- a/Scripts/build-wired-server-app.sh
+++ b/Scripts/build-wired-server-app.sh
@@ -20,6 +20,15 @@ APP_ZIP_PATH="$ROOT_DIR/dist/Wired-Server.app.zip"
 SERVER_ZIP_PATH="$ROOT_DIR/dist/$SERVER_BINARY_NAME.zip"
 NOTARIZE="${NOTARIZE:-}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+
+# Auto-load notary profile from ~/.wired-notary if not set via environment.
+# File format (shell-sourceable):  NOTARY_PROFILE="<your-profile>"
+if [[ -z "$NOTARY_PROFILE" && -f "${HOME}/.wired-notary" ]]; then
+  # shellcheck source=/dev/null
+  source "${HOME}/.wired-notary"
+  NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+fi
+
 VERSION_SWIFT="$ROOT_DIR/Sources/wired3/Core/Version.swift"
 VERSION_SWIFT_BACKUP=""
 
@@ -259,6 +268,15 @@ else
   codesign --force --sign - "$DIST_SERVER_BINARY"
   codesign --force --sign - "$RESOURCES_DIR/$SERVER_BINARY_NAME"
   codesign --force --deep --sign - "$APP_DIR"
+fi
+
+if [[ "$SIGNING_MODE" == "developer-id" && -z "$NOTARY_PROFILE" ]]; then
+  echo ""
+  echo "    TIP: Notarization is disabled. To enable it, create ~/.wired-notary:"
+  echo "         NOTARY_PROFILE=\"<profile-name>\""
+  echo "         Then store the credentials once with:"
+  echo "         xcrun notarytool store-credentials \"<profile-name>\" --apple-id <id> --team-id <team>"
+  echo ""
 fi
 
 if [[ -z "$NOTARIZE" ]]; then

--- a/Scripts/migrate-from-wired25.py
+++ b/Scripts/migrate-from-wired25.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""
+migrate-from-wired25.py
+Migrates users, groups and bans from a Wired 2.5 SQLite database
+into an existing Wired 3 (wired3) SQLite database.
+
+Usage:
+    python3 Scripts/migrate-from-wired25.py \
+        --source  /path/to/wired25/database.sqlite3 \
+        --target  /path/to/wired3/database.sqlite3  \
+        [--dry-run]   # analyse only, no writes
+        [--overwrite] # replace existing users/groups in Wired 3
+
+IMPORTANT:
+  • Make a backup of both databases before running!
+  • Wired 2.5 stores passwords as SHA1 hashes, Wired 3 uses SHA256 + salt.
+    Passwords are copied as-is. Wired 3 will treat them as "legacy" and users
+    will need to set a new password on first login (or you reset them manually).
+  • The 'admin' account that Wired 3 creates by default is never overwritten
+    unless --overwrite is passed.
+"""
+
+import sqlite3
+import argparse
+import sys
+from datetime import datetime, timezone
+
+# ── Privilege mapping: Wired 2.5 column → Wired 3 privilege name ─────────────
+#
+# Boolean privileges (0/1 in 2.5, stored as separate rows in 3)
+BOOL_PRIVILEGE_MAP = {
+    "user_get_info":                        "wired.account.user.get_info",
+    "user_disconnect_users":                "wired.account.user.disconnect_users",
+    "user_ban_users":                       "wired.account.user.ban_users",
+    "user_cannot_be_disconnected":          "wired.account.user.cannot_be_disconnected",
+    "user_cannot_set_nick":                 "wired.account.user.cannot_set_nick",
+    "user_get_users":                       "wired.account.user.get_users",
+    "chat_kick_users":                      "wired.account.chat.kick_users",
+    "chat_set_topic":                       "wired.account.chat.set_topic",
+    "chat_create_chats":                    "wired.account.chat.create_chats",
+    "message_send_messages":                "wired.account.message.send_messages",
+    "message_broadcast":                    "wired.account.message.broadcast",
+    "file_list_files":                      "wired.account.file.list_files",
+    "file_search_files":                    "wired.account.file.search_files",
+    "file_get_info":                        "wired.account.file.get_info",
+    "file_create_links":                    "wired.account.file.create_links",
+    "file_rename_files":                    "wired.account.file.rename_files",
+    "file_set_type":                        "wired.account.file.set_type",
+    "file_set_comment":                     "wired.account.file.set_comment",
+    "file_set_permissions":                 "wired.account.file.set_permissions",
+    "file_set_executable":                  "wired.account.file.set_executable",
+    "file_set_label":                       "wired.account.file.set_label",
+    "file_create_directories":              "wired.account.file.create_directories",
+    "file_move_files":                      "wired.account.file.move_files",
+    "file_delete_files":                    "wired.account.file.delete_files",
+    "file_access_all_dropboxes":            "wired.account.file.access_all_dropboxes",
+    "account_change_password":              "wired.account.account.change_password",
+    "account_list_accounts":               "wired.account.account.list_accounts",
+    "account_read_accounts":               "wired.account.account.read_accounts",
+    "account_create_users":                "wired.account.account.create_users",
+    "account_edit_users":                  "wired.account.account.edit_users",
+    "account_delete_users":                "wired.account.account.delete_users",
+    "account_create_groups":               "wired.account.account.create_groups",
+    "account_edit_groups":                 "wired.account.account.edit_groups",
+    "account_delete_groups":               "wired.account.account.delete_groups",
+    "account_raise_account_privileges":    "wired.account.account.raise_account_privileges",
+    "transfer_download_files":             "wired.account.transfer.download_files",
+    "transfer_upload_files":               "wired.account.transfer.upload_files",
+    "transfer_upload_anywhere":            "wired.account.transfer.upload_anywhere",
+    "transfer_upload_directories":         "wired.account.transfer.upload_directories",
+    "board_read_boards":                   "wired.account.board.read_boards",
+    "board_add_boards":                    "wired.account.board.add_boards",
+    "board_move_boards":                   "wired.account.board.move_boards",
+    "board_rename_boards":                 "wired.account.board.rename_boards",
+    "board_delete_boards":                 "wired.account.board.delete_boards",
+    "board_get_board_info":                "wired.account.board.get_board_info",
+    "board_set_board_info":                "wired.account.board.set_board_info",
+    "board_add_threads":                   "wired.account.board.add_threads",
+    "board_move_threads":                  "wired.account.board.move_threads",
+    "board_add_posts":                     "wired.account.board.add_posts",
+    "board_edit_own_threads_and_posts":    "wired.account.board.edit_own_threads_and_posts",
+    "board_edit_all_threads_and_posts":    "wired.account.board.edit_all_threads_and_posts",
+    "board_delete_own_threads_and_posts":  "wired.account.board.delete_own_threads_and_posts",
+    "board_delete_all_threads_and_posts":  "wired.account.board.delete_all_threads_and_posts",
+    "log_view_log":                        "wired.account.log.view_log",
+    "events_view_events":                  "wired.account.events.view_events",
+    "settings_get_settings":              "wired.account.settings.get_settings",
+    "settings_set_settings":              "wired.account.settings.set_settings",
+    "banlist_get_bans":                    "wired.account.banlist.get_bans",
+    "banlist_add_bans":                    "wired.account.banlist.add_bans",
+    "banlist_delete_bans":                 "wired.account.banlist.delete_bans",
+    "tracker_list_servers":                "wired.account.tracker.list_servers",
+    "tracker_register_servers":            "wired.account.tracker.register_servers",
+}
+
+# Integer privileges (stored as value in Wired 3, still as separate privilege rows)
+INT_PRIVILEGE_MAP = {
+    "file_recursive_list_depth_limit":     "wired.account.file.recursive_list_depth_limit",
+    "transfer_download_speed_limit":       "wired.account.transfer.download_speed_limit",
+    "transfer_upload_speed_limit":         "wired.account.transfer.upload_speed_limit",
+    "transfer_download_limit":             "wired.account.transfer.download_limit",
+    "transfer_upload_limit":               "wired.account.transfer.upload_limit",
+}
+
+
+def log(msg):
+    print(msg)
+
+
+def warn(msg):
+    print(f"  WARNING: {msg}")
+
+
+def migrate_groups(src, dst, dry_run, overwrite):
+    log("\n── Groups ───────────────────────────────────────────────")
+    rows = src.execute("SELECT name, color FROM groups").fetchall()
+    log(f"  Found {len(rows)} group(s) in Wired 2.5")
+
+    migrated = skipped = 0
+    for row in rows:
+        name  = row["name"]
+        color = row["color"]  # already in "wired.account.color.xxx" format or NULL
+
+        if dry_run:
+            log(f"  DRY   group '{name}'  color={color}")
+            migrated += 1
+            continue
+
+        exists = dst.execute(
+            "SELECT id FROM groups WHERE name = ?", (name,)
+        ).fetchone()
+
+        if exists and not overwrite:
+            log(f"  SKIP  group '{name}' (already exists)")
+            skipped += 1
+            continue
+
+        if exists:
+            dst.execute(
+                "UPDATE groups SET color = ? WHERE name = ?",
+                (color, name)
+            )
+            group_id = exists["id"]
+            log(f"  UPD   group '{name}'")
+        else:
+            cur = dst.execute(
+                "INSERT INTO groups (name, color) VALUES (?, ?)",
+                (name, color)
+            )
+            group_id = cur.lastrowid
+            log(f"  ADD   group '{name}'")
+
+        # Migrate group privileges
+        _migrate_privileges(
+            src_row=src.execute("SELECT * FROM groups WHERE name = ?", (name,)).fetchone(),
+            dst=dst,
+            table="group_privileges",
+            fk_col="group_id",
+            fk_val=group_id,
+            dry_run=dry_run,
+        )
+        migrated += 1
+
+    log(f"  → {migrated} migrated, {skipped} skipped")
+
+
+def migrate_users(src, dst, dry_run, overwrite):
+    log("\n── Users ────────────────────────────────────────────────")
+    rows = src.execute("SELECT * FROM users").fetchall()
+    log(f"  Found {len(rows)} user(s) in Wired 2.5")
+
+    migrated = skipped = 0
+    now = datetime.now(timezone.utc).isoformat()
+
+    for row in rows:
+        username = row["name"]
+
+        # Map fields
+        password          = row["password"] or ""
+        full_name         = row["full_name"]
+        comment           = row["comment"]
+        creation_time     = row["creation_time"]
+        modification_time = row["modification_time"]
+        login_time        = row["login_time"]
+        edited_by         = row["edited_by"]
+        downloads         = row["downloads"] or 0
+        download_xfr      = row["download_transferred"] or 0
+        uploads           = row["uploads"] or 0
+        upload_xfr        = row["upload_transferred"] or 0
+        group             = row["group"]
+        groups            = row["groups"]
+        color             = row["color"]
+        files             = row["files"]
+
+        if dry_run:
+            log(f"  DRY   user '{username}'  group={group}  color={color}")
+            migrated += 1
+            continue
+
+        exists = dst.execute(
+            "SELECT id FROM users WHERE username = ?", (username,)
+        ).fetchone()
+
+        if exists and not overwrite:
+            log(f"  SKIP  user '{username}' (already exists)")
+            skipped += 1
+            continue
+
+        if exists:
+            dst.execute("""
+                UPDATE users SET
+                    password=?, full_name=?, comment=?,
+                    creation_time=?, modification_time=?, login_time=?,
+                    edited_by=?, downloads=?, download_transferred=?,
+                    uploads=?, upload_transferred=?,
+                    "group"=?, groups=?, color=?, files=?,
+                    password_salt=NULL
+                WHERE username=?
+            """, (
+                password, full_name, comment,
+                creation_time, modification_time, login_time,
+                edited_by, downloads, download_xfr,
+                uploads, upload_xfr,
+                group, groups, color, files,
+                username,
+            ))
+            user_id = exists["id"]
+            # Remove old privileges so they get re-written cleanly
+            dst.execute("DELETE FROM user_privileges WHERE user_id = ?", (user_id,))
+            log(f"  UPD   user '{username}'")
+        else:
+            cur = dst.execute("""
+                INSERT INTO users (
+                    username, password, password_salt,
+                    full_name, comment,
+                    creation_time, modification_time, login_time,
+                    edited_by, downloads, download_transferred,
+                    uploads, upload_transferred,
+                    "group", groups, color, files
+                ) VALUES (?,?,NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """, (
+                username, password,
+                full_name, comment,
+                creation_time, modification_time, login_time,
+                edited_by, downloads, download_xfr,
+                uploads, upload_xfr,
+                group, groups, color, files,
+            ))
+            user_id = cur.lastrowid
+            log(f"  ADD   user '{username}'")
+
+        # Migrate user privileges
+        _migrate_privileges(
+            src_row=row,
+            dst=dst,
+            table="user_privileges",
+            fk_col="user_id",
+            fk_val=user_id,
+            dry_run=dry_run,
+        )
+        migrated += 1
+
+    log(f"  → {migrated} migrated, {skipped} skipped")
+
+
+def migrate_bans(src, dst, dry_run, overwrite):
+    log("\n── Bans ─────────────────────────────────────────────────")
+    rows = src.execute("SELECT ip, expiration_date FROM banlist").fetchall()
+    log(f"  Found {len(rows)} ban(s) in Wired 2.5")
+
+    migrated = skipped = 0
+    for row in rows:
+        ip_pattern      = row["ip"]
+        expiration_date = row["expiration_date"]
+
+        if dry_run:
+            log(f"  DRY   ban '{ip_pattern}'  expires={expiration_date}")
+            migrated += 1
+            continue
+
+        exists = dst.execute(
+            "SELECT id FROM banlist WHERE ip_pattern = ?", (ip_pattern,)
+        ).fetchone()
+
+        if exists and not overwrite:
+            log(f"  SKIP  ban '{ip_pattern}'")
+            skipped += 1
+            continue
+
+        if exists:
+            dst.execute(
+                "UPDATE banlist SET expiration_date = ? WHERE ip_pattern = ?",
+                (expiration_date, ip_pattern)
+            )
+        else:
+            dst.execute(
+                "INSERT INTO banlist (ip_pattern, expiration_date) VALUES (?, ?)",
+                (ip_pattern, expiration_date)
+            )
+        log(f"  ADD   ban '{ip_pattern}'  expires={expiration_date or 'never'}")
+        migrated += 1
+
+    log(f"  → {migrated} migrated, {skipped} skipped")
+
+
+def _migrate_privileges(src_row, dst, table, fk_col, fk_val, dry_run):
+    """Write privilege rows for a single user or group."""
+    cols = src_row.keys()
+
+    for src_col, priv_name in BOOL_PRIVILEGE_MAP.items():
+        if src_col not in cols:
+            continue
+        raw = src_row[src_col]
+        if raw is None:
+            continue
+        value = bool(int(raw))
+        if not dry_run:
+            dst.execute(
+                f"INSERT OR REPLACE INTO {table} (name, value, {fk_col}) VALUES (?,?,?)",
+                (priv_name, value, fk_val)
+            )
+
+    for src_col, priv_name in INT_PRIVILEGE_MAP.items():
+        if src_col not in cols:
+            continue
+        raw = src_row[src_col]
+        if raw is None:
+            continue
+        # Integer privileges: store the integer value cast to BOOLEAN column
+        # (Wired 3 treats these as numeric limits — 0 = unlimited)
+        value = int(raw)
+        if not dry_run:
+            dst.execute(
+                f"INSERT OR REPLACE INTO {table} (name, value, {fk_col}) VALUES (?,?,?)",
+                (priv_name, value, fk_val)
+            )
+
+
+def print_summary(src):
+    log("\n── Source database summary ───────────────────────────────")
+    for table in ("users", "groups", "banlist"):
+        try:
+            n = src.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            log(f"  {table:<12} {n} row(s)")
+        except Exception:
+            log(f"  {table:<12} (not found)")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Migrate Wired 2.5 database to Wired 3 format"
+    )
+    parser.add_argument("--source",    required=True, help="Path to Wired 2.5 database.sqlite3")
+    parser.add_argument("--target",    required=True, help="Path to Wired 3 database.sqlite3")
+    parser.add_argument("--dry-run",   action="store_true", help="Analyse only, no writes")
+    parser.add_argument("--overwrite", action="store_true", help="Replace existing records in Wired 3")
+    args = parser.parse_args()
+
+    log("╔══════════════════════════════════════════════════════════╗")
+    log("║        Wired 2.5 → Wired 3  database migration          ║")
+    log("╚══════════════════════════════════════════════════════════╝")
+    if args.dry_run:
+        log("  MODE: DRY RUN – no changes will be written\n")
+
+    src = sqlite3.connect(args.source)
+    src.row_factory = sqlite3.Row
+    dst = sqlite3.connect(args.target)
+    dst.row_factory = sqlite3.Row
+    dst.execute("PRAGMA foreign_keys = ON")
+    dst.execute("PRAGMA journal_mode = WAL")
+
+    print_summary(src)
+
+    try:
+        if not args.dry_run:
+            dst.execute("BEGIN")
+
+        migrate_groups(src, dst, args.dry_run, args.overwrite)
+        migrate_users(src, dst, args.dry_run, args.overwrite)
+        migrate_bans(src, dst, args.dry_run, args.overwrite)
+
+        if not args.dry_run:
+            dst.commit()
+            log("\n✓ Migration committed successfully.")
+        else:
+            log("\n✓ Dry run complete – no changes were written.")
+
+        log("")
+        log("  NOTE: Passwords were migrated as-is (SHA1 hashes from Wired 2.5).")
+        log("        Users will need to set a new password on their first login")
+        log("        to Wired 3 (use the admin panel to reset passwords).")
+
+    except Exception as e:
+        if not args.dry_run:
+            dst.rollback()
+        log(f"\n✗ ERROR: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        src.close()
+        dst.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/migrate-from-wired25.py
+++ b/Scripts/migrate-from-wired25.py
@@ -220,7 +220,7 @@ def migrate_users(src, dst, dry_run, overwrite):
                     edited_by=?, downloads=?, download_transferred=?,
                     uploads=?, upload_transferred=?,
                     "group"=?, groups=?, color=?, files=?,
-                    password_salt=NULL
+                    password_salt=NULL, is_legacy=1
                 WHERE username=?
             """, (
                 password, full_name, comment,
@@ -237,13 +237,13 @@ def migrate_users(src, dst, dry_run, overwrite):
         else:
             cur = dst.execute("""
                 INSERT INTO users (
-                    username, password, password_salt,
+                    username, password, password_salt, is_legacy,
                     full_name, comment,
                     creation_time, modification_time, login_time,
                     edited_by, downloads, download_transferred,
                     uploads, upload_transferred,
                     "group", groups, color, files
-                ) VALUES (?,?,NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                ) VALUES (?,?,NULL,1,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
             """, (
                 username, password,
                 full_name, comment,

--- a/Scripts/migrate-from-wired25.py
+++ b/Scripts/migrate-from-wired25.py
@@ -11,11 +11,17 @@ Usage:
         [--dry-run]   # analyse only, no writes
         [--overwrite] # replace existing users/groups in Wired 3
 
+SCOPE:
+  This script migrates accounts (users + groups + bans) only.
+  Boards, threads and posts are NOT migrated by this script.
+  Use the built-in server migration instead (wired3 --migrate-from <path>)
+  if you also need to carry over board content — that path migrates everything.
+
 IMPORTANT:
   • Make a backup of both databases before running!
   • Wired 2.5 stores passwords as SHA1 hashes, Wired 3 uses SHA256 + salt.
-    Passwords are copied as-is. Wired 3 will treat them as "legacy" and users
-    will need to set a new password on first login (or you reset them manually).
+    Passwords are copied as-is (is_legacy flag set to 1). Wired 3 will treat
+    them as "legacy" and users will need to set a new password on first login.
   • The 'admin' account that Wired 3 creates by default is never overwritten
     unless --overwrite is passed.
 """

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_CONFIG="${1:-release}"
-DOWNLOADS_DIR="${HOME}/Downloads"
+DOWNLOADS_DIR="/Users/admin/Desktop/VirtualBuddyShared/maertin/Downloads"
 
 # ── Version: auto-detect from last git tag (e.g. v3.0-beta.21+38) ────────────
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_CONFIG="${1:-release}"
-DOWNLOADS_DIR="/Users/admin/Desktop/VirtualBuddyShared/maertin/Downloads"
+DOWNLOADS_DIR="$HOME/Downloads"
 
 # ── Version: auto-detect from last git tag (e.g. v3.0-beta.21+38) ────────────
 

--- a/Sources/WiredServerApp/BiometricCredentialStore.swift
+++ b/Sources/WiredServerApp/BiometricCredentialStore.swift
@@ -1,0 +1,83 @@
+import Foundation
+import LocalAuthentication
+import Security
+
+/// Stores the macOS admin password in the Keychain protected by biometric authentication.
+/// Reading the item triggers a Touch ID / Apple Watch sheet automatically.
+struct BiometricCredentialStore {
+    private static let service = "fr.read-write.WiredServer3"
+    private static let account = "admin-privilege-password"
+
+    /// True if Touch ID or Apple Watch authentication is enrolled and available.
+    static var isAvailable: Bool {
+        LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+    }
+
+    /// True if a credential has been saved, without triggering any authentication UI.
+    static var hasStoredCredential: Bool {
+        let context = LAContext()
+        context.interactionNotAllowed = true
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecUseAuthenticationContext as String: context
+        ]
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        // errSecInteractionNotAllowed → item exists but needs biometric; errSecSuccess → readable without
+        return status == errSecSuccess || status == errSecInteractionNotAllowed
+    }
+
+    /// Save password. Access to the stored item requires biometric auth.
+    /// Invalidated automatically when enrolled fingerprints change (.biometryCurrentSet).
+    static func save(password: String) {
+        guard let data = password.data(using: .utf8) else { return }
+        var cfError: Unmanaged<CFError>?
+        guard let access = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            .biometryCurrentSet,
+            &cfError
+        ) else { return }
+
+        let attrs: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessControl as String: access
+        ]
+        SecItemDelete(attrs as CFDictionary)
+        SecItemAdd(attrs as CFDictionary, nil)
+    }
+
+    /// Retrieve the stored password. Triggers the Touch ID / Apple Watch UI.
+    /// Returns nil if the user cancels or no credential is stored.
+    static func load(reason: String) -> String? {
+        let context = LAContext()
+        context.localizedReason = reason
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecUseAuthenticationContext as String: context
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let password = String(data: data, encoding: .utf8) else { return nil }
+        return password
+    }
+
+    /// Remove any stored credential.
+    static func delete() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/Sources/WiredServerApp/BiometricCredentialStore.swift
+++ b/Sources/WiredServerApp/BiometricCredentialStore.swift
@@ -2,8 +2,8 @@ import Foundation
 import LocalAuthentication
 import Security
 
-/// Stores the macOS admin password in the Keychain protected by biometric authentication.
-/// Reading the item triggers a Touch ID / Apple Watch sheet automatically.
+/// Stores the macOS admin password in the Keychain, protected by explicit Touch ID / Apple Watch
+/// authentication at read time. Saving does not require biometric — authentication happens in load().
 struct BiometricCredentialStore {
     private static let service = "fr.read-write.WiredServer3"
     private static let account = "admin-privilege-password"
@@ -13,62 +13,65 @@ struct BiometricCredentialStore {
         LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
     }
 
-    /// True if a credential has been saved, without triggering any authentication UI.
+    /// True if a credential has been saved. Does not trigger any authentication UI.
     static var hasStoredCredential: Bool {
-        let context = LAContext()
-        context.interactionNotAllowed = true
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecUseAuthenticationContext as String: context
+            kSecAttrAccount as String: account
         ]
-        let status = SecItemCopyMatching(query as CFDictionary, nil)
-        // errSecInteractionNotAllowed → item exists but needs biometric; errSecSuccess → readable without
-        return status == errSecSuccess || status == errSecInteractionNotAllowed
+        return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
     }
 
-    /// Save password. Access to the stored item requires biometric auth.
-    /// Invalidated automatically when enrolled fingerprints change (.biometryCurrentSet).
+    /// Save password to keychain. No biometric ACL on the item — Touch ID is enforced at load time
+    /// via LAContext.evaluatePolicy, which works reliably regardless of app signing.
     static func save(password: String) {
         guard let data = password.data(using: .utf8) else { return }
-        var cfError: Unmanaged<CFError>?
-        guard let access = SecAccessControlCreateWithFlags(
-            nil,
-            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-            .biometryCurrentSet,
-            &cfError
-        ) else { return }
+
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
 
         let attrs: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecValueData as String: data,
-            kSecAttrAccessControl as String: access
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
-        SecItemDelete(attrs as CFDictionary)
         SecItemAdd(attrs as CFDictionary, nil)
     }
 
-    /// Retrieve the stored password. Triggers the Touch ID / Apple Watch UI.
-    /// Returns nil if the user cancels or no credential is stored.
+    /// Retrieve the stored password. Shows the Touch ID / Apple Watch sheet first.
+    /// Blocks the calling thread until authentication completes.
+    /// Returns nil if the user cancels, authentication fails, or no credential is stored.
     static func load(reason: String) -> String? {
         let context = LAContext()
-        context.localizedReason = reason
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecUseAuthenticationContext as String: context
-        ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess,
-              let data = result as? Data,
-              let password = String(data: data, encoding: .utf8) else { return nil }
-        return password
+        var laError: NSError?
+        guard context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &laError) else { return nil }
+
+        var result: String?
+        let semaphore = DispatchSemaphore(value: 0)
+        context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, _ in
+            defer { semaphore.signal() }
+            guard success else { return }
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccount as String: account,
+                kSecReturnData as String: true
+            ]
+            var item: AnyObject?
+            guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+                  let data = item as? Data,
+                  let password = String(data: data, encoding: .utf8) else { return }
+            result = password
+        }
+        semaphore.wait()
+        return result
     }
 
     /// Remove any stored credential.

--- a/Sources/WiredServerApp/ContentView.swift
+++ b/Sources/WiredServerApp/ContentView.swift
@@ -50,6 +50,14 @@ struct ContentView: View {
         } message: {
             Text(L("alert.binary_updated.message"))
         }
+        .alert(L("alert.privileged_update.title"), isPresented: $model.showPrivilegedUpdateAlert) {
+            Button(L("alert.privileged_update.install")) {
+                model.applyPrivilegedUpdate()
+            }
+            Button(L("alert.privileged_update.later"), role: .cancel) {}
+        } message: {
+            Text(L("alert.privileged_update.message"))
+        }
         .alert(L("alert.initial_password.title"), isPresented: $model.showInitialPasswordAlert) {
             Button(L("alert.initial_password.copy")) {
                 NSPasteboard.general.clearContents()

--- a/Sources/WiredServerApp/DashboardTab.swift
+++ b/Sources/WiredServerApp/DashboardTab.swift
@@ -138,14 +138,22 @@ struct DashboardTabView: View {
 
                     HStack(spacing: 8) {
                         Button(
-                            model.isRunning
+                            model.isServerActive
                                 ? L("general.execution.stop")
                                 : L("general.execution.start")
                         ) {
-                            if model.isRunning {
-                                model.stopServer()
+                            if model.isServerActive {
+                                if model.installMode == .launchDaemon {
+                                    model.stopDaemon()
+                                } else {
+                                    model.stopServer()
+                                }
                             } else {
-                                Task { await model.startServer() }
+                                if model.installMode == .launchDaemon {
+                                    model.startDaemon()
+                                } else {
+                                    Task { await model.startServer() }
+                                }
                             }
                         }
 
@@ -182,14 +190,14 @@ struct DashboardTabView: View {
                     LazyVGrid(columns: metricsColumns, alignment: .leading, spacing: 14) {
                         DashboardMetricCard(
                             title: L("dashboard.metric.server_status"),
-                            value: model.isRunning
+                            value: model.isServerActive
                                 ? L("general.execution.running")
                                 : L("general.execution.stopped"),
                             detail: model.statusMessage,
-                            symbolName: model.isRunning
+                            symbolName: model.isServerActive
                                 ? "play.circle.fill"
                                 : "stop.circle.fill",
-                            tint: model.isRunning ? .green : .orange
+                            tint: model.isServerActive ? .green : .orange
                         )
                         DashboardMetricCard(
                             title: L("dashboard.metric.connected_users"),

--- a/Sources/WiredServerApp/DashboardTab.swift
+++ b/Sources/WiredServerApp/DashboardTab.swift
@@ -285,7 +285,7 @@ struct DashboardTabView: View {
                             value: String(model.serverPort),
                             detail: model.portStatus.description,
                             symbolName: "network",
-                            tint: model.portStatus == .open ? .green : .orange
+                            tint: model.portStatus == .open ? .green : (model.portStatus == .error ? .orange : .red)
                         )
                     }
                 }

--- a/Sources/WiredServerApp/Localization.swift
+++ b/Sources/WiredServerApp/Localization.swift
@@ -77,17 +77,7 @@ private final class Localizer {
     }
 
     private static func candidateBundles() -> [Bundle] {
-        var bundles: [Bundle] = [Bundle.main]
-
-        if let resourceBundles = Bundle.main.urls(forResourcesWithExtension: "bundle", subdirectory: nil) {
-            for url in resourceBundles {
-                if let bundle = Bundle(url: url) {
-                    bundles.append(bundle)
-                }
-            }
-        }
-
-        return bundles
+        [.module, .main]
     }
 }
 

--- a/Sources/WiredServerApp/Localization.swift
+++ b/Sources/WiredServerApp/Localization.swift
@@ -3,6 +3,7 @@ import Foundation
 private enum AppLanguage: String {
     case en
     case fr
+    case de
 }
 
 private final class Localizer {
@@ -17,7 +18,8 @@ private final class Localizer {
         self.selectedLanguage = selected
         self.tableByLanguage = [
             .en: Localizer.loadTable(for: .en),
-            .fr: Localizer.loadTable(for: .fr)
+            .fr: Localizer.loadTable(for: .fr),
+            .de: Localizer.loadTable(for: .de)
         ]
     }
 
@@ -40,6 +42,9 @@ private final class Localizer {
                 .first?
                 .lowercased()
 
+            if languageCode == AppLanguage.de.rawValue {
+                return .de
+            }
             if languageCode == AppLanguage.fr.rawValue {
                 return .fr
             }

--- a/Sources/WiredServerApp/Localization.swift
+++ b/Sources/WiredServerApp/Localization.swift
@@ -34,25 +34,17 @@ private final class Localizer {
     }
 
     private static func resolveLanguage() -> AppLanguage {
-        let preferred = Bundle.main.preferredLocalizations + Locale.preferredLanguages
-        for value in preferred {
+        for value in Locale.preferredLanguages {
             let languageCode = value
                 .replacingOccurrences(of: "_", with: "-")
                 .split(separator: "-")
                 .first?
                 .lowercased()
 
-            if languageCode == AppLanguage.de.rawValue {
-                return .de
-            }
-            if languageCode == AppLanguage.fr.rawValue {
-                return .fr
-            }
-            if languageCode == AppLanguage.en.rawValue {
-                return .en
-            }
+            if languageCode == AppLanguage.de.rawValue { return .de }
+            if languageCode == AppLanguage.fr.rawValue { return .fr }
+            if languageCode == AppLanguage.en.rawValue { return .en }
         }
-
         return .en
     }
 

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -107,3 +107,4 @@
 "error.migration_no_source" = "Keine Quelldatenbank ausgewählt.";
 "error.migration_server_running" = "Stoppen Sie den Server, bevor Sie die Migration starten.";
 "error.migration_failed" = "Migration fehlgeschlagen";
+"error.migration_timed_out" = "Die Migration wurde nach 5 Minuten abgebrochen.";

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -1,5 +1,9 @@
 "window.title" = "Wired Server";
 "alert.error.title" = "Fehler";
+"alert.privileged_update.title" = "Server-Update verfügbar";
+"alert.privileged_update.message" = "Eine neue Version der Server-Binary ist in dieser App enthalten. Jetzt installieren? Ihr Administrator-Passwort wird benötigt.";
+"alert.privileged_update.install" = "Jetzt installieren";
+"alert.privileged_update.later" = "Später";
 "common.ok" = "OK";
 "common.choose" = "Auswählen";
 "common.select" = "Auswählen";

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -52,6 +52,7 @@
 
 "files.section" = "Dateien";
 "files.directory" = "Dateiverzeichnis";
+"files.daemon_userpath_warning" = "Dieser Pfad liegt unter /Users/ und könnte für den LaunchDaemon nicht zugänglich sein. Der Daemon startet beim Systemstart vor dem Login — Home-Verzeichnisse sind zu diesem Zeitpunkt möglicherweise noch nicht eingehängt oder entschlüsselt. Verwende stattdessen einen Pfad unter /Library/ oder /var/.";
 "files.index.section" = "Index";
 "files.index.every" = "Server-Dateien neu indizieren alle";
 "files.index.seconds" = "Sek.";

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -1,18 +1,27 @@
 "window.title" = "Wired Server";
 "alert.error.title" = "Fehler";
+"alert.binary_updated.title" = "Server aktualisiert";
+"alert.binary_updated.message" = "Eine neue Version der Server-Binary wurde installiert. Der laufende Server verwendet noch die alte Version. Möchten Sie ihn jetzt neu starten?";
+"alert.binary_updated.restart" = "Jetzt neu starten";
+"alert.binary_updated.later" = "Später";
 "alert.privileged_update.title" = "Server-Update verfügbar";
 "alert.privileged_update.message" = "Eine neue Version der Server-Binary ist in dieser App enthalten. Jetzt installieren? Ihr Administrator-Passwort wird benötigt.";
 "alert.privileged_update.install" = "Jetzt installieren";
 "alert.privileged_update.later" = "Später";
+"alert.initial_password.title" = "Erstes Admin-Passwort";
+"alert.initial_password.message" = "Der Server wurde mit einem zufälligen Admin-Passwort initialisiert. Notieren Sie es jetzt — es wird nicht erneut angezeigt.";
+"alert.initial_password.copy" = "In Zwischenablage kopieren";
 "common.ok" = "OK";
 "common.choose" = "Auswählen";
 "common.select" = "Auswählen";
 "common.save" = "Speichern";
 
 "pane.general" = "Allgemein";
+"pane.dashboard" = "Dashboard";
 "pane.network" = "Netzwerk";
 "pane.files" = "Dateien";
-"pane.advanced" = "Erweitert";
+"pane.database" = "Datenbank";
+"pane.security" = "Sicherheit";
 "pane.logs" = "Protokolle";
 
 "general.installation.section" = "Installation";
@@ -21,7 +30,9 @@
 "general.install.state.installed" = "Installiert";
 "general.install.state.uninstalled" = "Nicht installiert";
 "general.install.directory" = "Installationsverzeichnis";
-"general.install.version" = "Version";
+"general.install.version" = "Server-Version";
+"general.install.p7_version" = "P7-Protokoll";
+"general.install.wired_protocol" = "Wired-Protokoll";
 
 "general.execution.section" = "Ausführung";
 "general.execution.running" = "Server läuft";
@@ -34,9 +45,10 @@
 "network.port" = "Listening-Port";
 "network.check" = "Prüfen";
 "network.restart_required" = "Der Server muss nach einer Port-Änderung neu gestartet werden.";
-"network.port_status.unknown" = "Port-Status unbekannt";
-"network.port_status.open" = "Port ist geöffnet";
-"network.port_status.closed" = "Port ist geschlossen";
+"network.port_status.unknown" = "Externer Portcheck läuft…";
+"network.port_status.open" = "Von außen erreichbar";
+"network.port_status.closed" = "Von außen nicht erreichbar";
+"network.port_status.error" = "Portcheck fehlgeschlagen (kein Internet?)";
 
 "files.section" = "Dateien";
 "files.directory" = "Dateiverzeichnis";
@@ -44,6 +56,91 @@
 "files.index.every" = "Server-Dateien neu indizieren alle";
 "files.index.seconds" = "Sek.";
 "files.index.now" = "Neu indizieren";
+
+"dashboard.title" = "Server-Dashboard";
+"dashboard.subtitle" = "Schnellübersicht: Gesundheit, Laufzeit, Speicher und Überwachung.";
+"dashboard.section.live" = "Live-Status";
+"dashboard.section.storage" = "Speicher";
+"dashboard.section.database" = "Datenbank";
+"dashboard.section.attention" = "Aufmerksamkeit";
+"dashboard.metric.server_status" = "Server-Status";
+"dashboard.metric.connected_users" = "Verbundene Benutzer";
+"dashboard.metric.connected_users.help" = "Geschätzt aus aktiven Verbindungen.";
+"dashboard.metric.pid" = "Prozess-ID";
+"dashboard.metric.server_uptime" = "Server-Uptime";
+"dashboard.metric.cpu" = "CPU";
+"dashboard.metric.memory" = "Arbeitsspeicher";
+"dashboard.metric.files_size" = "Dateigröße";
+"dashboard.metric.database_size" = "Datenbankgröße";
+"dashboard.metric.snapshot" = "Letzter Snapshot";
+"dashboard.metric.disk_free" = "Freier Speicher";
+"dashboard.metric.disk_total" = "Gesamtspeicher";
+"dashboard.metric.host_uptime" = "Host-Uptime";
+"dashboard.metric.port" = "Listening-Port";
+"dashboard.metric.accounts" = "Konten";
+"dashboard.metric.groups" = "Gruppen";
+"dashboard.metric.events" = "Ereignisse";
+"dashboard.metric.boards" = "Boards";
+"dashboard.metric.snapshot_interval" = "Snapshot-Intervall";
+"dashboard.metric.event_retention" = "Ereignisaufbewahrung";
+"dashboard.metric.last_error" = "Letzter Fehlereintrag";
+"dashboard.snapshot.disabled" = "Deaktiviert";
+"dashboard.snapshot.pending" = "Warten auf ersten Snapshot";
+"dashboard.errors.none" = "Keine aktuellen Fehler erkannt";
+"dashboard.health.server" = "Server";
+"dashboard.health.host" = "Host";
+"dashboard.health.database" = "Datenbank";
+"dashboard.health.files" = "Dateien";
+"dashboard.health.good" = "Gut";
+"dashboard.health.warning" = "Warnung";
+"dashboard.health.critical" = "Kritisch";
+"dashboard.health.unknown" = "Unbekannt";
+"dashboard.health.server.not_installed" = "Die Server-Binary ist noch nicht installiert.";
+"dashboard.health.server.stopped" = "Der Server ist installiert, aber aktuell gestoppt.";
+"dashboard.health.server.port_closed" = "Der Prozess läuft, aber der konfigurierte Port scheint geschlossen.";
+"dashboard.health.server.admin_unsecured" = "Das Admin-Konto hat noch kein wirksames Passwort.";
+"dashboard.health.server.recent_error" = "Aktuelle Fehlereinträge erfordern Aufmerksamkeit.";
+"dashboard.health.server.ok" = "Server-Prozess und Core-Runtime sehen gesund aus.";
+"dashboard.health.host.unknown" = "Host-Festplatteninformationen sind nicht verfügbar.";
+"dashboard.health.host.disk_critical" = "Der freie Speicherplatz des Hosts ist kritisch niedrig.";
+"dashboard.health.host.disk_warning" = "Der freie Speicherplatz des Hosts wird knapp.";
+"dashboard.health.host.ok" = "Host-Speicher sieht gesund aus.";
+"dashboard.health.database.not_initialized" = "Die Datenbank wurde noch nicht initialisiert.";
+"dashboard.health.database.snapshot_pending" = "Snapshots sind aktiviert, aber noch kein Snapshot vorhanden.";
+"dashboard.health.database.ok" = "Datenbank und Aufbewahrungseinstellungen sehen gesund aus.";
+"dashboard.health.files.missing" = "Das konfigurierte Dateiverzeichnis existiert nicht.";
+"dashboard.health.files.ok" = "Das Dateistammverzeichnis ist vorhanden und lesbar.";
+
+"database.snapshot.section" = "SQLite-Snapshot";
+"database.snapshot.interval" = "Snapshot alle";
+"database.snapshot.seconds" = "Sek.";
+"database.snapshot.help" = "Erstellt eine lokale SQLite-Sicherungskopie im konfigurierten Intervall. Auf 0 setzen, um automatische Snapshots zu deaktivieren.";
+"database.snapshot.trigger_now" = "Snapshot jetzt erstellen";
+"status.snapshot_triggered" = "Datenbank-Snapshot ausgelöst.";
+"status.snapshot_not_running" = "Der Server läuft nicht.";
+"status.snapshot_failed" = "Snapshot konnte nicht ausgelöst werden — PID-Datei nicht gefunden.";
+"database.events.section" = "Ereignisaufbewahrung";
+"database.events.retention" = "Ereignisse automatisch löschen";
+"database.events.help" = "Löscht Ereignisse, die älter als das gewählte Aufbewahrungsfenster sind.";
+"database.events.retention.never" = "Nie";
+"database.events.retention.daily" = "Täglich";
+"database.events.retention.weekly" = "Wöchentlich";
+"database.events.retention.monthly" = "Monatlich";
+"database.events.retention.yearly" = "Jährlich";
+
+"touchid.section" = "Touch ID / Apple Watch";
+"touchid.status.enabled" = "Touch ID für Admin-Operationen aktiviert";
+"touchid.status.disabled" = "Touch ID nicht aktiviert";
+"touchid.description" = "Wenn aktiviert, verwenden Admin-Operationen (Start/Stopp Daemon, Installation) Touch ID statt einer Passwort-Eingabe.";
+"touchid.forget" = "Passwort vergessen";
+"touchid.reason" = "Authentifizierung zur Kontrolle des Wired-Servers";
+"touchid.dialog.title" = "Administrator-Passwort erforderlich";
+"touchid.dialog.message" = "Geben Sie Ihr macOS-Administrator-Passwort ein, um fortzufahren.";
+"touchid.dialog.placeholder" = "Passwort";
+"touchid.save.title" = "Touch ID aktivieren?";
+"touchid.save.message" = "Speichern Sie Ihr Administrator-Passwort mit Touch ID, damit zukünftige Operationen keine Passwort-Eingabe erfordern.";
+"touchid.save.enable" = "Touch ID aktivieren";
+"touchid.wrong_password" = "Authentifizierung fehlgeschlagen — falsches Passwort.";
 
 "advanced.admin.section" = "Admin-Konto";
 "advanced.admin.password.placeholder" = "Admin-Passwort";
@@ -60,7 +157,16 @@
 "advanced.security.compression" = "Bevorzugte Komprimierung";
 "advanced.security.cipher" = "Bevorzugte Verschlüsselung";
 "advanced.security.checksum" = "Bevorzugte Prüfsumme";
-"advanced.save" = "Erweiterte Einstellungen speichern";
+
+"advanced.identity.section" = "Server-Identität (TOFU)";
+"advanced.identity.fingerprint" = "Fingerabdruck";
+"advanced.identity.fingerprint.none" = "Kein Identitätsschlüssel — Server einmal starten, um ihn zu generieren";
+"advanced.identity.strict" = "Strikter Modus";
+"advanced.identity.strict.help" = "Clients müssen die Verbindung ablehnen, wenn sich der Server-Schlüssel ändert (empfohlen).";
+"advanced.identity.export" = "Öffentlichen Schlüssel exportieren";
+"advanced.identity.copied" = "Fingerabdruck kopiert!";
+
+"security.save" = "Sicherheitseinstellungen speichern";
 
 "logs.open" = "Protokolle öffnen";
 "logs.empty" = "Noch keine Protokolle";
@@ -73,9 +179,14 @@
 "status.port_saved_restart_required" = "Port gespeichert. Neustart erforderlich.";
 "status.port_saved" = "Port gespeichert";
 "status.files_settings_saved" = "Dateieinstellungen gespeichert";
+"status.files_settings_saved_reloaded" = "Dateieinstellungen gespeichert und angewendet";
+"status.database_settings_saved" = "Datenbankeinstellungen gespeichert";
+"status.database_settings_saved_reloaded" = "Datenbankeinstellungen gespeichert und angewendet";
 "status.reindex_on_next_start" = "Neu-Indizierung wird beim nächsten Start durchgeführt";
+"status.reindex_triggered" = "Neu-Indizierung ausgelöst";
 "status.server_restarted_reindex" = "Server neu gestartet, Neu-Indizierung ausgelöst";
 "status.advanced_saved" = "Erweiterte Einstellungen gespeichert";
+"status.advanced_saved_reloaded" = "Erweiterte Einstellungen gespeichert und angewendet";
 "status.admin_password_updated" = "Admin-Passwort aktualisiert";
 "status.admin_user_created" = "Admin-Benutzer erstellt";
 "status.building_binary" = "wired3-Binary wird kompiliert...";
@@ -99,6 +210,10 @@
 "error.database_not_initialized" = "Datenbank nicht initialisiert: Server zunächst einmal starten";
 "error.sql_prepare_failed" = "SQL-Vorbereitung fehlgeschlagen";
 "error.sql_execution_failed" = "SQL-Ausführung fehlgeschlagen";
+"error.migration_no_source" = "Keine Quelldatenbank ausgewählt.";
+"error.migration_server_running" = "Stoppen Sie den Server, bevor Sie die Migration starten.";
+"error.migration_failed" = "Migration fehlgeschlagen";
+"error.migration_timed_out" = "Die Migration wurde nach 5 Minuten abgebrochen.";
 
 "database.migration.section" = "Migration von Wired 2.5";
 "database.migration.source" = "Wired 2.5-Datenbank";
@@ -108,7 +223,3 @@
 "database.migration.running" = "Migration läuft…";
 "database.migration.server_warning" = "Der Server muss gestoppt sein, bevor die Migration gestartet wird.";
 "database.migration.help" = "Migriert Benutzer, Gruppen und Sperren aus einer Wired 2.5-SQLite-Datenbank. Passwörter werden unverändert übernommen (SHA1) – Benutzer müssen beim ersten Login ein neues Passwort setzen.";
-"error.migration_no_source" = "Keine Quelldatenbank ausgewählt.";
-"error.migration_server_running" = "Stoppen Sie den Server, bevor Sie die Migration starten.";
-"error.migration_failed" = "Migration fehlgeschlagen";
-"error.migration_timed_out" = "Die Migration wurde nach 5 Minuten abgebrochen.";

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -95,3 +95,15 @@
 "error.database_not_initialized" = "Datenbank nicht initialisiert: Server zunächst einmal starten";
 "error.sql_prepare_failed" = "SQL-Vorbereitung fehlgeschlagen";
 "error.sql_execution_failed" = "SQL-Ausführung fehlgeschlagen";
+
+"database.migration.section" = "Migration von Wired 2.5";
+"database.migration.source" = "Wired 2.5-Datenbank";
+"database.migration.source.none" = "Keine Datei ausgewählt";
+"database.migration.overwrite" = "Vorhandene Einträge überschreiben";
+"database.migration.run" = "Migration starten";
+"database.migration.running" = "Migration läuft…";
+"database.migration.server_warning" = "Der Server muss gestoppt sein, bevor die Migration gestartet wird.";
+"database.migration.help" = "Migriert Benutzer, Gruppen und Sperren aus einer Wired 2.5-SQLite-Datenbank. Passwörter werden unverändert übernommen (SHA1) – Benutzer müssen beim ersten Login ein neues Passwort setzen.";
+"error.migration_no_source" = "Keine Quelldatenbank ausgewählt.";
+"error.migration_server_running" = "Stoppen Sie den Server, bevor Sie die Migration starten.";
+"error.migration_failed" = "Migration fehlgeschlagen";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -199,3 +199,4 @@
 "error.migration_no_source" = "No source database selected.";
 "error.migration_server_running" = "Stop the server before running the migration.";
 "error.migration_failed" = "Migration failed";
+"error.migration_timed_out" = "Migration timed out after 5 minutes and was terminated.";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -119,6 +119,15 @@
 "database.events.retention.monthly" = "Every month";
 "database.events.retention.yearly" = "Every year";
 
+"database.migration.section" = "Migration from Wired 2.5";
+"database.migration.source" = "Wired 2.5 database";
+"database.migration.source.none" = "No file selected";
+"database.migration.overwrite" = "Overwrite existing records";
+"database.migration.run" = "Start Migration";
+"database.migration.running" = "Migration in progress…";
+"database.migration.server_warning" = "The server must be stopped before running the migration.";
+"database.migration.help" = "Migrates users, groups and bans from a Wired 2.5 SQLite database. Passwords are copied as-is (SHA1) — users must set a new password on first login.";
+
 "advanced.admin.section" = "Admin account";
 "advanced.admin.password.placeholder" = "Admin password";
 "advanced.admin.set_password" = "Set Password";
@@ -187,3 +196,6 @@
 "error.database_not_initialized" = "Database not initialized: start the server once first";
 "error.sql_prepare_failed" = "SQL prepare failed";
 "error.sql_execution_failed" = "SQL execution failed";
+"error.migration_no_source" = "No source database selected.";
+"error.migration_server_running" = "Stop the server before running the migration.";
+"error.migration_failed" = "Migration failed";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -52,6 +52,7 @@
 
 "files.section" = "Files";
 "files.directory" = "Files directory";
+"files.daemon_userpath_warning" = "This path is under /Users/ and may not be accessible to the LaunchDaemon. The daemon starts at boot before login — home directories may not be mounted or decrypted yet. Use a path under /Library/ or /var/ instead.";
 "files.index.section" = "Index";
 "files.index.every" = "Re-index server files every";
 "files.index.seconds" = "sec.";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -1,6 +1,10 @@
 "window.title" = "Wired Server";
 "alert.error.title" = "Error";
 "alert.binary_updated.title" = "Server Updated";
+"alert.privileged_update.title" = "Server Update Available";
+"alert.privileged_update.message" = "A new version of the server binary is included in this app. Install it now? Your administrator password will be required.";
+"alert.privileged_update.install" = "Install Now";
+"alert.privileged_update.later" = "Later";
 "alert.binary_updated.message" = "A new version of the server binary has been installed. The running server is still using the previous version. Would you like to restart it now?";
 "alert.binary_updated.restart" = "Restart Now";
 "alert.binary_updated.later" = "Later";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -128,6 +128,20 @@
 "database.migration.server_warning" = "The server must be stopped before running the migration.";
 "database.migration.help" = "Migrates users, groups and bans from a Wired 2.5 SQLite database. Passwords are copied as-is (SHA1) — users must set a new password on first login.";
 
+"touchid.section" = "Touch ID / Apple Watch";
+"touchid.status.enabled" = "Touch ID is enabled for admin operations";
+"touchid.status.disabled" = "Touch ID is not enabled";
+"touchid.description" = "When enabled, admin operations (start/stop daemon, install) use Touch ID instead of a password prompt.";
+"touchid.forget" = "Forget Password";
+"touchid.reason" = "Authenticate to control Wired Server";
+"touchid.dialog.title" = "Administrator Password Required";
+"touchid.dialog.message" = "Enter your macOS administrator password to continue.";
+"touchid.dialog.placeholder" = "Password";
+"touchid.save.title" = "Enable Touch ID?";
+"touchid.save.message" = "Save your administrator password with Touch ID so future operations don't require a password prompt.";
+"touchid.save.enable" = "Enable Touch ID";
+"touchid.wrong_password" = "Authentication failed — wrong password.";
+
 "advanced.admin.section" = "Admin account";
 "advanced.admin.password.placeholder" = "Admin password";
 "advanced.admin.set_password" = "Set Password";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -45,9 +45,10 @@
 "network.port" = "Listening Port";
 "network.check" = "Check";
 "network.restart_required" = "Server must be restarted after port change.";
-"network.port_status.unknown" = "Unknown port status";
-"network.port_status.open" = "Port is open";
-"network.port_status.closed" = "Port is closed";
+"network.port_status.unknown" = "Checking external reachability…";
+"network.port_status.open" = "Reachable from internet";
+"network.port_status.closed" = "Not reachable from internet";
+"network.port_status.error" = "Port check failed (no internet?)";
 
 "files.section" = "Files";
 "files.directory" = "Files directory";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -114,6 +114,10 @@
 "database.snapshot.interval" = "Snapshot every";
 "database.snapshot.seconds" = "sec.";
 "database.snapshot.help" = "Creates a local SQLite backup copy at the configured interval. Set the interval to 0 to disable automatic snapshots.";
+"database.snapshot.trigger_now" = "Create Snapshot Now";
+"status.snapshot_triggered" = "Database snapshot triggered.";
+"status.snapshot_not_running" = "Server is not running.";
+"status.snapshot_failed" = "Failed to trigger snapshot — PID file not found.";
 "database.events.section" = "Event Retention";
 "database.events.retention" = "Automatically purge events";
 "database.events.help" = "Deletes events older than the selected retention window.";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -45,9 +45,10 @@
 "network.port" = "Port en écoute";
 "network.check" = "Vérifier";
 "network.restart_required" = "Le serveur doit être redémarré après un changement de port.";
-"network.port_status.unknown" = "Statut du port inconnu";
-"network.port_status.open" = "Le port est ouvert";
-"network.port_status.closed" = "Le port est fermé";
+"network.port_status.unknown" = "Vérification de la disponibilité externe…";
+"network.port_status.open" = "Accessible depuis internet";
+"network.port_status.closed" = "Non accessible depuis internet";
+"network.port_status.error" = "Vérification échouée (pas d'internet ?)";
 
 "files.section" = "Fichiers";
 "files.directory" = "Répertoire de fichiers";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -52,6 +52,7 @@
 
 "files.section" = "Fichiers";
 "files.directory" = "Répertoire de fichiers";
+"files.daemon_userpath_warning" = "Ce chemin est sous /Users/ et pourrait ne pas être accessible au LaunchDaemon. Le daemon démarre au boot avant la connexion — les répertoires personnels peuvent ne pas être montés ou déchiffrés à ce stade. Utilise un chemin sous /Library/ ou /var/ à la place.";
 "files.index.section" = "Index";
 "files.index.every" = "Réindexer les fichiers toutes les";
 "files.index.seconds" = "sec.";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -187,3 +187,15 @@
 "error.database_not_initialized" = "Base de données non initialisée : démarre le serveur une première fois";
 "error.sql_prepare_failed" = "Erreur SQL prepare";
 "error.sql_execution_failed" = "Erreur SQL execution";
+
+"database.migration.section" = "Migration depuis Wired 2.5";
+"database.migration.source" = "Base de données Wired 2.5";
+"database.migration.source.none" = "Aucun fichier sélectionné";
+"database.migration.overwrite" = "Écraser les entrées existantes";
+"database.migration.run" = "Démarrer la migration";
+"database.migration.running" = "Migration en cours…";
+"database.migration.server_warning" = "Le serveur doit être arrêté avant de lancer la migration.";
+"database.migration.help" = "Migre les utilisateurs, groupes et bannissements depuis une base SQLite Wired 2.5. Les mots de passe sont copiés tels quels (SHA1) — les utilisateurs devront définir un nouveau mot de passe à la première connexion.";
+"error.migration_no_source" = "Aucune base source sélectionnée.";
+"error.migration_server_running" = "Arrêtez le serveur avant de lancer la migration.";
+"error.migration_failed" = "Échec de la migration";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -119,6 +119,20 @@
 "database.events.retention.monthly" = "Chaque mois";
 "database.events.retention.yearly" = "Chaque année";
 
+"touchid.section" = "Touch ID / Apple Watch";
+"touchid.status.enabled" = "Touch ID activé pour les opérations admin";
+"touchid.status.disabled" = "Touch ID non activé";
+"touchid.description" = "Lorsqu'activé, les opérations admin (démarrer/arrêter le daemon, installer) utilisent Touch ID au lieu d'un mot de passe.";
+"touchid.forget" = "Oublier le mot de passe";
+"touchid.reason" = "Authentification pour contrôler le serveur Wired";
+"touchid.dialog.title" = "Mot de passe administrateur requis";
+"touchid.dialog.message" = "Entrez votre mot de passe administrateur macOS pour continuer.";
+"touchid.dialog.placeholder" = "Mot de passe";
+"touchid.save.title" = "Activer Touch ID ?";
+"touchid.save.message" = "Enregistrez votre mot de passe administrateur avec Touch ID pour éviter de le saisir à chaque opération.";
+"touchid.save.enable" = "Activer Touch ID";
+"touchid.wrong_password" = "Authentification échouée — mot de passe incorrect.";
+
 "advanced.admin.section" = "Compte admin";
 "advanced.admin.password.placeholder" = "Mot de passe admin";
 "advanced.admin.set_password" = "Définir";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -199,3 +199,4 @@
 "error.migration_no_source" = "Aucune base source sélectionnée.";
 "error.migration_server_running" = "Arrêtez le serveur avant de lancer la migration.";
 "error.migration_failed" = "Échec de la migration";
+"error.migration_timed_out" = "La migration a expiré après 5 minutes et a été arrêtée.";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -1,6 +1,10 @@
 "window.title" = "Wired Server";
 "alert.error.title" = "Erreur";
 "alert.binary_updated.title" = "Serveur mis à jour";
+"alert.privileged_update.title" = "Mise à jour disponible";
+"alert.privileged_update.message" = "Une nouvelle version du binaire serveur est incluse dans cette application. L'installer maintenant ? Votre mot de passe administrateur sera requis.";
+"alert.privileged_update.install" = "Installer maintenant";
+"alert.privileged_update.later" = "Plus tard";
 "alert.binary_updated.message" = "Une nouvelle version du binaire serveur a été installée. Le serveur en cours d'exécution utilise encore l'ancienne version. Voulez-vous le redémarrer maintenant ?";
 "alert.binary_updated.restart" = "Redémarrer maintenant";
 "alert.binary_updated.later" = "Plus tard";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -114,6 +114,10 @@
 "database.snapshot.interval" = "Faire un snapshot toutes les";
 "database.snapshot.seconds" = "sec.";
 "database.snapshot.help" = "Crée une copie locale de sauvegarde SQLite à l'intervalle configuré. Mettre l'intervalle à 0 désactive les snapshots automatiques.";
+"database.snapshot.trigger_now" = "Créer un snapshot maintenant";
+"status.snapshot_triggered" = "Snapshot de la base de données déclenché.";
+"status.snapshot_not_running" = "Le serveur n'est pas en cours d'exécution.";
+"status.snapshot_failed" = "Échec du déclenchement du snapshot — fichier PID introuvable.";
 "database.events.section" = "Rétention des événements";
 "database.events.retention" = "Purger automatiquement les événements";
 "database.events.help" = "Supprime les événements plus anciens que la durée de rétention choisie.";

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -188,6 +188,60 @@ struct GeneralTabView: View {
                     }
                 }
 
+                Section("Install Mode") {
+                    if !model.isUsingSystemDirectory {
+                        Label("Migrate to /Library/Wired3/ first to enable LaunchDaemon mode.", systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.orange)
+                            .font(.footnote)
+                    } else {
+                        Picker("Mode", selection: Binding(
+                            get: { model.installMode },
+                            set: { newMode in
+                                Task { await model.switchInstallMode(to: newMode) }
+                            }
+                        )) {
+                            Text("LaunchAgent (current user)").tag(ServerInstallMode.launchAgent)
+                            Text("LaunchDaemon (system service)").tag(ServerInstallMode.launchDaemon)
+                        }
+                        .disabled(model.isSwitchingMode || model.isBusy)
+
+                        if model.installMode == .launchDaemon {
+                            HStack {
+                                Text("System User")
+                                    .bold()
+                                TextField("_wired", text: $model.daemonUserName)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 120)
+                                    .disabled(model.isSwitchingMode || model.launchDaemonInstalled)
+                                if model.daemonUserExists {
+                                    Image(systemName: "person.fill.checkmark")
+                                        .foregroundStyle(.green)
+                                } else {
+                                    Image(systemName: "person.fill.xmark")
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Button("Save") { model.saveDaemonSettings() }
+                                    .disabled(model.isSwitchingMode)
+                            }
+                        }
+
+                        if model.isSwitchingMode {
+                            HStack(spacing: 8) {
+                                ProgressView().controlSize(.small)
+                                Text(model.modeSwitchStatus)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } else if !model.modeSwitchStatus.isEmpty {
+                            Text(model.modeSwitchStatus)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+
                 Section("Versions") {
                     HStack(spacing: 8) {
                         Text(L("general.install.version"))
@@ -222,25 +276,39 @@ struct GeneralTabView: View {
                 }
 
                 Section(L("general.execution.section")) {
-                    HStack {
-                        StatusDot(color: model.isRunning ? .green : .red)
-                        Text(model.isRunning ? L("general.execution.running") : L("general.execution.stopped"))
+                    if model.installMode == .launchDaemon {
+                        HStack {
+                            StatusDot(color: model.daemonRunning ? .green : .red)
+                            Text(model.daemonRunning ? "Running (daemon)" : "Stopped (daemon)")
+                            Spacer()
+                            Button(model.daemonRunning ? "Stop" : "Start") {
+                                if model.daemonRunning { model.stopDaemon() }
+                                else { model.startDaemon() }
+                            }
+                            .disabled(!model.launchDaemonInstalled)
+                        }
 
-                        Spacer()
-
-                        Button(model.isRunning ? L("general.execution.stop") : L("general.execution.start")) {
-                            if model.isRunning {
-                                model.stopServer()
-                            } else {
-                                Task { await model.startServer() }
+                        Toggle("Start at Boot", isOn: Binding(
+                            get: { model.daemonStartAtBoot },
+                            set: { model.toggleDaemonStartAtBoot($0) }
+                        ))
+                        .disabled(!model.launchDaemonInstalled)
+                    } else {
+                        HStack {
+                            StatusDot(color: model.isRunning ? .green : .red)
+                            Text(model.isRunning ? L("general.execution.running") : L("general.execution.stopped"))
+                            Spacer()
+                            Button(model.isRunning ? L("general.execution.stop") : L("general.execution.start")) {
+                                if model.isRunning { model.stopServer() }
+                                else { Task { await model.startServer() } }
                             }
                         }
-                    }
 
-                    Toggle(L("general.execution.start_on_login"), isOn: Binding(
-                        get: { model.launchAtLogin },
-                        set: { model.toggleLaunchAtLogin($0) }
-                    ))
+                        Toggle(L("general.execution.start_on_login"), isOn: Binding(
+                            get: { model.launchAtLogin },
+                            set: { model.toggleLaunchAtLogin($0) }
+                        ))
+                    }
                 }
 
 //                if !model.statusMessage.isEmpty {

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -102,7 +102,7 @@ private struct ExternalVolumeWarningView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(hasFDA ? "Full Disk Access granted for wired3." : "Files directory is on an external volume.")
                     .font(.footnote).bold()
-                    .foregroundStyle(hasFDA ? .primary : .orange)
+                    .foregroundStyle(hasFDA ? Color.primary : Color.orange)
                 Text(hasFDA
                     ? "The daemon can access the external drive."
                     : "Grant Full Disk Access to wired3 so the LaunchDaemon can read and write files on this volume."

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -89,6 +89,42 @@ private struct KeyValueRow<Control: View>: View {
 }
 
 @available(macOS 12.0, *)
+private struct ExternalVolumeWarningView: View {
+    let hasFDA: Bool
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: hasFDA ? "externaldrive.fill.badge.checkmark" : "externaldrive.badge.exclamationmark")
+                .foregroundStyle(hasFDA ? .green : .orange)
+                .font(.title3)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(hasFDA ? "Full Disk Access granted for wired3." : "Files directory is on an external volume.")
+                    .font(.footnote).bold()
+                    .foregroundStyle(hasFDA ? .primary : .orange)
+                Text(hasFDA
+                    ? "The daemon can access the external drive."
+                    : "Grant Full Disk Access to wired3 so the LaunchDaemon can read and write files on this volume."
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if !hasFDA {
+                Button("Open Settings…") { onOpenSettings() }
+                    .font(.footnote)
+            }
+        }
+        .padding(8)
+        .background((hasFDA ? Color.green : Color.orange).opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+@available(macOS 12.0, *)
 private struct StatusDot: View {
     let color: Color
 
@@ -230,6 +266,12 @@ struct GeneralTabView: View {
                                 Spacer()
                                 Button("Save") { model.saveDaemonSettings() }
                                     .disabled(model.isSwitchingMode)
+                            }
+                        }
+
+                        if model.installMode == .launchDaemon && model.filesDirectoryIsOnExternalVolume {
+                            ExternalVolumeWarningView(hasFDA: model.wired3HasFullDiskAccess) {
+                                model.openFullDiskAccessSettings()
                             }
                         }
 
@@ -417,6 +459,12 @@ struct FilesTabView: View {
 
                         Button(L("common.choose")) {
                             model.chooseFilesDirectory()
+                        }
+                    }
+
+                    if model.installMode == .launchDaemon && model.filesDirectoryIsOnExternalVolume {
+                        ExternalVolumeWarningView(hasFDA: model.wired3HasFullDiskAccess) {
+                            model.openFullDiskAccessSettings()
                         }
                     }
                 }

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -493,6 +493,11 @@ struct FilesTabView: View {
                             model.openFullDiskAccessSettings()
                         }
                     }
+                    if model.installMode == .launchDaemon && model.filesDirectory.hasPrefix("/Users/") {
+                        Label(L("files.daemon_userpath_warning"), systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .font(.footnote)
+                    }
                 }
 
                 Section(L("files.index.section")) {

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -241,32 +241,30 @@ struct GeneralTabView: View {
                         }
                         .disabled(model.isSwitchingMode || model.isBusy)
 
-                        if model.installMode == .launchDaemon {
-                            HStack(spacing: 8) {
-                                Text("User")
-                                    .bold()
-                                    .frame(width: 40, alignment: .leading)
-                                TextField("_wired", text: $model.daemonUserName)
-                                    .textFieldStyle(.roundedBorder)
-                                    .frame(width: 100)
-                                    .disabled(model.isSwitchingMode || model.launchDaemonInstalled)
-                                Image(systemName: model.daemonUserExists ? "person.fill.checkmark" : "person.fill.xmark")
-                                    .foregroundStyle(model.daemonUserExists ? .green : .secondary)
+                        HStack(spacing: 8) {
+                            Text("Daemon User")
+                                .bold()
+                                .frame(width: 90, alignment: .leading)
+                            TextField("_wired", text: $model.daemonUserName)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 100)
+                                .disabled(model.isSwitchingMode)
+                            Image(systemName: model.daemonUserExists ? "person.fill.checkmark" : "person.fill.xmark")
+                                .foregroundStyle(model.daemonUserExists ? .green : .secondary)
 
-                                Text("Group")
-                                    .bold()
-                                    .frame(width: 44, alignment: .leading)
-                                TextField("staff", text: $model.daemonGroupName)
-                                    .textFieldStyle(.roundedBorder)
-                                    .frame(width: 100)
-                                    .disabled(model.isSwitchingMode || model.launchDaemonInstalled)
-                                Image(systemName: model.daemonGroupExists ? "checkmark.circle.fill" : "xmark.circle")
-                                    .foregroundStyle(model.daemonGroupExists ? .green : .secondary)
+                            Text("Group")
+                                .bold()
+                                .frame(width: 44, alignment: .leading)
+                            TextField("staff", text: $model.daemonGroupName)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 100)
+                                .disabled(model.isSwitchingMode)
+                            Image(systemName: model.daemonGroupExists ? "checkmark.circle.fill" : "xmark.circle")
+                                .foregroundStyle(model.daemonGroupExists ? .green : .secondary)
 
-                                Spacer()
-                                Button("Save") { model.saveDaemonSettings() }
-                                    .disabled(model.isSwitchingMode)
-                            }
+                            Spacer()
+                            Button("Save") { model.saveDaemonSettings() }
+                                .disabled(model.isSwitchingMode)
                         }
 
                         if model.installMode == .launchDaemon && model.filesDirectoryIsOnExternalVolume {

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -153,6 +153,41 @@ struct GeneralTabView: View {
                     }
                 }
 
+                Section("System Data Directory") {
+                    if model.isUsingSystemDirectory {
+                        HStack(spacing: 8) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Text("/Library/Wired3/ (system-wide)")
+                                .textSelection(.enabled)
+                        }
+                    } else if model.systemMigrationAvailable {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Migrate server data to /Library/Wired3/ to enable LaunchDaemon support. The original data will be preserved as a backup.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+
+                            HStack(spacing: 10) {
+                                Button("Migrate to /Library/Wired3/") {
+                                    Task { await model.migrateToSystemDirectory() }
+                                }
+                                .disabled(model.isSystemMigrating || model.isBusy)
+
+                                if model.isSystemMigrating {
+                                    ProgressView().controlSize(.small)
+                                }
+                            }
+
+                            if !model.systemMigrationStatus.isEmpty {
+                                Text(model.systemMigrationStatus)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                                    .textSelection(.enabled)
+                            }
+                        }
+                    }
+                }
+
                 Section("Versions") {
                     HStack(spacing: 8) {
                         Text(L("general.install.version"))

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -663,6 +663,7 @@ struct DatabaseTabView: View {
 struct SecurityTabView: View {
     @EnvironmentObject private var model: WiredServerViewModel
     @State private var fingerprintCopied = false
+    @State private var passwordText: String = ""
 
     var body: some View {
         SettingsScrollPane {
@@ -695,17 +696,20 @@ struct SecurityTabView: View {
                     }
 
                     HStack(spacing: 8) {
-                        SecureField(L("advanced.admin.password.placeholder"), text: $model.newAdminPassword)
+                        SecureField(L("advanced.admin.password.placeholder"), text: $passwordText)
                             .frame(width: 260)
+                            .onSubmit { applyPassword() }
 
                         Spacer()
 
                         Button(L("advanced.admin.set_password")) {
-                            model.setAdminPassword()
+                            applyPassword()
                         }
 
                         Button(L("advanced.admin.create_user")) {
+                            model.newAdminPassword = passwordText
                             model.createAdminUser()
+                            passwordText = ""
                         }
                     }
                 }
@@ -789,6 +793,12 @@ struct SecurityTabView: View {
             .formStyle(.grouped)
         }
         .onAppear { model.refreshIdentityFingerprint() }
+    }
+
+    private func applyPassword() {
+        model.newAdminPassword = passwordText
+        model.setAdminPassword()
+        passwordText = ""
     }
 }
 

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -386,6 +386,7 @@ struct GeneralTabView: View {
 @available(macOS 12.0, *)
 struct NetworkTabView: View {
     @EnvironmentObject private var model: WiredServerViewModel
+    @State private var portText: String = ""
 
     var body: some View {
         SettingsScrollPane {
@@ -397,12 +398,16 @@ struct NetworkTabView: View {
 
                         Spacer()
 
-                        TextField("", value: $model.serverPort, formatter: Formatters.integer)
+                        TextField("4871", text: $portText)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: UIConstants.numberFieldWidth)
+                            .onChange(of: portText) { newValue in
+                                portText = String(newValue.filter { $0.isNumber }.prefix(5))
+                            }
+                            .onSubmit { savePort() }
 
                         Button(L("common.save")) {
-                            model.saveNetworkSettings()
+                            savePort()
                         }
                     }
 
@@ -427,6 +432,15 @@ struct NetworkTabView: View {
             }
             .formStyle(.grouped)
         }
+        .onAppear { portText = String(model.serverPort) }
+        .onChange(of: model.serverPort) { portText = String($0) }
+    }
+
+    private func savePort() {
+        let parsed = Int(portText) ?? model.serverPort
+        model.serverPort = max(1, min(parsed, 65_535))
+        portText = String(model.serverPort)
+        model.saveNetworkSettings()
     }
 
     private func color(for status: PortStatus) -> Color {

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -206,20 +206,27 @@ struct GeneralTabView: View {
                         .disabled(model.isSwitchingMode || model.isBusy)
 
                         if model.installMode == .launchDaemon {
-                            HStack {
-                                Text("System User")
+                            HStack(spacing: 8) {
+                                Text("User")
                                     .bold()
+                                    .frame(width: 40, alignment: .leading)
                                 TextField("_wired", text: $model.daemonUserName)
                                     .textFieldStyle(.roundedBorder)
-                                    .frame(width: 120)
+                                    .frame(width: 100)
                                     .disabled(model.isSwitchingMode || model.launchDaemonInstalled)
-                                if model.daemonUserExists {
-                                    Image(systemName: "person.fill.checkmark")
-                                        .foregroundStyle(.green)
-                                } else {
-                                    Image(systemName: "person.fill.xmark")
-                                        .foregroundStyle(.secondary)
-                                }
+                                Image(systemName: model.daemonUserExists ? "person.fill.checkmark" : "person.fill.xmark")
+                                    .foregroundStyle(model.daemonUserExists ? .green : .secondary)
+
+                                Text("Group")
+                                    .bold()
+                                    .frame(width: 44, alignment: .leading)
+                                TextField("staff", text: $model.daemonGroupName)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 100)
+                                    .disabled(model.isSwitchingMode || model.launchDaemonInstalled)
+                                Image(systemName: model.daemonGroupExists ? "checkmark.circle.fill" : "xmark.circle")
+                                    .foregroundStyle(model.daemonGroupExists ? .green : .secondary)
+
                                 Spacer()
                                 Button("Save") { model.saveDaemonSettings() }
                                     .disabled(model.isSwitchingMode)

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -390,47 +390,46 @@ struct NetworkTabView: View {
 
     var body: some View {
         SettingsScrollPane {
-            Form {
-                Section(L("network.section")) {
-                    HStack {
-                        Text(L("network.port"))
-                            .bold()
+            SettingsSection(title: L("network.section")) {
+                HStack(spacing: 8) {
+                    Text(L("network.port"))
+                        .bold()
 
-                        Spacer()
-
-                        TextField("4871", text: $portText)
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: UIConstants.numberFieldWidth)
-                            .onChange(of: portText) { newValue in
-                                portText = String(newValue.filter { $0.isNumber }.prefix(5))
-                            }
-                            .onSubmit { savePort() }
-
-                        Button(L("common.save")) {
-                            savePort()
+                    TextField("", text: $portText)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 70)
+                        .multilineTextAlignment(.center)
+                        .onChange(of: portText) { newValue in
+                            portText = String(newValue.filter { $0.isNumber }.prefix(5))
                         }
-                    }
+                        .onSubmit { savePort() }
 
-                    HStack(spacing: 8) {
-                        StatusDot(color: color(for: model.portStatus))
-                        Text(model.portStatus.description)
-
-                        Spacer()
-
-                        Button(L("network.check")) {
-                            model.checkPort()
-                        }
-                    }
-
-                }
-
-                Section {
-                    Text(L("network.restart_required"))
-                        .font(.footnote)
+                    Text("Default: 4871")
                         .foregroundStyle(.secondary)
+
+                    Spacer(minLength: 8)
+
+                    Button(L("common.save")) {
+                        savePort()
+                    }
                 }
+
+                Divider()
+
+                HStack(spacing: 8) {
+                    StatusDot(color: color(for: model.portStatus))
+                    Text(model.portStatus.description)
+                        .frame(minWidth: 200, alignment: .leading)
+                    Spacer()
+                    Button(L("network.check")) {
+                        model.checkPort()
+                    }
+                }
+
+                Text(L("network.restart_required"))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
-            .formStyle(.grouped)
         }
         .onAppear { portText = String(model.serverPort) }
         .onChange(of: model.serverPort) { portText = String($0) }
@@ -451,6 +450,8 @@ struct NetworkTabView: View {
             return .green
         case .closed:
             return .red
+        case .error:
+            return .orange
         }
     }
 }

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -697,10 +697,8 @@ struct SecurityTabView: View {
 
                     HStack(spacing: 8) {
                         SecureField(L("advanced.admin.password.placeholder"), text: $passwordText)
-                            .frame(width: 260)
+                            .textFieldStyle(.roundedBorder)
                             .onSubmit { applyPassword() }
-
-                        Spacer()
 
                         Button(L("advanced.admin.set_password")) {
                             applyPassword()

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -644,6 +644,27 @@ struct SecurityTabView: View {
     var body: some View {
         SettingsScrollPane {
             Form {
+                if BiometricCredentialStore.isAvailable {
+                    Section(L("touchid.section")) {
+                        HStack {
+                            StatusDot(color: model.hasTouchIDCredential ? .green : .gray)
+                            Text(model.hasTouchIDCredential
+                                 ? L("touchid.status.enabled")
+                                 : L("touchid.status.disabled"))
+                            Spacer()
+                            if model.hasTouchIDCredential {
+                                Button(L("touchid.forget")) {
+                                    model.forgetTouchIDCredential()
+                                }
+                                .foregroundStyle(.red)
+                            }
+                        }
+                        Text(L("touchid.description"))
+                            .foregroundStyle(.secondary)
+                            .font(.footnote)
+                    }
+                }
+
                 Section(L("advanced.admin.section")) {
                     HStack {
                         StatusDot(color: model.hasAdminPassword ? .green : .red)

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -90,6 +90,7 @@ private struct KeyValueRow<Control: View>: View {
 
 @available(macOS 12.0, *)
 private struct ExternalVolumeWarningView: View {
+    @EnvironmentObject private var model: WiredServerViewModel
     let hasFDA: Bool
     let onOpenSettings: () -> Void
 
@@ -105,7 +106,7 @@ private struct ExternalVolumeWarningView: View {
                     .foregroundStyle(hasFDA ? Color.primary : Color.orange)
                 Text(hasFDA
                     ? "The daemon can access the external drive."
-                    : "Grant Full Disk Access to wired3 so the LaunchDaemon can read and write files on this volume."
+                    : "Grant Full Disk Access to wired3 in System Settings, then restart the daemon."
                 )
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -116,6 +117,15 @@ private struct ExternalVolumeWarningView: View {
             if !hasFDA {
                 Button("Open Settings…") { onOpenSettings() }
                     .font(.footnote)
+
+                Button("Restart Daemon") {
+                    model.stopDaemon()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        model.startDaemon()
+                    }
+                }
+                .font(.footnote)
+                .disabled(!model.isDaemonRunning)
             }
         }
         .padding(8)

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -101,11 +101,11 @@ private struct ExternalVolumeWarningView: View {
                 .font(.title3)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(hasFDA ? "Daemon can access the external volume." : "Files directory is on an external volume.")
+                Text(hasFDA ? "Daemon access check passed." : "Files directory is on an external volume.")
                     .font(.footnote).bold()
                     .foregroundStyle(hasFDA ? Color.primary : Color.orange)
                 Text(hasFDA
-                    ? "The daemon user has read access to the files directory."
+                    ? "The daemon user appears to have read access. After a binary update, re-signing may revoke this — verify by checking the server log for \"0 files, 0 dirs\"."
                     : "Ensure the files directory is readable by the daemon user, then click Re-check."
                 )
                 .font(.footnote)

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -534,6 +534,14 @@ struct DatabaseTabView: View {
                     Text(L("database.snapshot.help"))
                         .font(.footnote)
                         .foregroundStyle(.secondary)
+
+                    HStack {
+                        Spacer(minLength: 0)
+                        Button(L("database.snapshot.trigger_now")) {
+                            model.triggerSnapshotNow()
+                        }
+                        .disabled(!model.hasPIDFile)
+                    }
                 }
 
                 Section(L("database.events.section")) {

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -381,6 +381,86 @@ struct DatabaseTabView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
+
+                Section(L("database.migration.section")) {
+                    // Warning when server is running
+                    if model.isRunning {
+                        HStack(spacing: 6) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text(L("database.migration.server_warning"))
+                                .foregroundStyle(.orange)
+                        }
+                    }
+
+                    // File picker row
+                    HStack(spacing: 8) {
+                        Text(L("database.migration.source"))
+                            .bold()
+
+                        if model.migrationSourcePath.isEmpty {
+                            Text(L("database.migration.source.none"))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        } else {
+                            Text(model.migrationSourcePath)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .textSelection(.enabled)
+                        }
+
+                        Spacer(minLength: 0)
+
+                        Button(L("common.choose")) {
+                            model.chooseMigrationSource()
+                        }
+                        .disabled(model.isMigrating)
+                    }
+
+                    // Overwrite toggle
+                    Toggle(L("database.migration.overwrite"), isOn: $model.migrationOverwrite)
+                        .disabled(model.isMigrating)
+
+                    // Start button
+                    HStack {
+                        Spacer()
+                        if model.isMigrating {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                                .frame(width: 20, height: 20)
+                            Text(L("database.migration.running"))
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Button(L("database.migration.run")) {
+                                Task { await model.runMigration() }
+                            }
+                            .disabled(model.migrationSourcePath.isEmpty || model.isRunning)
+                        }
+                    }
+
+                    // Output area (shown once migration has run)
+                    if !model.migrationOutput.isEmpty {
+                        ScrollView {
+                            Text(model.migrationOutput)
+                                .font(.system(.caption, design: .monospaced))
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .topLeading)
+                                .padding(8)
+                        }
+                        .frame(minHeight: 180, maxHeight: 300)
+                        .background(Color(NSColor.textBackgroundColor))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                        )
+                    }
+
+                    Text(L("database.migration.help"))
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
             }
             .formStyle(.grouped)
         }

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -101,12 +101,12 @@ private struct ExternalVolumeWarningView: View {
                 .font(.title3)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(hasFDA ? "Full Disk Access granted for wired3." : "Files directory is on an external volume.")
+                Text(hasFDA ? "Daemon can access the external volume." : "Files directory is on an external volume.")
                     .font(.footnote).bold()
                     .foregroundStyle(hasFDA ? Color.primary : Color.orange)
                 Text(hasFDA
-                    ? "The daemon can access the external drive."
-                    : "Grant Full Disk Access to wired3 in System Settings, then restart the daemon."
+                    ? "The daemon user has read access to the files directory."
+                    : "Ensure the files directory is readable by the daemon user, then click Re-check."
                 )
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -115,8 +115,10 @@ private struct ExternalVolumeWarningView: View {
             Spacer()
 
             if !hasFDA {
-                Button("Open Settings…") { onOpenSettings() }
-                    .font(.footnote)
+                Button("Re-check") {
+                    model.refreshFDAStatusPrivileged()
+                }
+                .font(.footnote)
 
                 Button("Restart Daemon") {
                     model.stopDaemon()
@@ -276,6 +278,7 @@ struct GeneralTabView: View {
                             Button("Save") { model.saveDaemonSettings() }
                                 .disabled(model.isSwitchingMode)
                         }
+                        .labelsHidden()
 
                         if model.installMode == .launchDaemon && model.filesDirectoryIsOnExternalVolume {
                             ExternalVolumeWarningView(hasFDA: model.wired3HasFullDiskAccess) {

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -249,8 +249,8 @@ struct GeneralTabView: View {
                                 .textFieldStyle(.roundedBorder)
                                 .frame(width: 100)
                                 .disabled(model.isSwitchingMode)
-                            Image(systemName: model.daemonUserExists ? "person.fill.checkmark" : "person.fill.xmark")
-                                .foregroundStyle(model.daemonUserExists ? .green : .secondary)
+                            Image(systemName: model.isDaemonUserExists ? "person.fill.checkmark" : "person.fill.xmark")
+                                .foregroundStyle(model.isDaemonUserExists ? .green : .secondary)
 
                             Text("Group")
                                 .bold()
@@ -259,8 +259,8 @@ struct GeneralTabView: View {
                                 .textFieldStyle(.roundedBorder)
                                 .frame(width: 100)
                                 .disabled(model.isSwitchingMode)
-                            Image(systemName: model.daemonGroupExists ? "checkmark.circle.fill" : "xmark.circle")
-                                .foregroundStyle(model.daemonGroupExists ? .green : .secondary)
+                            Image(systemName: model.isDaemonGroupExists ? "checkmark.circle.fill" : "xmark.circle")
+                                .foregroundStyle(model.isDaemonGroupExists ? .green : .secondary)
 
                             Spacer()
                             Button("Save") { model.saveDaemonSettings() }
@@ -325,11 +325,11 @@ struct GeneralTabView: View {
                 Section(L("general.execution.section")) {
                     if model.installMode == .launchDaemon {
                         HStack {
-                            StatusDot(color: model.daemonRunning ? .green : .red)
-                            Text(model.daemonRunning ? "Running (daemon)" : "Stopped (daemon)")
+                            StatusDot(color: model.isDaemonRunning ? .green : .red)
+                            Text(model.isDaemonRunning ? "Running (daemon)" : "Stopped (daemon)")
                             Spacer()
-                            Button(model.daemonRunning ? "Stop" : "Start") {
-                                if model.daemonRunning { model.stopDaemon() }
+                            Button(model.isDaemonRunning ? "Stop" : "Start") {
+                                if model.isDaemonRunning { model.stopDaemon() }
                                 else { model.startDaemon() }
                             }
                             .disabled(!model.launchDaemonInstalled)

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -255,7 +255,7 @@ struct GeneralTabView: View {
                             Text("Group")
                                 .bold()
                                 .frame(width: 44, alignment: .leading)
-                            TextField("staff", text: $model.daemonGroupName)
+                            TextField("daemon", text: $model.daemonGroupName)
                                 .textFieldStyle(.roundedBorder)
                                 .frame(width: 100)
                                 .disabled(model.isSwitchingMode)

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -443,15 +443,28 @@ final class WiredServerViewModel: ObservableObject {
         return path.hasPrefix("/Volumes/")
     }
 
-    // Checks FDA for the wired3 binary via the TCC database (readable only with FDA granted)
+    // Checks whether wired3 has FDA by asking launchd to probe the TCC database
+    // on its behalf. The app itself may not have FDA, so we probe via sqlite3 run
+    // as the daemon user, falling back to a direct TCC.db read if possible.
     var wired3HasFullDiskAccess: Bool {
         let tcc = "/Library/Application Support/com.apple.TCC/TCC.db"
-        guard FileManager.default.isReadableFile(atPath: tcc) else { return false }
-        // TCC.db is readable — query for the wired3 binary
         let binaryPath = installedBinaryPath
-        let output = runCommand("/usr/bin/sqlite3", [tcc,
-            "SELECT allowed FROM access WHERE service='kTCCServiceSystemPolicyAllFiles' AND client='\(binaryPath)' LIMIT 1"])
-        return output.trimmingCharacters(in: .whitespacesAndNewlines) == "1"
+        let query = "SELECT allowed FROM access WHERE service='kTCCServiceSystemPolicyAllFiles' AND client='\(binaryPath)' LIMIT 1"
+
+        // Try reading TCC.db directly (works if this app has FDA).
+        if FileManager.default.isReadableFile(atPath: tcc) {
+            let output = runCommand("/usr/bin/sqlite3", [tcc, query])
+            if output.trimmingCharacters(in: .whitespacesAndNewlines) == "1" { return true }
+        }
+
+        // Fallback: run sqlite3 as the daemon user so it can read the system TCC.db.
+        let result = runProcess("/usr/bin/sudo", ["-u", daemonUserName, "-n",
+            "/usr/bin/sqlite3", tcc, query])
+        if result.output.trimmingCharacters(in: .whitespacesAndNewlines) == "1" { return true }
+
+        // Last resort: try to open a file in a protected location as a live FDA probe.
+        // If the daemon can read /Library/Application Support/com.apple.TCC/ the grant is active.
+        return FileManager.default.isReadableFile(atPath: tcc)
     }
 
     func openFullDiskAccessSettings() {

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -862,6 +862,8 @@ final class WiredServerViewModel: ObservableObject {
     }
 
     func startServer() async {
+        // LaunchDaemon is managed by launchd — never start a local process in that mode.
+        guard installMode == .launchAgent else { return }
         refreshRunningStatus()
         guard !isRunning else { return }
 

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -117,6 +117,9 @@ final class WiredServerViewModel: ObservableObject {
     @Published var daemonStartAtBoot: Bool = false
     @Published var isSwitchingMode: Bool = false
     @Published var modeSwitchStatus: String = ""
+    @Published var isDaemonRunning: Bool = false
+    @Published var isDaemonUserExists: Bool = false
+    @Published var isDaemonGroupExists: Bool = false
 
     private var lastDashboardLightRefresh = Date.distantPast
     private var lastDashboardHeavyRefresh = Date.distantPast
@@ -403,12 +406,10 @@ final class WiredServerViewModel: ObservableObject {
 
     // MARK: - LaunchDaemon / LaunchAgent Mode Switching
 
-    var daemonUserExists: Bool {
-        runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
-    }
-
-    var daemonGroupExists: Bool {
-        runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
+    func refreshDaemonStatus() {
+        isDaemonRunning = runProcess("/bin/launchctl", ["print", "system/\(launchAgentLabel)"]).status == 0
+        isDaemonUserExists = runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
+        isDaemonGroupExists = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
     }
 
     // MARK: - External Volume / FDA
@@ -439,11 +440,6 @@ final class WiredServerViewModel: ObservableObject {
         fileManager.fileExists(atPath: launchDaemonPlistPath)
     }
 
-    var daemonRunning: Bool {
-        let result = runProcess("/bin/launchctl", ["print", "system/\(launchAgentLabel)"])
-        return result.status == 0
-    }
-
     func saveDaemonSettings() {
         userDefaults.set(daemonUserName, forKey: daemonUserNameKey)
         userDefaults.set(daemonGroupName, forKey: daemonGroupNameKey)
@@ -458,6 +454,7 @@ final class WiredServerViewModel: ObservableObject {
         }
         isSwitchingMode = true
         modeSwitchStatus = "Preparing..."
+        refreshDaemonStatus()
 
         do {
             if isRunning {
@@ -473,7 +470,7 @@ final class WiredServerViewModel: ObservableObject {
                     launchAtLogin = false
                 }
                 modeSwitchStatus = "Activating LaunchDaemon (one admin dialog)..."
-                try activateLaunchDaemon(name: daemonUserName, createUser: !daemonUserExists)
+                try activateLaunchDaemon(name: daemonUserName, createUser: !isDaemonUserExists)
 
             case .launchAgent:
                 modeSwitchStatus = "Deactivating LaunchDaemon (one admin dialog)..."
@@ -504,18 +501,26 @@ final class WiredServerViewModel: ObservableObject {
     }
 
     func startDaemon() {
-        _ = runProcess("/bin/launchctl",
-            ["bootstrap", "system", launchDaemonPlistPath])
+        do {
+            try runPrivileged("launchctl bootstrap system '\(launchDaemonPlistPath)'",
+                              error: .launchDaemonInstallFailed("start"))
+        } catch {
+            publishError("Failed to start daemon: \(error.localizedDescription)")
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            self?.refreshAll()
+            self?.refreshDaemonStatus()
         }
     }
 
     func stopDaemon() {
-        _ = runProcess("/bin/launchctl",
-            ["bootout", "system/\(launchAgentLabel)"])
+        do {
+            try runPrivileged("launchctl bootout system/'\(launchAgentLabel)'",
+                              error: .launchDaemonRemoveFailed("stop"))
+        } catch {
+            publishError("Failed to stop daemon: \(error.localizedDescription)")
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            self?.refreshAll()
+            self?.refreshDaemonStatus()
         }
     }
 
@@ -523,7 +528,7 @@ final class WiredServerViewModel: ObservableObject {
     private func activateLaunchDaemon(name: String, createUser: Bool) throws {
         let tempURL = try writeDaemonPlistToTemp()
         let group = daemonGroupName
-        let createGroup = !daemonGroupExists
+        let createGroup = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status != 0
 
         var cmds: [String] = []
 
@@ -1112,6 +1117,9 @@ final class WiredServerViewModel: ObservableObject {
 
     private func pollState() {
         refreshRunningStatus()
+        if installMode == .launchDaemon {
+            refreshDaemonStatus()
+        }
         refreshLogText()
         refreshDashboard()
     }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -1533,6 +1533,17 @@ final class WiredServerViewModel: ObservableObject {
 
     @discardableResult
     private func synchronizeInstalledBinaryIfNeeded(allowInstallIfMissing: Bool = true) throws -> Bool {
+        // Never replace the binary while the daemon is running — launchd detects the
+        // replacement and kills the process. Check here as a last-resort guard regardless
+        // of which call path reaches this function.
+        if installMode == .launchDaemon {
+            let daemonLive = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).status == 0
+            if daemonLive {
+                appendRuntimeLog("binary-update: daemon is running, skipping binary replacement")
+                return false
+            }
+        }
+
         guard let bundledBinary = bundledServerBinaryPath() else {
             appendRuntimeLog("binary-update: no bundled wired3 found, skipping synchronization")
             return false

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -120,6 +120,7 @@ final class WiredServerViewModel: ObservableObject {
     @Published var isDaemonRunning: Bool = false
     @Published var isDaemonUserExists: Bool = false
     @Published var isDaemonGroupExists: Bool = false
+    @Published var wired3HasFullDiskAccess: Bool = false
 
     var isServerActive: Bool {
         installMode == .launchDaemon ? isDaemonRunning : isRunning
@@ -434,6 +435,7 @@ final class WiredServerViewModel: ObservableObject {
         isDaemonRunning = runProcess("/usr/bin/pgrep", ["-f", "/Library/Wired3/bin/wired3"]).status == 0
         isDaemonUserExists = runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
         isDaemonGroupExists = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
+        checkFDAFast()
     }
 
     // MARK: - External Volume / FDA
@@ -443,28 +445,55 @@ final class WiredServerViewModel: ObservableObject {
         return path.hasPrefix("/Volumes/")
     }
 
-    // Checks whether wired3 has FDA by asking launchd to probe the TCC database
-    // on its behalf. The app itself may not have FDA, so we probe via sqlite3 run
-    // as the daemon user, falling back to a direct TCC.db read if possible.
-    var wired3HasFullDiskAccess: Bool {
-        let tcc = "/Library/Application Support/com.apple.TCC/TCC.db"
-        let binaryPath = installedBinaryPath
-        let query = "SELECT allowed FROM access WHERE service='kTCCServiceSystemPolicyAllFiles' AND client='\(binaryPath)' LIMIT 1"
-
-        // Try reading TCC.db directly (works if this app has FDA).
-        if FileManager.default.isReadableFile(atPath: tcc) {
-            let output = runCommand("/usr/bin/sqlite3", [tcc, query])
-            if output.trimmingCharacters(in: .whitespacesAndNewlines) == "1" { return true }
+    // Non-privileged fast check: can our app process list the files directory?
+    // External volumes under /Volumes/ don't need FDA — they're accessible by all processes.
+    // This avoids the TCC.db read (which SIP protects even from root on macOS 14+).
+    private func checkFDAFast() {
+        guard filesDirectoryIsOnExternalVolume, !wired3HasFullDiskAccess else { return }
+        let path = currentServerRootPath()
+        var isDir: ObjCBool = false
+        if FileManager.default.fileExists(atPath: path, isDirectory: &isDir), isDir.boolValue {
+            wired3HasFullDiskAccess = true
         }
+    }
 
-        // Fallback: run sqlite3 as the daemon user so it can read the system TCC.db.
-        let result = runProcess("/usr/bin/sudo", ["-u", daemonUserName, "-n",
-            "/usr/bin/sqlite3", tcc, query])
-        if result.output.trimmingCharacters(in: .whitespacesAndNewlines) == "1" { return true }
+    // Writes a shell script that tests whether the daemon user can list the files directory.
+    // TCC.db is protected by SIP on macOS 14+ and cannot be read even by root without special
+    // entitlements. A functional access test is the only reliable approach.
+    private func writeFDACheckScript(filesDir: String, daemonUser: String, outputFile: String, to scriptPath: String) {
+        let sh = """
+        #!/bin/sh
+        OUT='\(outputFile)'
+        FILES='\(filesDir)'
+        DUSER='\(daemonUser)'
 
-        // Last resort: try to open a file in a protected location as a live FDA probe.
-        // If the daemon can read /Library/Application Support/com.apple.TCC/ the grant is active.
-        return FileManager.default.isReadableFile(atPath: tcc)
+        # Test if the daemon user can read the files directory (Unix permissions check).
+        # External volumes don't require FDA — this tests actual access, not TCC grants.
+        if sudo -u "$DUSER" /bin/ls "$FILES" >/dev/null 2>&1; then
+            echo 1 > "$OUT"
+        else
+            echo 0 > "$OUT"
+        fi
+        """
+        try? sh.write(toFile: scriptPath, atomically: true, encoding: .utf8)
+    }
+
+    // Privileged access check — runs as root (AppleScript admin auth) to test _wired user access.
+    func refreshFDAStatusPrivileged() {
+        guard filesDirectoryIsOnExternalVolume else {
+            wired3HasFullDiskAccess = false
+            return
+        }
+        let filesDir = currentServerRootPath()
+        let ts = Int(Date().timeIntervalSince1970)
+        let fdaTmpFile = "/tmp/.wired3fda_\(ts)"
+        let fdaShFile  = "/tmp/.wired3sh_\(ts).sh"
+        writeFDACheckScript(filesDir: filesDir, daemonUser: daemonUserName, outputFile: fdaTmpFile, to: fdaShFile)
+        try? runPrivileged("sh '\(fdaShFile)'; true", error: .launchDaemonInstallFailed(""))
+        let raw = (try? String(contentsOfFile: fdaTmpFile, encoding: .utf8)) ?? "0"
+        try? FileManager.default.removeItem(atPath: fdaTmpFile)
+        try? FileManager.default.removeItem(atPath: fdaShFile)
+        wired3HasFullDiskAccess = raw.trimmingCharacters(in: .whitespacesAndNewlines) == "1"
     }
 
     func openFullDiskAccessSettings() {
@@ -557,9 +586,32 @@ final class WiredServerViewModel: ObservableObject {
 
         // bootstrap registers the service (no-op if already registered).
         // kickstart starts it regardless of RunAtLoad value.
-        let cmd = "launchctl bootstrap system '\(launchDaemonPlistPath)' 2>/dev/null; launchctl kickstart system/\(launchAgentLabel) 2>/dev/null; true"
+        // If files dir is on an external volume, embed a TCC/FDA check in the SAME privileged
+        // script so only ONE admin auth dialog is shown.
+        let onExternal = filesDirectoryIsOnExternalVolume
+        let ts = Int(Date().timeIntervalSince1970)
+        let fdaTmpFile = "/tmp/.wired3fda_\(ts)"
+        let fdaShFile  = "/tmp/.wired3sh_\(ts).sh"
+
+        if onExternal {
+            writeFDACheckScript(filesDir: currentServerRootPath(), daemonUser: daemonUserName, outputFile: fdaTmpFile, to: fdaShFile)
+        }
+
+        var cmd = "launchctl bootstrap system '\(launchDaemonPlistPath)' 2>/dev/null"
+        cmd += "; launchctl kickstart system/\(launchAgentLabel) 2>/dev/null"
+        if onExternal {
+            cmd += "; sh '\(fdaShFile)'"
+        }
+        cmd += "; true"
+
         do {
             try runPrivileged(cmd, error: .launchDaemonInstallFailed("start"))
+            if onExternal {
+                let raw = (try? String(contentsOfFile: fdaTmpFile, encoding: .utf8)) ?? "0"
+                try? FileManager.default.removeItem(atPath: fdaTmpFile)
+                try? FileManager.default.removeItem(atPath: fdaShFile)
+                wired3HasFullDiskAccess = raw.trimmingCharacters(in: .whitespacesAndNewlines) == "1"
+            }
         } catch {
             publishError("Failed to start daemon: \(error.localizedDescription)")
         }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -260,7 +260,7 @@ final class WiredServerViewModel: ObservableObject {
         // pgrep works without root; launchctl print system/... can return non-zero for
         // non-root users even when the daemon is running, causing false negatives.
         if installMode == .launchDaemon {
-            isDaemonRunning = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).status == 0
+            isDaemonRunning = runProcess("/usr/bin/pgrep", ["-f", "/Library/Wired3/bin/wired3"]).status == 0
         }
         var binaryWasUpdated = false
         // In LaunchDaemon mode: skip auto-update when daemon is running (launchd
@@ -431,7 +431,7 @@ final class WiredServerViewModel: ObservableObject {
     func refreshDaemonStatus() {
         // pgrep works without root and is faster/more reliable than launchctl print for
         // detecting whether the daemon process is actually running.
-        isDaemonRunning = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).status == 0
+        isDaemonRunning = runProcess("/usr/bin/pgrep", ["-f", "/Library/Wired3/bin/wired3"]).status == 0
         isDaemonUserExists = runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
         isDaemonGroupExists = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
     }
@@ -525,6 +525,23 @@ final class WiredServerViewModel: ObservableObject {
     }
 
     func startDaemon() {
+        // Kill any stale LaunchAgent wired3 process (running from user home, not /Library/Wired3/).
+        // This can happen when switching from LaunchAgent to LaunchDaemon mode while a server
+        // is still running, or if stopServer() was skipped. Without this the daemon cannot
+        // bind port 4871.
+        let pgrepOut = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).output
+        let allWiredPIDs = pgrepOut.split(separator: "\n").compactMap { Int32($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        let staleAgentPIDs = allWiredPIDs.filter { pid in
+            let args = runProcess("/bin/ps", ["-p", "\(pid)", "-o", "args="]).output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !args.hasPrefix("/Library/Wired3/bin/wired3")
+        }
+        for pid in staleAgentPIDs {
+            kill(pid, SIGTERM)
+        }
+        if !staleAgentPIDs.isEmpty {
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+
         // bootstrap registers the service (no-op if already registered).
         // kickstart starts it regardless of RunAtLoad value.
         let cmd = "launchctl bootstrap system '\(launchDaemonPlistPath)' 2>/dev/null; launchctl kickstart system/\(launchAgentLabel) 2>/dev/null; true"
@@ -1545,7 +1562,7 @@ final class WiredServerViewModel: ObservableObject {
         // replacement and kills the process. Check here as a last-resort guard regardless
         // of which call path reaches this function.
         if installMode == .launchDaemon {
-            let daemonLive = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).status == 0
+            let daemonLive = runProcess("/usr/bin/pgrep", ["-f", "/Library/Wired3/bin/wired3"]).status == 0
             if daemonLive {
                 appendRuntimeLog("binary-update: daemon is running, skipping binary replacement")
                 return false

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -459,16 +459,18 @@ final class WiredServerViewModel: ObservableObject {
     // a binary update, re-grant FDA to /Library/Wired3/bin/wired3 in
     // System Settings → Privacy & Security → Full Disk Access.
     private func writeFDACheckScript(filesDir: String, daemonUser: String, outputFile: String, to scriptPath: String) {
+        let wired3Binary = installedBinaryPath
         let sh = """
         #!/bin/sh
         OUT='\(outputFile)'
         FILES='\(filesDir)'
         DUSER='\(daemonUser)'
+        WIRED3='\(wired3Binary)'
 
-        # Test whether the daemon user can read the files directory.
-        # su -m preserves the current environment but switches UID, giving a better TCC context
-        # than sudo -u (which inherits root's TCC grants).
-        if su -m "$DUSER" -c "/bin/ls \\"$FILES\\"" >/dev/null 2>&1; then
+        # Run the actual wired3 binary (which holds the FDA/Removable-Volumes TCC grant)
+        # to probe the files directory. Using /bin/ls would fail on macOS 26+ because the
+        # TCC grant is bound to the wired3 binary path, not to the _wired user.
+        if su -m "$DUSER" -c "\\"$WIRED3\\" --check-access \\"$FILES\\"" >/dev/null 2>&1; then
             echo 1 > "$OUT"
         else
             echo 0 > "$OUT"

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -253,9 +253,12 @@ final class WiredServerViewModel: ObservableObject {
     func refreshAll() {
         bootstrapRuntimeIfNeeded()
         var binaryWasUpdated = false
-        // In LaunchDaemon mode, never auto-replace the binary while the daemon
-        // is running — launchd detects the file change and kills the process.
-        let canAutoUpdate = installMode == .launchAgent || !isDaemonRunning
+        // In LaunchDaemon mode: skip auto-update when daemon is running (launchd
+        // kills the process on binary replacement) and only attempt when we have
+        // write access to the bin directory.
+        let binDir = URL(fileURLWithPath: installedBinaryPath).deletingLastPathComponent().path
+        let canWrite = fileManager.isWritableFile(atPath: binDir)
+        let canAutoUpdate = (installMode == .launchAgent || !isDaemonRunning) && canWrite
         if canAutoUpdate {
             do {
                 binaryWasUpdated = try synchronizeInstalledBinaryIfNeeded(allowInstallIfMissing: false)
@@ -563,6 +566,9 @@ final class WiredServerViewModel: ObservableObject {
 
         cmds += [
             "chown -R \(name):\(group) /Library/Wired3",
+            // bin/ stays group-writable so the admin user (in staff group) can update the binary
+            "chmod 775 /Library/Wired3/bin",
+            "chmod 755 /Library/Wired3/bin/wired3 2>/dev/null || true",
             "cp '\(tempURL.path)' '\(launchDaemonPlistPath)'",
             "chmod 644 '\(launchDaemonPlistPath)'",
             "chown root:wheel '\(launchDaemonPlistPath)'"

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -98,13 +98,24 @@ final class WiredServerViewModel: ObservableObject {
     private let userDefaults = UserDefaults.standard
     private let launchAtAppStartKey = "wiredswift.server.launchAtAppStart"
     private let workingDirectoryKey = "wired3WorkingDirectory"
+    private let installModeKey = "wired3InstallMode"
+    private let daemonUserNameKey = "wired3DaemonUserName"
+    private let daemonStartAtBootKey = "wired3DaemonStartAtBoot"
     private let launchAgentLabel = "fr.read-write.wired3.server"
+    private let launchDaemonPlistPath = "/Library/LaunchDaemons/fr.read-write.wired3.server.plist"
     private let embeddedBinarySHAKey = "Wired3EmbeddedSHA256"
 
     static let systemDataDirectory = "/Library/Wired3"
 
     @Published var isSystemMigrating: Bool = false
     @Published var systemMigrationStatus: String = ""
+
+    @Published var installMode: ServerInstallMode = .launchAgent
+    @Published var daemonUserName: String = "_wired"
+    @Published var daemonStartAtBoot: Bool = false
+    @Published var isSwitchingMode: Bool = false
+    @Published var modeSwitchStatus: String = ""
+
     private var lastDashboardLightRefresh = Date.distantPast
     private var lastDashboardHeavyRefresh = Date.distantPast
 
@@ -170,7 +181,12 @@ final class WiredServerViewModel: ObservableObject {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let defaultDirectory = appSupport.appendingPathComponent("Wired3", isDirectory: true).path
         self.workingDirectory = UserDefaults.standard.string(forKey: "wired3WorkingDirectory") ?? defaultDirectory
-        self.launchServerAtAppStart = userDefaults.bool(forKey: launchAtAppStartKey)
+        self.launchServerAtAppStart = UserDefaults.standard.bool(forKey: launchAtAppStartKey)
+
+        let savedMode = UserDefaults.standard.string(forKey: "wired3InstallMode")
+        self.installMode = ServerInstallMode(rawValue: savedMode ?? "") ?? .launchAgent
+        self.daemonUserName = UserDefaults.standard.string(forKey: "wired3DaemonUserName") ?? "_wired"
+        self.daemonStartAtBoot = UserDefaults.standard.bool(forKey: "wired3DaemonStartAtBoot")
 
         if #available(macOS 13.0, *) {
             try? SMAppService.mainApp.unregister()
@@ -380,6 +396,195 @@ final class WiredServerViewModel: ObservableObject {
            let result = sqlite3_column_text(stmt, 0),
            String(cString: result) == "ok" { return }
         throw WiredServerError.systemMigrationFailed("Database integrity check failed")
+    }
+
+    // MARK: - LaunchDaemon / LaunchAgent Mode Switching
+
+    var daemonUserExists: Bool {
+        runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
+    }
+
+    var launchDaemonInstalled: Bool {
+        fileManager.fileExists(atPath: launchDaemonPlistPath)
+    }
+
+    var daemonRunning: Bool {
+        let result = runProcess("/bin/launchctl", ["print", "system/\(launchAgentLabel)"])
+        return result.status == 0
+    }
+
+    func saveDaemonSettings() {
+        userDefaults.set(daemonUserName, forKey: daemonUserNameKey)
+        userDefaults.set(daemonStartAtBoot, forKey: daemonStartAtBootKey)
+    }
+
+    func switchInstallMode(to mode: ServerInstallMode) async {
+        guard mode != installMode, !isSwitchingMode else { return }
+        guard isUsingSystemDirectory else {
+            publishError("Please migrate data to /Library/Wired3/ before switching to LaunchDaemon mode.")
+            return
+        }
+        isSwitchingMode = true
+        modeSwitchStatus = "Preparing..."
+
+        do {
+            if isRunning {
+                modeSwitchStatus = "Stopping server..."
+                stopServer()
+                try await Task.sleep(for: .seconds(2))
+            }
+
+            switch mode {
+            case .launchDaemon:
+                modeSwitchStatus = "Creating system user '\(daemonUserName)' (admin required)..."
+                if !daemonUserExists {
+                    try createDaemonUser(name: daemonUserName)
+                }
+                modeSwitchStatus = "Setting directory ownership..."
+                try setSystemDirectoryOwnership(user: daemonUserName)
+                modeSwitchStatus = "Installing LaunchDaemon..."
+                if launchAtLogin {
+                    try configureLaunchAtLogin(enabled: false)
+                    launchAtLogin = false
+                }
+                try installLaunchDaemon()
+
+            case .launchAgent:
+                modeSwitchStatus = "Removing LaunchDaemon..."
+                try removeLaunchDaemon()
+                modeSwitchStatus = "Resetting directory ownership..."
+                try setSystemDirectoryOwnership(user: NSUserName())
+            }
+
+            installMode = mode
+            userDefaults.set(mode.rawValue, forKey: installModeKey)
+            modeSwitchStatus = "Done."
+        } catch {
+            modeSwitchStatus = "Failed: \(error.localizedDescription)"
+            publishError("Mode switch failed: \(error.localizedDescription)")
+        }
+
+        isSwitchingMode = false
+        refreshAll()
+    }
+
+    func toggleDaemonStartAtBoot(_ enabled: Bool) {
+        daemonStartAtBoot = enabled
+        userDefaults.set(enabled, forKey: daemonStartAtBootKey)
+        guard launchDaemonInstalled else { return }
+        do {
+            try installLaunchDaemon()
+        } catch {
+            publishError("Failed to update LaunchDaemon: \(error.localizedDescription)")
+        }
+    }
+
+    func startDaemon() {
+        _ = runProcess("/bin/launchctl",
+            ["bootstrap", "system", launchDaemonPlistPath])
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.refreshAll()
+        }
+    }
+
+    func stopDaemon() {
+        _ = runProcess("/bin/launchctl",
+            ["bootout", "system/\(launchAgentLabel)"])
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.refreshAll()
+        }
+    }
+
+    private func createDaemonUser(name: String) throws {
+        let uid = findFreeSystemUID()
+        let script = """
+        do shell script "dscl . -create /Users/\(name) && \
+        dscl . -create /Users/\(name) UserShell /usr/bin/false && \
+        dscl . -create /Users/\(name) RealName 'Wired Server' && \
+        dscl . -create /Users/\(name) UniqueID \(uid) && \
+        dscl . -create /Users/\(name) PrimaryGroupID 20 && \
+        dscl . -create /Users/\(name) NFSHomeDirectory /Library/Wired3 && \
+        dscl . -create /Users/\(name) IsHidden 1" with administrator privileges
+        """
+        var errorInfo: NSDictionary?
+        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
+        if let err = errorInfo {
+            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
+            throw WiredServerError.daemonUserCreationFailed(msg)
+        }
+        guard daemonUserExists else {
+            throw WiredServerError.daemonUserCreationFailed("User '\(name)' missing after creation")
+        }
+    }
+
+    private func setSystemDirectoryOwnership(user: String) throws {
+        let script = """
+        do shell script "chown -R \(user):staff /Library/Wired3" with administrator privileges
+        """
+        var errorInfo: NSDictionary?
+        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
+        if let err = errorInfo {
+            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
+            throw WiredServerError.systemDirectoryOwnershipFailed(msg)
+        }
+    }
+
+    private func installLaunchDaemon() throws {
+        let filesRoot = currentServerRootPath()
+        let plist: [String: Any] = [
+            "Label": launchAgentLabel,
+            "ProgramArguments": [
+                installedBinaryPath,
+                "--working-directory", workingDirectory,
+                "--db", databasePath,
+                "--config", configPath,
+                "--root", filesRoot
+            ],
+            "UserName": daemonUserName,
+            "WorkingDirectory": workingDirectory,
+            "RunAtLoad": daemonStartAtBoot,
+            "KeepAlive": false,
+            "StandardOutPath": logPath,
+            "StandardErrorPath": logPath
+        ]
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fr.read-write.wired3.server.plist")
+        guard (plist as NSDictionary).write(to: tempURL, atomically: true) else {
+            throw WiredServerError.launchDaemonWriteFailed
+        }
+
+        let script = """
+        do shell script "cp '\(tempURL.path)' '\(launchDaemonPlistPath)' && chmod 644 '\(launchDaemonPlistPath)' && chown root:wheel '\(launchDaemonPlistPath)'" with administrator privileges
+        """
+        var errorInfo: NSDictionary?
+        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
+        if let err = errorInfo {
+            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
+            throw WiredServerError.launchDaemonInstallFailed(msg)
+        }
+    }
+
+    private func removeLaunchDaemon() throws {
+        let script = """
+        do shell script "launchctl bootout system/\(launchAgentLabel) 2>/dev/null; rm -f '\(launchDaemonPlistPath)'" with administrator privileges
+        """
+        var errorInfo: NSDictionary?
+        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
+        if let err = errorInfo {
+            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
+            throw WiredServerError.launchDaemonRemoveFailed(msg)
+        }
+    }
+
+    private func findFreeSystemUID() -> Int {
+        let output = runCommand("/usr/bin/dscl", [".", "-list", "/Users", "UniqueID"])
+        let used = Set(output.components(separatedBy: .newlines).compactMap { line -> Int? in
+            let parts = line.split(separator: " ").map(String.init)
+            return parts.count >= 2 ? Int(parts.last ?? "") : nil
+        })
+        for uid in 400...499 where !used.contains(uid) { return uid }
+        return 489
     }
 
     // MARK: - Wired 2.5 Migration
@@ -2263,6 +2468,18 @@ private struct DashboardProcessMetrics {
     static let empty = DashboardProcessMetrics(uptime: "-", cpu: "-", memory: "-")
 }
 
+enum ServerInstallMode: String {
+    case launchAgent
+    case launchDaemon
+
+    var displayName: String {
+        switch self {
+        case .launchAgent: return "LaunchAgent (current user, starts at login)"
+        case .launchDaemon: return "LaunchDaemon (system service, starts at boot)"
+        }
+    }
+}
+
 enum DashboardHealthLevel {
     case good
     case warning
@@ -2300,6 +2517,11 @@ enum WiredServerError: LocalizedError, Equatable {
     case databaseExecutionFailed(String)
     case systemDirectoryCreationFailed(String)
     case systemMigrationFailed(String)
+    case systemDirectoryOwnershipFailed(String)
+    case daemonUserCreationFailed(String)
+    case launchDaemonWriteFailed
+    case launchDaemonInstallFailed(String)
+    case launchDaemonRemoveFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -2327,6 +2549,16 @@ enum WiredServerError: LocalizedError, Equatable {
             return "Failed to create system data directory: \(msg)"
         case .systemMigrationFailed(let msg):
             return "Data migration failed: \(msg)"
+        case .systemDirectoryOwnershipFailed(let msg):
+            return "Failed to set directory ownership: \(msg)"
+        case .daemonUserCreationFailed(let msg):
+            return "Failed to create daemon user: \(msg)"
+        case .launchDaemonWriteFailed:
+            return "Failed to write LaunchDaemon plist"
+        case .launchDaemonInstallFailed(let msg):
+            return "Failed to install LaunchDaemon: \(msg)"
+        case .launchDaemonRemoveFailed(let msg):
+            return "Failed to remove LaunchDaemon: \(msg)"
         }
     }
 }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -2,6 +2,7 @@
 // TODO: Split WiredServerViewModel into focused sub-view-models
 import AppKit
 import Foundation
+import LocalAuthentication
 import Network
 import ServiceManagement
 #if os(Linux)
@@ -78,6 +79,8 @@ final class WiredServerViewModel: ObservableObject {
 
     @Published var isBusy: Bool = false
     @Published var statusMessage: String = ""
+
+    @Published var hasTouchIDCredential: Bool = BiometricCredentialStore.hasStoredCredential
 
     @Published var showErrorAlert: Bool = false
     @Published var lastErrorMessage: String = ""
@@ -381,15 +384,10 @@ final class WiredServerViewModel: ObservableObject {
 
     private func createSystemDataDirectory() throws {
         let username = NSUserName()
-        let script = """
-        do shell script "mkdir -p /Library/Wired3 && chown \(username):staff /Library/Wired3 && chmod 755 /Library/Wired3" with administrator privileges
-        """
-        var errorInfo: NSDictionary?
-        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
-        if let err = errorInfo {
-            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
-            throw WiredServerError.systemDirectoryCreationFailed(msg)
-        }
+        try runPrivileged(
+            "mkdir -p /Library/Wired3 && chown \(username):staff /Library/Wired3 && chmod 755 /Library/Wired3",
+            error: .systemDirectoryCreationFailed("")
+        )
         guard fileManager.fileExists(atPath: Self.systemDataDirectory) else {
             throw WiredServerError.systemDirectoryCreationFailed("Directory missing after creation")
         }
@@ -753,19 +751,92 @@ final class WiredServerViewModel: ObservableObject {
         return tempURL
     }
 
+    // MARK: - Privileged execution
+
     private func runPrivileged(_ shellScript: String, error fallbackError: WiredServerError) throws {
-        let appleScript = "do shell script \"\(shellScript)\" with administrator privileges"
-        var errorInfo: NSDictionary?
-        NSAppleScript(source: appleScript)?.executeAndReturnError(&errorInfo)
-        if let err = errorInfo {
-            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
-            // Re-throw with the actual message by matching the error type
+        // 1. Try Touch ID — if available and a credential is stored
+        if BiometricCredentialStore.isAvailable && BiometricCredentialStore.hasStoredCredential {
+            if let pw = BiometricCredentialStore.load(reason: L("touchid.reason")) {
+                let succeeded = executePrivileged(shellScript: shellScript, password: pw)
+                if succeeded {
+                    return
+                }
+                // Wrong stored password — clear it and fall through to manual dialog
+                BiometricCredentialStore.delete()
+                hasTouchIDCredential = false
+            }
+            // User cancelled Touch ID — fall through to manual dialog
+        }
+
+        // 2. Custom password dialog (so we capture the password for optional Touch ID save)
+        guard let pw = promptAdminPassword() else {
+            throw fallbackError
+        }
+
+        let succeeded = executePrivileged(shellScript: shellScript, password: pw)
+        guard succeeded else {
+            let msg = L("touchid.wrong_password")
             switch fallbackError {
             case .launchDaemonInstallFailed: throw WiredServerError.launchDaemonInstallFailed(msg)
             case .launchDaemonRemoveFailed:  throw WiredServerError.launchDaemonRemoveFailed(msg)
+            case .systemDirectoryCreationFailed: throw WiredServerError.systemDirectoryCreationFailed(msg)
             default:                         throw fallbackError
             }
         }
+
+        // 3. Offer to save for Touch ID (only if available and not already stored)
+        if BiometricCredentialStore.isAvailable && !BiometricCredentialStore.hasStoredCredential {
+            offerTouchIDSave(password: pw)
+        }
+    }
+
+    /// Execute a shell command with an explicit admin password via AppleScript.
+    /// Returns true on success, false on auth failure or error.
+    @discardableResult
+    private func executePrivileged(shellScript: String, password: String) -> Bool {
+        let escapedPw = password
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let appleScript = "do shell script \"\(shellScript)\" with administrator privileges password \"\(escapedPw)\""
+        var errorInfo: NSDictionary?
+        NSAppleScript(source: appleScript)?.executeAndReturnError(&errorInfo)
+        return errorInfo == nil
+    }
+
+    /// Show a custom password dialog. Returns the entered password, or nil if cancelled.
+    private func promptAdminPassword() -> String? {
+        let alert = NSAlert()
+        alert.messageText = L("touchid.dialog.title")
+        alert.informativeText = L("touchid.dialog.message")
+        alert.addButton(withTitle: L("common.ok"))
+        alert.addButton(withTitle: L("common.cancel"))
+
+        let field = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        field.placeholderString = L("touchid.dialog.placeholder")
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        let pw = field.stringValue
+        return pw.isEmpty ? nil : pw
+    }
+
+    /// Ask the user once whether to save the password for Touch ID.
+    private func offerTouchIDSave(password: String) {
+        let alert = NSAlert()
+        alert.messageText = L("touchid.save.title")
+        alert.informativeText = L("touchid.save.message")
+        alert.addButton(withTitle: L("touchid.save.enable"))
+        alert.addButton(withTitle: L("common.cancel"))
+        if alert.runModal() == .alertFirstButtonReturn {
+            BiometricCredentialStore.save(password: password)
+            hasTouchIDCredential = true
+        }
+    }
+
+    func forgetTouchIDCredential() {
+        BiometricCredentialStore.delete()
+        hasTouchIDCredential = false
     }
 
     private func findFreeSystemUID() throws -> Int {

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -2854,7 +2854,7 @@ strict_identity = yes
     }
 
     private static func checkPortExternal(ip: String, port: Int) async -> PortStatus {
-        guard let url = URL(string: "https://check-host.net/check-tcp?host=\(ip):\(port)&max_nodes=1") else { return .error }
+        guard let url = URL(string: "https://check-host.net/check-tcp?host=\(ip):\(port)&max_nodes=3") else { return .error }
         var req = URLRequest(url: url)
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         req.timeoutInterval = 15
@@ -2873,12 +2873,15 @@ strict_identity = yes
             guard let (resultData, _) = try? await URLSession.shared.data(for: resultReq) else { continue }
             guard let json = try? JSONSerialization.jsonObject(with: resultData) as? [String: Any] else { continue }
 
+            var anyOpen = false
+            var anyPending = false
             for (_, nodeValue) in json {
+                if nodeValue is NSNull { anyPending = true; continue }
                 guard let results = nodeValue as? [[String: Any]], !results.isEmpty else { continue }
-                if results.first?["address"] != nil { return .open }
-                if results.first?["error"] != nil { return .closed }
+                if results.first?["address"] != nil { anyOpen = true }
             }
-            // null means still pending — continue polling
+            if anyOpen { return .open }
+            if !anyPending { return .closed }  // all nodes answered, none succeeded
         }
         return .closed
     }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -429,13 +429,22 @@ final class WiredServerViewModel: ObservableObject {
 
     // MARK: - LaunchDaemon / LaunchAgent Mode Switching
 
+    private var daemonAccountsVerified = false
+
     func refreshDaemonStatus() {
         // pgrep works without root and is faster/more reliable than launchctl print for
         // detecting whether the daemon process is actually running.
-        isDaemonRunning = runProcess("/usr/bin/pgrep", ["-f", "/Library/Wired3/bin/wired3"]).status == 0
-        isDaemonUserExists = runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
-        isDaemonGroupExists = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
+        isDaemonRunning = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).status == 0
+        if !daemonAccountsVerified {
+            isDaemonUserExists = runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
+            isDaemonGroupExists = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
+            daemonAccountsVerified = true
+        }
         checkFDAFast()
+    }
+
+    func invalidateDaemonAccountsCache() {
+        daemonAccountsVerified = false
     }
 
     // MARK: - External Volume / FDA
@@ -632,8 +641,20 @@ final class WiredServerViewModel: ObservableObject {
         }
     }
 
+    private func validateDaemonIdentifier(_ value: String) throws {
+        let pattern = "^[a-z_][a-z0-9_-]{0,31}$"
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              regex.firstMatch(in: value, range: NSRange(value.startIndex..., in: value)) != nil else {
+            throw WiredServerError.launchDaemonInstallFailed(
+                "Invalid account name '\(value)'. Use only lowercase letters, digits, underscores, or hyphens (max 32 chars)."
+            )
+        }
+    }
+
     // One admin dialog: create group (optional) + create user (optional) + chown + install plist
     private func activateLaunchDaemon(name: String, createUser: Bool) throws {
+        try validateDaemonIdentifier(name)
+        try validateDaemonIdentifier(daemonGroupName)
         let tempURL = try writeDaemonPlistToTemp()
         let group = daemonGroupName
         let createGroup = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status != 0
@@ -641,7 +662,7 @@ final class WiredServerViewModel: ObservableObject {
         var cmds: [String] = []
 
         if createGroup {
-            let gid = findFreeSystemGID()
+            let gid = try findFreeSystemGID()
             cmds += [
                 "dscl . -create /Groups/\(group)",
                 "dscl . -create /Groups/\(group) PrimaryGroupID \(gid)",
@@ -651,7 +672,7 @@ final class WiredServerViewModel: ObservableObject {
         }
 
         if createUser {
-            let uid = findFreeSystemUID()
+            let uid = try findFreeSystemUID()
             let gid = groupGID(for: group)
             cmds += [
                 "dscl . -create /Users/\(name)",
@@ -685,6 +706,7 @@ final class WiredServerViewModel: ObservableObject {
 
         try runPrivileged(cmds.joined(separator: " && "),
                           error: WiredServerError.launchDaemonInstallFailed(""))
+        daemonAccountsVerified = false
     }
 
     // One admin dialog: bootout + remove plist + chown back to current user
@@ -693,9 +715,10 @@ final class WiredServerViewModel: ObservableObject {
             "launchctl bootout system/\(launchAgentLabel) 2>/dev/null",
             "rm -f '\(launchDaemonPlistPath)'",
             "chown -R \(restoreUser):staff /Library/Wired3"  // back to staff for LaunchAgent
-        ].joined(separator: "; ")
+        ].joined(separator: " && ")
 
         try runPrivileged(cmds, error: WiredServerError.launchDaemonRemoveFailed(""))
+        daemonAccountsVerified = false
     }
 
     // Used by toggleDaemonStartAtBoot — updates existing plist with one admin dialog
@@ -749,24 +772,28 @@ final class WiredServerViewModel: ObservableObject {
         }
     }
 
-    private func findFreeSystemUID() -> Int {
+    private func findFreeSystemUID() throws -> Int {
         let output = runCommand("/usr/bin/dscl", [".", "-list", "/Users", "UniqueID"])
         let used = Set(output.components(separatedBy: .newlines).compactMap { line -> Int? in
             let parts = line.split(separator: " ").map(String.init)
             return parts.count >= 2 ? Int(parts.last ?? "") : nil
         })
         for uid in 400...499 where !used.contains(uid) { return uid }
-        return 489
+        throw WiredServerError.launchDaemonInstallFailed(
+            "No free UID available in the 400–499 system range. Free a UID and try again."
+        )
     }
 
-    private func findFreeSystemGID() -> Int {
+    private func findFreeSystemGID() throws -> Int {
         let output = runCommand("/usr/bin/dscl", [".", "-list", "/Groups", "PrimaryGroupID"])
         let used = Set(output.components(separatedBy: .newlines).compactMap { line -> Int? in
             let parts = line.split(separator: " ").map(String.init)
             return parts.count >= 2 ? Int(parts.last ?? "") : nil
         })
         for gid in 400...499 where !used.contains(gid) { return gid }
-        return 488
+        throw WiredServerError.launchDaemonInstallFailed(
+            "No free GID available in the 400–499 system range. Free a GID and try again."
+        )
     }
 
     private func groupGID(for group: String) -> Int {
@@ -782,7 +809,7 @@ final class WiredServerViewModel: ObservableObject {
 
     // MARK: - Wired 2.5 Migration
 
-    func chooseMigrationSource() {
+    @MainActor func chooseMigrationSource() {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = false
         panel.canChooseFiles = true

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -415,10 +415,7 @@ final class WiredServerViewModel: ObservableObject {
 
     var filesDirectoryIsOnExternalVolume: Bool {
         let path = currentServerRootPath()
-        let url = URL(fileURLWithPath: path)
-        guard let values = try? url.resourceValues(forKeys: [.volumeURLKey]),
-              let volumeURL = values.volumeURL else { return false }
-        return volumeURL.path.hasPrefix("/Volumes/")
+        return path.hasPrefix("/Volumes/")
     }
 
     // Checks FDA for the wired3 binary via the TCC database (readable only with FDA granted)

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -86,6 +86,7 @@ final class WiredServerViewModel: ObservableObject {
     @Published var lastErrorMessage: String = ""
 
     @Published var showRestartAfterUpdateAlert: Bool = false
+    @Published var showPrivilegedUpdateAlert: Bool = false
     @Published var showInitialPasswordAlert: Bool = false
     @Published var initialAdminPassword: String = ""
 
@@ -267,17 +268,20 @@ final class WiredServerViewModel: ObservableObject {
             isDaemonRunning = runProcess("/usr/bin/pgrep", ["-f", "/Library/Wired3/bin/wired3"]).status == 0
         }
         var binaryWasUpdated = false
-        // In LaunchDaemon mode: skip auto-update when daemon is running (launchd
-        // kills the process on binary replacement) and only attempt when we have
-        // write access to the bin directory.
         let binDir = URL(fileURLWithPath: installedBinaryPath).deletingLastPathComponent().path
         let canWrite = fileManager.isWritableFile(atPath: binDir)
-        let canAutoUpdate = (installMode == .launchAgent || !isDaemonRunning) && canWrite
-        if canAutoUpdate {
+        if installMode == .launchAgent && canWrite {
+            // LaunchAgent mode: update binary in-place (user owns the bin dir).
             do {
                 binaryWasUpdated = try synchronizeInstalledBinaryIfNeeded(allowInstallIfMissing: false)
             } catch {
                 publishError("\(L("error.install_failed")): \(error.localizedDescription)")
+            }
+        } else if installMode == .launchDaemon && !isDaemonRunning && !canWrite {
+            // LaunchDaemon mode: bin dir is root-owned. When the daemon is stopped,
+            // detect if an update is available and offer a privileged install via alert.
+            if !showPrivilegedUpdateAlert, isBinaryUpdateAvailable() {
+                showPrivilegedUpdateAlert = true
             }
         }
         refreshInstallStatus()
@@ -632,6 +636,11 @@ final class WiredServerViewModel: ObservableObject {
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
             self?.refreshDaemonStatus()
+            // After daemon stops, check if a privileged binary update is available
+            if let self, self.installMode == .launchDaemon, !self.isDaemonRunning,
+               !self.showPrivilegedUpdateAlert, self.isBinaryUpdateAvailable() {
+                self.showPrivilegedUpdateAlert = true
+            }
         }
     }
 
@@ -788,13 +797,16 @@ final class WiredServerViewModel: ObservableObject {
             throw fallbackError
         }
 
-        let succeeded = executePrivileged(shellScript: shellScript, password: pw)
+        let (succeeded, isAuthFailure) = executePrivileged(shellScript: shellScript, password: pw)
         if !succeeded {
-            // Wrong password — clear cache and Keychain entry if it was from Touch ID
             sessionPassword = nil
-            if BiometricCredentialStore.hasStoredCredential {
-                BiometricCredentialStore.delete()
-                hasTouchIDCredential = false
+            if isAuthFailure {
+                // Only wipe the keychain entry on confirmed auth failure (wrong password),
+                // not on shell command errors — those leave a valid credential untouched.
+                if BiometricCredentialStore.hasStoredCredential {
+                    BiometricCredentialStore.delete()
+                    hasTouchIDCredential = false
+                }
             }
             let msg = L("touchid.wrong_password")
             switch fallbackError {
@@ -812,16 +824,19 @@ final class WiredServerViewModel: ObservableObject {
     }
 
     /// Execute a shell command with an explicit admin password via AppleScript.
-    /// Returns true on success, false on auth failure or error.
+    /// Returns (success, isAuthFailure). AppleScript error codes < 0 indicate auth/system
+    /// failures; positive codes are shell exit statuses (command ran but failed).
     @discardableResult
-    private func executePrivileged(shellScript: String, password: String) -> Bool {
+    private func executePrivileged(shellScript: String, password: String) -> (Bool, Bool) {
         let escapedPw = password
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
         let appleScript = "do shell script \"\(shellScript)\" with administrator privileges password \"\(escapedPw)\""
         var errorInfo: NSDictionary?
         NSAppleScript(source: appleScript)?.executeAndReturnError(&errorInfo)
-        return errorInfo == nil
+        guard let errorInfo else { return (true, false) }
+        let code = errorInfo[NSAppleScript.errorNumber] as? Int ?? 0
+        return (false, code < 0)
     }
 
     /// Show a custom password dialog. Returns the entered password, or nil if cancelled.
@@ -1796,6 +1811,36 @@ final class WiredServerViewModel: ObservableObject {
         try installBinaryWithStagingRollback(from: bundledBinary, expectedSHA256: expectedSHA256)
         return true
     }
+
+    /// Returns true if the bundled binary differs from the installed binary (update available).
+    private func isBinaryUpdateAvailable() -> Bool {
+        guard let bundledBinary = bundledServerBinaryPath() else { return false }
+        guard let bundledSHA256 = try? normalizedSHA256ForFile(at: bundledBinary) else { return false }
+        let metadataSHA256 = bundledBinaryExpectedSHA256()
+        let expectedSHA256 = (metadataSHA256 == bundledSHA256 ? metadataSHA256 : nil) ?? bundledSHA256
+        guard fileManager.isExecutableFile(atPath: installedBinaryPath),
+              let installedSHA256 = try? normalizedSHA256ForFile(at: installedBinaryPath) else { return true }
+        return installedSHA256 != expectedSHA256
+    }
+
+    /// Install the bundled binary into the LaunchDaemon bin dir using a privileged shell copy.
+    /// Only safe to call when the daemon is confirmed stopped.
+    func applyPrivilegedUpdate() {
+        guard let bundledBinary = bundledServerBinaryPath() else { return }
+        let src = bundledBinary.replacingOccurrences(of: "'", with: "'\\''")
+        let dst = installedBinaryPath.replacingOccurrences(of: "'", with: "'\\''")
+        let script = "cp -f '\(src)' '\(dst)' && chmod 755 '\(dst)'"
+        do {
+            try runPrivileged(script, error: .launchDaemonInstallFailed(""))
+            appendRuntimeLog("binary-update: privileged update applied")
+            showPrivilegedUpdateAlert = false
+            refreshInstallStatus()
+            refreshInstalledVersion()
+        } catch {
+            publishError("\(L("error.install_failed")): \(error.localizedDescription)")
+        }
+    }
+
 
     private func installBinaryWithStagingRollback(from sourcePath: String, expectedSHA256: String) throws {
         let destinationURL = URL(fileURLWithPath: installedBinaryPath)

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -278,11 +278,7 @@ final class WiredServerViewModel: ObservableObject {
             }
         }
         refreshInstallStatus()
-        // Skip version check when daemon is running: avoids launching wired3 --version
-        // concurrently with the daemon process (potential interference + main thread blocking).
-        if !isDaemonRunning {
-            refreshInstalledVersion()
-        }
+        refreshInstalledVersion()
         launchAtLogin = isLaunchAtLoginEnabled()
         loadConfig()
         refreshRunningStatus()

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -2567,7 +2567,7 @@ strict_identity = yes
         if !isInstalled {
             return .init(level: .critical, title: L("dashboard.health.critical"), detail: L("dashboard.health.server.not_installed"))
         }
-        if !isRunning {
+        if !isServerActive {
             return .init(level: .warning, title: L("dashboard.health.warning"), detail: L("dashboard.health.server.stopped"))
         }
         if portStatus == .closed {

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -1885,6 +1885,17 @@ final class WiredServerViewModel: ObservableObject {
                 throw WiredServerError.binaryIntegrityCheckFailed("installed hash mismatch")
             }
 
+            // Re-sign with an ad-hoc signature. When the wired3 binary is extracted
+            // from the app bundle and placed at /Library/Wired3/bin/ as a standalone
+            // executable, macOS code-signing validation (SIGKILL/Invalid Page) requires
+            // an individual signature — the bundle signature it inherited is not enough.
+            let signResult = runProcess("/usr/bin/codesign", ["--force", "--sign", "-", destinationURL.path])
+            if signResult.status != 0 {
+                appendRuntimeLog("binary-update: codesign warning — \(signResult.output.trimmingCharacters(in: .whitespacesAndNewlines))")
+            } else {
+                appendRuntimeLog("binary-update: ad-hoc signature applied")
+            }
+
             if fileManager.fileExists(atPath: backupURL.path) {
                 try? fileManager.removeItem(at: backupURL)
             }
@@ -1987,8 +1998,13 @@ final class WiredServerViewModel: ObservableObject {
     private func refreshDashboardLightweight() {
         dashboardHostUptime = formattedDuration(ProcessInfo.processInfo.systemUptime)
 
-        let activePIDs = activeServerPIDs()
-        if let pid = activePIDs.first {
+        // In daemon mode lsof can't cross the user boundary (_wired vs. maertin),
+        // so read the PID directly from the PID file the server writes on startup.
+        let pid: Int32? = installMode == .launchDaemon
+            ? serverPIDFromFile()
+            : activeServerPIDs().first
+
+        if let pid {
             dashboardServerPID = String(pid)
             let metrics = processMetrics(for: pid)
             dashboardServerUptime = metrics.uptime
@@ -2004,6 +2020,13 @@ final class WiredServerViewModel: ObservableObject {
         }
 
         dashboardLastErrorLine = extractLastErrorLine(from: logsText)
+    }
+
+    private func serverPIDFromFile() -> Int32? {
+        let pidPath = URL(fileURLWithPath: workingDirectory)
+            .appendingPathComponent("wired3.pid").path
+        guard let raw = try? String(contentsOfFile: pidPath, encoding: .utf8) else { return nil }
+        return pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
     private func refreshDashboardHeavyweight() {

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -574,6 +574,9 @@ final class WiredServerViewModel: ObservableObject {
             // bin/ uses staff group so the admin user can write the binary (admin is not in daemon group)
             "chown \(name):staff /Library/Wired3/bin",
             "chmod 775 /Library/Wired3/bin",
+            // Remove stale .updates dir: chown -R would have set it to _wired:daemon,
+            // preventing admin (not in daemon group) from writing inside it.
+            "rm -rf '/Library/Wired3/bin/.updates'",
             "chmod 755 /Library/Wired3/bin/wired3 2>/dev/null || true",
             "cp '\(tempURL.path)' '\(launchDaemonPlistPath)'",
             "chmod 644 '\(launchDaemonPlistPath)'",

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -113,7 +113,7 @@ final class WiredServerViewModel: ObservableObject {
 
     @Published var installMode: ServerInstallMode = .launchAgent
     @Published var daemonUserName: String = "_wired"
-    @Published var daemonGroupName: String = "staff"
+    @Published var daemonGroupName: String = "daemon"
     @Published var daemonStartAtBoot: Bool = false
     @Published var isSwitchingMode: Bool = false
     @Published var modeSwitchStatus: String = ""
@@ -191,7 +191,7 @@ final class WiredServerViewModel: ObservableObject {
         let savedMode = UserDefaults.standard.string(forKey: "wired3InstallMode")
         self.installMode = ServerInstallMode(rawValue: savedMode ?? "") ?? .launchAgent
         self.daemonUserName = UserDefaults.standard.string(forKey: "wired3DaemonUserName") ?? "_wired"
-        self.daemonGroupName = UserDefaults.standard.string(forKey: "wired3DaemonGroupName") ?? "staff"
+        self.daemonGroupName = UserDefaults.standard.string(forKey: "wired3DaemonGroupName") ?? "daemon"
         self.daemonStartAtBoot = UserDefaults.standard.bool(forKey: "wired3DaemonStartAtBoot")
 
         if #available(macOS 13.0, *) {
@@ -566,7 +566,8 @@ final class WiredServerViewModel: ObservableObject {
 
         cmds += [
             "chown -R \(name):\(group) /Library/Wired3",
-            // bin/ stays group-writable so the admin user (in staff group) can update the binary
+            // bin/ uses staff group so the admin user can write the binary (admin is not in daemon group)
+            "chown \(name):staff /Library/Wired3/bin",
             "chmod 775 /Library/Wired3/bin",
             "chmod 755 /Library/Wired3/bin/wired3 2>/dev/null || true",
             "cp '\(tempURL.path)' '\(launchDaemonPlistPath)'",

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -2833,49 +2833,54 @@ strict_identity = yes
         return .init(level: .good, title: L("dashboard.health.good"), detail: L("dashboard.health.files.ok"))
     }
 
+    // MARK: - External port reachability check
+
+    /// Two-step external port check:
+    ///   1. Resolve external IP via api.ipify.org
+    ///   2. Probe TCP reachability via check-host.net
     private static func probePort(port: Int) async -> PortStatus {
-        guard let nwPort = NWEndpoint.Port(rawValue: UInt16(max(0, min(port, 65_535)))) else {
-            return .closed
+        guard (1...65_535).contains(port) else { return .closed }
+        guard let externalIP = await fetchExternalIP() else { return .error }
+        return await checkPortExternal(ip: externalIP, port: port)
+    }
+
+    private static func fetchExternalIP() async -> String? {
+        guard let url = URL(string: "https://api.ipify.org?format=json") else { return nil }
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 10
+        guard let (data, _) = try? await URLSession.shared.data(for: req) else { return nil }
+        struct IPResponse: Decodable { let ip: String }
+        return (try? JSONDecoder().decode(IPResponse.self, from: data))?.ip
+    }
+
+    private static func checkPortExternal(ip: String, port: Int) async -> PortStatus {
+        guard let url = URL(string: "https://check-host.net/check-tcp?host=\(ip):\(port)&max_nodes=1") else { return .error }
+        var req = URLRequest(url: url)
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.timeoutInterval = 15
+        guard let (data, _) = try? await URLSession.shared.data(for: req) else { return .error }
+
+        struct CheckInit: Decodable { let request_id: String }
+        guard let checkResp = try? JSONDecoder().decode(CheckInit.self, from: data) else { return .error }
+
+        // Poll at 3 s, then +4 s, then +6 s (open ports resolve in ~2 s, timeouts in ~6 s)
+        for delay: UInt64 in [3_000_000_000, 4_000_000_000, 6_000_000_000] {
+            try? await Task.sleep(nanoseconds: delay)
+            guard let resultURL = URL(string: "https://check-host.net/check-result/\(checkResp.request_id)") else { return .error }
+            var resultReq = URLRequest(url: resultURL)
+            resultReq.setValue("application/json", forHTTPHeaderField: "Accept")
+            resultReq.timeoutInterval = 10
+            guard let (resultData, _) = try? await URLSession.shared.data(for: resultReq) else { continue }
+            guard let json = try? JSONSerialization.jsonObject(with: resultData) as? [String: Any] else { continue }
+
+            for (_, nodeValue) in json {
+                guard let results = nodeValue as? [[String: Any]], !results.isEmpty else { continue }
+                if results.first?["address"] != nil { return .open }
+                if results.first?["error"] != nil { return .closed }
+            }
+            // null means still pending — continue polling
         }
-
-        return await withCheckedContinuation { continuation in
-            let connection = NWConnection(host: .ipv4(.loopback), port: nwPort, using: .tcp)
-            let queue = DispatchQueue(label: "wired.server.port.check")
-            final class ResolutionState: @unchecked Sendable {
-                let lock = NSLock()
-                var resolved = false
-            }
-            let state = ResolutionState()
-
-            @Sendable func finish(_ status: PortStatus) {
-                state.lock.lock()
-                if state.resolved {
-                    state.lock.unlock()
-                    return
-                }
-                state.resolved = true
-                state.lock.unlock()
-                connection.cancel()
-                continuation.resume(returning: status)
-            }
-
-            connection.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    finish(.open)
-                case .failed, .waiting, .cancelled:
-                    finish(.closed)
-                default:
-                    break
-                }
-            }
-
-            queue.asyncAfter(deadline: .now() + 1.5) {
-                finish(.closed)
-            }
-
-            connection.start(queue: queue)
-        }
+        return .closed
     }
 }
 
@@ -2930,6 +2935,7 @@ enum PortStatus {
     case unknown
     case open
     case closed
+    case error
 
     var description: String {
         switch self {
@@ -2939,6 +2945,8 @@ enum PortStatus {
             return L("network.port_status.open")
         case .closed:
             return L("network.port_status.closed")
+        case .error:
+            return L("network.port_status.error")
         }
     }
 }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -594,7 +594,7 @@ final class WiredServerViewModel: ObservableObject {
                 "dscl . -create /Users/\(name) RealName 'Wired Server'",
                 "dscl . -create /Users/\(name) UniqueID \(uid)",
                 "dscl . -create /Users/\(name) PrimaryGroupID \(gid)",
-                "dscl . -create /Users/\(name) NFSHomeDirectory /Library/Wired3",
+                "dscl . -create /Users/\(name) NFSHomeDirectory /var/empty",
                 "dscl . -create /Users/\(name) IsHidden 1"
             ]
         }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -608,6 +608,11 @@ final class WiredServerViewModel: ObservableObject {
             // preventing admin (not in daemon group) from writing inside it.
             "rm -rf '/Library/Wired3/bin/.updates'",
             "chmod 755 /Library/Wired3/bin/wired3 2>/dev/null || true",
+            // etc/ uses staff group so the admin user can write config.ini
+            "chown \(name):staff /Library/Wired3/etc",
+            "chmod 775 /Library/Wired3/etc",
+            "chown \(name):staff /Library/Wired3/etc/config.ini 2>/dev/null || true",
+            "chmod 664 /Library/Wired3/etc/config.ini 2>/dev/null || true",
             "cp '\(tempURL.path)' '\(launchDaemonPlistPath)'",
             "chmod 644 '\(launchDaemonPlistPath)'",
             "chown root:wheel '\(launchDaemonPlistPath)'"

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -121,6 +121,10 @@ final class WiredServerViewModel: ObservableObject {
     @Published var isDaemonUserExists: Bool = false
     @Published var isDaemonGroupExists: Bool = false
 
+    var isServerActive: Bool {
+        installMode == .launchDaemon ? isDaemonRunning : isRunning
+    }
+
     private var lastDashboardLightRefresh = Date.distantPast
     private var lastDashboardHeavyRefresh = Date.distantPast
 
@@ -521,9 +525,11 @@ final class WiredServerViewModel: ObservableObject {
     }
 
     func startDaemon() {
+        // bootstrap registers the service (no-op if already registered).
+        // kickstart starts it regardless of RunAtLoad value.
+        let cmd = "launchctl bootstrap system '\(launchDaemonPlistPath)' 2>/dev/null; launchctl kickstart system/\(launchAgentLabel) 2>/dev/null; true"
         do {
-            try runPrivileged("launchctl bootstrap system '\(launchDaemonPlistPath)'",
-                              error: .launchDaemonInstallFailed("start"))
+            try runPrivileged(cmd, error: .launchDaemonInstallFailed("start"))
         } catch {
             publishError("Failed to start daemon: \(error.localizedDescription)")
         }
@@ -534,7 +540,7 @@ final class WiredServerViewModel: ObservableObject {
 
     func stopDaemon() {
         do {
-            try runPrivileged("launchctl bootout system/'\(launchAgentLabel)'",
+            try runPrivileged("launchctl bootout system/\(launchAgentLabel) 2>/dev/null; true",
                               error: .launchDaemonRemoveFailed("stop"))
         } catch {
             publishError("Failed to stop daemon: \(error.localizedDescription)")

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -335,19 +335,40 @@ final class WiredServerViewModel: ObservableObject {
             return
         }
 
-        // Wait for the process on a background thread, then read the temp file.
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            task.waitUntilExit()
-            writeHandle.closeFile()
-            let exitCode = task.terminationStatus
-            let data = (try? Data(contentsOf: tmpURL)) ?? Data()
-            let output = String(data: data, encoding: .utf8) ?? "(no output)"
-            try? FileManager.default.removeItem(at: tmpURL)
-            DispatchQueue.main.async {
-                self?.migrationOutput = output
-                self?.isMigrating = false
+        // Wait for the process using structured concurrency; cap at 5 minutes so
+        // isMigrating can never be stuck true forever if the subprocess hangs.
+        let didTimeout = await withTaskGroup(of: Bool.self) { group -> Bool in
+            group.addTask {
+                await withCheckedContinuation { cont in
+                    DispatchQueue.global(qos: .utility).async {
+                        task.waitUntilExit()
+                        cont.resume(returning: false)
+                    }
+                }
             }
+            group.addTask {
+                do {
+                    try await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000)
+                    task.terminate()
+                    return true
+                } catch {
+                    return false
+                }
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
         }
+
+        writeHandle.closeFile()
+        let data = (try? Data(contentsOf: tmpURL)) ?? Data()
+        let output = String(data: data, encoding: .utf8) ?? "(no output)"
+        try? FileManager.default.removeItem(at: tmpURL)
+
+        migrationOutput = didTimeout
+            ? (output.isEmpty ? "" : output + "\n") + L("error.migration_timed_out")
+            : output
+        isMigrating = false
     }
 
     func chooseBinaryPath() {

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -252,10 +252,11 @@ final class WiredServerViewModel: ObservableObject {
 
     func refreshAll() {
         bootstrapRuntimeIfNeeded()
-        // Refresh daemon status synchronously so isDaemonRunning is current before the
-        // auto-update guard below (the poll timer may not have fired yet since last start).
+        // Quick pgrep check to get a fresh isDaemonRunning before the auto-update guard.
+        // pgrep works without root; launchctl print system/... can return non-zero for
+        // non-root users even when the daemon is running, causing false negatives.
         if installMode == .launchDaemon {
-            refreshDaemonStatus()
+            isDaemonRunning = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).status == 0
         }
         var binaryWasUpdated = false
         // In LaunchDaemon mode: skip auto-update when daemon is running (launchd
@@ -272,7 +273,11 @@ final class WiredServerViewModel: ObservableObject {
             }
         }
         refreshInstallStatus()
-        refreshInstalledVersion()
+        // Skip version check when daemon is running: avoids launching wired3 --version
+        // concurrently with the daemon process (potential interference + main thread blocking).
+        if !isDaemonRunning {
+            refreshInstalledVersion()
+        }
         launchAtLogin = isLaunchAtLoginEnabled()
         loadConfig()
         refreshRunningStatus()
@@ -420,7 +425,9 @@ final class WiredServerViewModel: ObservableObject {
     // MARK: - LaunchDaemon / LaunchAgent Mode Switching
 
     func refreshDaemonStatus() {
-        isDaemonRunning = runProcess("/bin/launchctl", ["print", "system/\(launchAgentLabel)"]).status == 0
+        // pgrep works without root and is faster/more reliable than launchctl print for
+        // detecting whether the daemon process is actually running.
+        isDaemonRunning = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).status == 0
         isDaemonUserExists = runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
         isDaemonGroupExists = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
     }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -86,6 +86,11 @@ final class WiredServerViewModel: ObservableObject {
     @Published var showInitialPasswordAlert: Bool = false
     @Published var initialAdminPassword: String = ""
 
+    @Published var migrationSourcePath: String = ""
+    @Published var isMigrating: Bool = false
+    @Published var migrationOutput: String = ""
+    @Published var migrationOverwrite: Bool = false
+
     private let fileManager = FileManager.default
     private var pollTimer: Timer?
     private var process: Process?
@@ -258,6 +263,90 @@ final class WiredServerViewModel: ObservableObject {
         if panel.runModal() == .OK, let selected = panel.url?.path {
             filesDirectory = selected
             saveFilesSettings()
+        }
+    }
+
+    func chooseMigrationSource() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = L("common.choose")
+        panel.title = L("database.migration.source")
+        if panel.runModal() == .OK, let selected = panel.url?.path {
+            migrationSourcePath = selected
+            migrationOutput = ""
+        }
+    }
+
+    func runMigration() async {
+        guard !isMigrating else { return }
+        guard !migrationSourcePath.isEmpty else {
+            publishError(L("error.migration_no_source"))
+            return
+        }
+        guard !isRunning else {
+            publishError(L("error.migration_server_running"))
+            return
+        }
+
+        let executable = fileManager.isExecutableFile(atPath: installedBinaryPath) ? installedBinaryPath : binaryPath
+        guard fileManager.isExecutableFile(atPath: executable) else {
+            publishError(L("error.wired3_binary_missing"))
+            return
+        }
+
+        isMigrating = true
+
+        var args: [String] = [
+            "--working-directory", workingDirectory,
+            "--db", databasePath,
+            "--migrate-from", migrationSourcePath
+        ]
+        if migrationOverwrite {
+            args.append("--overwrite")
+        }
+
+        migrationOutput = ""
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: executable)
+        task.currentDirectoryURL = URL(fileURLWithPath: workingDirectory, isDirectory: true)
+        task.arguments = args
+
+        // Write subprocess output to a temp file to avoid pipe-buffering race conditions.
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wired3-migration-\(Int(Date().timeIntervalSince1970)).log")
+        FileManager.default.createFile(atPath: tmpURL.path, contents: nil)
+        guard let writeHandle = FileHandle(forWritingAtPath: tmpURL.path) else {
+            isMigrating = false
+            publishError(L("error.migration_failed"))
+            return
+        }
+        task.standardOutput = writeHandle
+        task.standardError = writeHandle
+
+        do {
+            try task.run()
+        } catch {
+            writeHandle.closeFile()
+            isMigrating = false
+            publishError("\(L("error.migration_failed")): \(error.localizedDescription)")
+            return
+        }
+
+        // Wait for the process on a background thread, then read the temp file.
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            task.waitUntilExit()
+            writeHandle.closeFile()
+            let exitCode = task.terminationStatus
+            let data = (try? Data(contentsOf: tmpURL)) ?? Data()
+            let output = String(data: data, encoding: .utf8) ?? "(no output)"
+            try? FileManager.default.removeItem(at: tmpURL)
+            DispatchQueue.main.async {
+                self?.migrationOutput = output
+                self?.isMigrating = false
+            }
         }
     }
 

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -100,6 +100,7 @@ final class WiredServerViewModel: ObservableObject {
     private let workingDirectoryKey = "wired3WorkingDirectory"
     private let installModeKey = "wired3InstallMode"
     private let daemonUserNameKey = "wired3DaemonUserName"
+    private let daemonGroupNameKey = "wired3DaemonGroupName"
     private let daemonStartAtBootKey = "wired3DaemonStartAtBoot"
     private let launchAgentLabel = "fr.read-write.wired3.server"
     private let launchDaemonPlistPath = "/Library/LaunchDaemons/fr.read-write.wired3.server.plist"
@@ -112,6 +113,7 @@ final class WiredServerViewModel: ObservableObject {
 
     @Published var installMode: ServerInstallMode = .launchAgent
     @Published var daemonUserName: String = "_wired"
+    @Published var daemonGroupName: String = "staff"
     @Published var daemonStartAtBoot: Bool = false
     @Published var isSwitchingMode: Bool = false
     @Published var modeSwitchStatus: String = ""
@@ -186,6 +188,7 @@ final class WiredServerViewModel: ObservableObject {
         let savedMode = UserDefaults.standard.string(forKey: "wired3InstallMode")
         self.installMode = ServerInstallMode(rawValue: savedMode ?? "") ?? .launchAgent
         self.daemonUserName = UserDefaults.standard.string(forKey: "wired3DaemonUserName") ?? "_wired"
+        self.daemonGroupName = UserDefaults.standard.string(forKey: "wired3DaemonGroupName") ?? "staff"
         self.daemonStartAtBoot = UserDefaults.standard.bool(forKey: "wired3DaemonStartAtBoot")
 
         if #available(macOS 13.0, *) {
@@ -404,6 +407,10 @@ final class WiredServerViewModel: ObservableObject {
         runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
     }
 
+    var daemonGroupExists: Bool {
+        runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
+    }
+
     var launchDaemonInstalled: Bool {
         fileManager.fileExists(atPath: launchDaemonPlistPath)
     }
@@ -415,6 +422,7 @@ final class WiredServerViewModel: ObservableObject {
 
     func saveDaemonSettings() {
         userDefaults.set(daemonUserName, forKey: daemonUserNameKey)
+        userDefaults.set(daemonGroupName, forKey: daemonGroupNameKey)
         userDefaults.set(daemonStartAtBoot, forKey: daemonStartAtBootKey)
     }
 
@@ -487,25 +495,40 @@ final class WiredServerViewModel: ObservableObject {
         }
     }
 
-    // One admin dialog: create user (optional) + chown + install plist
+    // One admin dialog: create group (optional) + create user (optional) + chown + install plist
     private func activateLaunchDaemon(name: String, createUser: Bool) throws {
         let tempURL = try writeDaemonPlistToTemp()
+        let group = daemonGroupName
+        let createGroup = !daemonGroupExists
 
         var cmds: [String] = []
+
+        if createGroup {
+            let gid = findFreeSystemGID()
+            cmds += [
+                "dscl . -create /Groups/\(group)",
+                "dscl . -create /Groups/\(group) PrimaryGroupID \(gid)",
+                "dscl . -create /Groups/\(group) Password '*'",
+                "dscl . -create /Groups/\(group) RealName 'Wired Server'"
+            ]
+        }
+
         if createUser {
             let uid = findFreeSystemUID()
+            let gid = groupGID(for: group)
             cmds += [
                 "dscl . -create /Users/\(name)",
                 "dscl . -create /Users/\(name) UserShell /usr/bin/false",
                 "dscl . -create /Users/\(name) RealName 'Wired Server'",
                 "dscl . -create /Users/\(name) UniqueID \(uid)",
-                "dscl . -create /Users/\(name) PrimaryGroupID 20",
+                "dscl . -create /Users/\(name) PrimaryGroupID \(gid)",
                 "dscl . -create /Users/\(name) NFSHomeDirectory /Library/Wired3",
                 "dscl . -create /Users/\(name) IsHidden 1"
             ]
         }
+
         cmds += [
-            "chown -R \(name):staff /Library/Wired3",
+            "chown -R \(name):\(group) /Library/Wired3",
             "cp '\(tempURL.path)' '\(launchDaemonPlistPath)'",
             "chmod 644 '\(launchDaemonPlistPath)'",
             "chown root:wheel '\(launchDaemonPlistPath)'"
@@ -520,7 +543,7 @@ final class WiredServerViewModel: ObservableObject {
         let cmds = [
             "launchctl bootout system/\(launchAgentLabel) 2>/dev/null",
             "rm -f '\(launchDaemonPlistPath)'",
-            "chown -R \(restoreUser):staff /Library/Wired3"
+            "chown -R \(restoreUser):staff /Library/Wired3"  // back to staff for LaunchAgent
         ].joined(separator: "; ")
 
         try runPrivileged(cmds, error: WiredServerError.launchDaemonRemoveFailed(""))
@@ -585,6 +608,27 @@ final class WiredServerViewModel: ObservableObject {
         })
         for uid in 400...499 where !used.contains(uid) { return uid }
         return 489
+    }
+
+    private func findFreeSystemGID() -> Int {
+        let output = runCommand("/usr/bin/dscl", [".", "-list", "/Groups", "PrimaryGroupID"])
+        let used = Set(output.components(separatedBy: .newlines).compactMap { line -> Int? in
+            let parts = line.split(separator: " ").map(String.init)
+            return parts.count >= 2 ? Int(parts.last ?? "") : nil
+        })
+        for gid in 400...499 where !used.contains(gid) { return gid }
+        return 488
+    }
+
+    private func groupGID(for group: String) -> Int {
+        let output = runCommand("/usr/bin/dscl", [".", "-read", "/Groups/\(group)", "PrimaryGroupID"])
+        for line in output.components(separatedBy: .newlines) {
+            let parts = line.split(separator: " ").map(String.init)
+            if parts.first == "PrimaryGroupID:", let gid = Int(parts.last ?? "") {
+                return gid
+            }
+        }
+        return 20  // fall back to staff GID
     }
 
     // MARK: - Wired 2.5 Migration

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -253,10 +253,15 @@ final class WiredServerViewModel: ObservableObject {
     func refreshAll() {
         bootstrapRuntimeIfNeeded()
         var binaryWasUpdated = false
-        do {
-            binaryWasUpdated = try synchronizeInstalledBinaryIfNeeded(allowInstallIfMissing: false)
-        } catch {
-            publishError("\(L("error.install_failed")): \(error.localizedDescription)")
+        // In LaunchDaemon mode, never auto-replace the binary while the daemon
+        // is running — launchd detects the file change and kills the process.
+        let canAutoUpdate = installMode == .launchAgent || !isDaemonRunning
+        if canAutoUpdate {
+            do {
+                binaryWasUpdated = try synchronizeInstalledBinaryIfNeeded(allowInstallIfMissing: false)
+            } catch {
+                publishError("\(L("error.install_failed")): \(error.localizedDescription)")
+            }
         }
         refreshInstallStatus()
         refreshInstalledVersion()

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -436,24 +436,16 @@ final class WiredServerViewModel: ObservableObject {
 
             switch mode {
             case .launchDaemon:
-                modeSwitchStatus = "Creating system user '\(daemonUserName)' (admin required)..."
-                if !daemonUserExists {
-                    try createDaemonUser(name: daemonUserName)
-                }
-                modeSwitchStatus = "Setting directory ownership..."
-                try setSystemDirectoryOwnership(user: daemonUserName)
-                modeSwitchStatus = "Installing LaunchDaemon..."
                 if launchAtLogin {
                     try configureLaunchAtLogin(enabled: false)
                     launchAtLogin = false
                 }
-                try installLaunchDaemon()
+                modeSwitchStatus = "Activating LaunchDaemon (one admin dialog)..."
+                try activateLaunchDaemon(name: daemonUserName, createUser: !daemonUserExists)
 
             case .launchAgent:
-                modeSwitchStatus = "Removing LaunchDaemon..."
-                try removeLaunchDaemon()
-                modeSwitchStatus = "Resetting directory ownership..."
-                try setSystemDirectoryOwnership(user: NSUserName())
+                modeSwitchStatus = "Deactivating LaunchDaemon (one admin dialog)..."
+                try deactivateLaunchDaemon(restoreUser: NSUserName())
             }
 
             installMode = mode
@@ -473,7 +465,7 @@ final class WiredServerViewModel: ObservableObject {
         userDefaults.set(enabled, forKey: daemonStartAtBootKey)
         guard launchDaemonInstalled else { return }
         do {
-            try installLaunchDaemon()
+            try reinstallDaemonPlist()
         } catch {
             publishError("Failed to update LaunchDaemon: \(error.localizedDescription)")
         }
@@ -495,42 +487,57 @@ final class WiredServerViewModel: ObservableObject {
         }
     }
 
-    private func createDaemonUser(name: String) throws {
-        let uid = findFreeSystemUID()
-        let script = """
-        do shell script "dscl . -create /Users/\(name) && \
-        dscl . -create /Users/\(name) UserShell /usr/bin/false && \
-        dscl . -create /Users/\(name) RealName 'Wired Server' && \
-        dscl . -create /Users/\(name) UniqueID \(uid) && \
-        dscl . -create /Users/\(name) PrimaryGroupID 20 && \
-        dscl . -create /Users/\(name) NFSHomeDirectory /Library/Wired3 && \
-        dscl . -create /Users/\(name) IsHidden 1" with administrator privileges
-        """
-        var errorInfo: NSDictionary?
-        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
-        if let err = errorInfo {
-            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
-            throw WiredServerError.daemonUserCreationFailed(msg)
+    // One admin dialog: create user (optional) + chown + install plist
+    private func activateLaunchDaemon(name: String, createUser: Bool) throws {
+        let tempURL = try writeDaemonPlistToTemp()
+
+        var cmds: [String] = []
+        if createUser {
+            let uid = findFreeSystemUID()
+            cmds += [
+                "dscl . -create /Users/\(name)",
+                "dscl . -create /Users/\(name) UserShell /usr/bin/false",
+                "dscl . -create /Users/\(name) RealName 'Wired Server'",
+                "dscl . -create /Users/\(name) UniqueID \(uid)",
+                "dscl . -create /Users/\(name) PrimaryGroupID 20",
+                "dscl . -create /Users/\(name) NFSHomeDirectory /Library/Wired3",
+                "dscl . -create /Users/\(name) IsHidden 1"
+            ]
         }
-        guard daemonUserExists else {
-            throw WiredServerError.daemonUserCreationFailed("User '\(name)' missing after creation")
-        }
+        cmds += [
+            "chown -R \(name):staff /Library/Wired3",
+            "cp '\(tempURL.path)' '\(launchDaemonPlistPath)'",
+            "chmod 644 '\(launchDaemonPlistPath)'",
+            "chown root:wheel '\(launchDaemonPlistPath)'"
+        ]
+
+        try runPrivileged(cmds.joined(separator: " && "),
+                          error: WiredServerError.launchDaemonInstallFailed(""))
     }
 
-    private func setSystemDirectoryOwnership(user: String) throws {
-        let script = """
-        do shell script "chown -R \(user):staff /Library/Wired3" with administrator privileges
-        """
-        var errorInfo: NSDictionary?
-        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
-        if let err = errorInfo {
-            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
-            throw WiredServerError.systemDirectoryOwnershipFailed(msg)
-        }
+    // One admin dialog: bootout + remove plist + chown back to current user
+    private func deactivateLaunchDaemon(restoreUser: String) throws {
+        let cmds = [
+            "launchctl bootout system/\(launchAgentLabel) 2>/dev/null",
+            "rm -f '\(launchDaemonPlistPath)'",
+            "chown -R \(restoreUser):staff /Library/Wired3"
+        ].joined(separator: "; ")
+
+        try runPrivileged(cmds, error: WiredServerError.launchDaemonRemoveFailed(""))
     }
 
-    private func installLaunchDaemon() throws {
-        let filesRoot = currentServerRootPath()
+    // Used by toggleDaemonStartAtBoot — updates existing plist with one admin dialog
+    private func reinstallDaemonPlist() throws {
+        let tempURL = try writeDaemonPlistToTemp()
+        let cmds = [
+            "cp '\(tempURL.path)' '\(launchDaemonPlistPath)'",
+            "chmod 644 '\(launchDaemonPlistPath)'",
+            "chown root:wheel '\(launchDaemonPlistPath)'"
+        ].joined(separator: " && ")
+        try runPrivileged(cmds, error: WiredServerError.launchDaemonInstallFailed(""))
+    }
+
+    private func writeDaemonPlistToTemp() throws -> URL {
         let plist: [String: Any] = [
             "Label": launchAgentLabel,
             "ProgramArguments": [
@@ -538,7 +545,7 @@ final class WiredServerViewModel: ObservableObject {
                 "--working-directory", workingDirectory,
                 "--db", databasePath,
                 "--config", configPath,
-                "--root", filesRoot
+                "--root", currentServerRootPath()
             ],
             "UserName": daemonUserName,
             "WorkingDirectory": workingDirectory,
@@ -547,33 +554,26 @@ final class WiredServerViewModel: ObservableObject {
             "StandardOutPath": logPath,
             "StandardErrorPath": logPath
         ]
-
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("fr.read-write.wired3.server.plist")
         guard (plist as NSDictionary).write(to: tempURL, atomically: true) else {
             throw WiredServerError.launchDaemonWriteFailed
         }
-
-        let script = """
-        do shell script "cp '\(tempURL.path)' '\(launchDaemonPlistPath)' && chmod 644 '\(launchDaemonPlistPath)' && chown root:wheel '\(launchDaemonPlistPath)'" with administrator privileges
-        """
-        var errorInfo: NSDictionary?
-        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
-        if let err = errorInfo {
-            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
-            throw WiredServerError.launchDaemonInstallFailed(msg)
-        }
+        return tempURL
     }
 
-    private func removeLaunchDaemon() throws {
-        let script = """
-        do shell script "launchctl bootout system/\(launchAgentLabel) 2>/dev/null; rm -f '\(launchDaemonPlistPath)'" with administrator privileges
-        """
+    private func runPrivileged(_ shellScript: String, error fallbackError: WiredServerError) throws {
+        let appleScript = "do shell script \"\(shellScript)\" with administrator privileges"
         var errorInfo: NSDictionary?
-        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
+        NSAppleScript(source: appleScript)?.executeAndReturnError(&errorInfo)
         if let err = errorInfo {
             let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
-            throw WiredServerError.launchDaemonRemoveFailed(msg)
+            // Re-throw with the actual message by matching the error type
+            switch fallbackError {
+            case .launchDaemonInstallFailed: throw WiredServerError.launchDaemonInstallFailed(msg)
+            case .launchDaemonRemoveFailed:  throw WiredServerError.launchDaemonRemoveFailed(msg)
+            default:                         throw fallbackError
+            }
         }
     }
 

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -438,7 +438,6 @@ final class WiredServerViewModel: ObservableObject {
             isDaemonGroupExists = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
             daemonAccountsVerified = true
         }
-        checkFDAFast()
     }
 
     func invalidateDaemonAccountsCache() {
@@ -452,21 +451,13 @@ final class WiredServerViewModel: ObservableObject {
         return path.hasPrefix("/Volumes/")
     }
 
-    // Non-privileged fast check: can our app process list the files directory?
-    // External volumes under /Volumes/ don't need FDA — they're accessible by all processes.
-    // This avoids the TCC.db read (which SIP protects even from root on macOS 14+).
-    private func checkFDAFast() {
-        guard filesDirectoryIsOnExternalVolume, !wired3HasFullDiskAccess else { return }
-        let path = currentServerRootPath()
-        var isDir: ObjCBool = false
-        if FileManager.default.fileExists(atPath: path, isDirectory: &isDir), isDir.boolValue {
-            wired3HasFullDiskAccess = true
-        }
-    }
-
     // Writes a shell script that tests whether the daemon user can list the files directory.
-    // TCC.db is protected by SIP on macOS 14+ and cannot be read even by root without special
-    // entitlements. A functional access test is the only reliable approach.
+    // Uses `su -m` rather than `sudo -u` so the subprocess runs with the daemon user's process
+    // identity — `sudo -u` launched from root inherits root's TCC context and can bypass macOS
+    // Removable Volumes / Full Disk Access checks that the actual daemon binary would hit.
+    // NOTE: This check is still approximate. If the server log shows "0 files, 0 dirs" after
+    // a binary update, re-grant FDA to /Library/Wired3/bin/wired3 in
+    // System Settings → Privacy & Security → Full Disk Access.
     private func writeFDACheckScript(filesDir: String, daemonUser: String, outputFile: String, to scriptPath: String) {
         let sh = """
         #!/bin/sh
@@ -474,9 +465,10 @@ final class WiredServerViewModel: ObservableObject {
         FILES='\(filesDir)'
         DUSER='\(daemonUser)'
 
-        # Test if the daemon user can read the files directory (Unix permissions check).
-        # External volumes don't require FDA — this tests actual access, not TCC grants.
-        if sudo -u "$DUSER" /bin/ls "$FILES" >/dev/null 2>&1; then
+        # Test whether the daemon user can read the files directory.
+        # su -m preserves the current environment but switches UID, giving a better TCC context
+        # than sudo -u (which inherits root's TCC grants).
+        if su -m "$DUSER" -c "/bin/ls \\"$FILES\\"" >/dev/null 2>&1; then
             echo 1 > "$OUT"
         else
             echo 0 > "$OUT"

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -252,6 +252,11 @@ final class WiredServerViewModel: ObservableObject {
 
     func refreshAll() {
         bootstrapRuntimeIfNeeded()
+        // Refresh daemon status synchronously so isDaemonRunning is current before the
+        // auto-update guard below (the poll timer may not have fired yet since last start).
+        if installMode == .launchDaemon {
+            refreshDaemonStatus()
+        }
         var binaryWasUpdated = false
         // In LaunchDaemon mode: skip auto-update when daemon is running (launchd
         // kills the process on binary replacement) and only attempt when we have

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -97,8 +97,14 @@ final class WiredServerViewModel: ObservableObject {
 
     private let userDefaults = UserDefaults.standard
     private let launchAtAppStartKey = "wiredswift.server.launchAtAppStart"
+    private let workingDirectoryKey = "wired3WorkingDirectory"
     private let launchAgentLabel = "fr.read-write.wired3.server"
     private let embeddedBinarySHAKey = "Wired3EmbeddedSHA256"
+
+    static let systemDataDirectory = "/Library/Wired3"
+
+    @Published var isSystemMigrating: Bool = false
+    @Published var systemMigrationStatus: String = ""
     private var lastDashboardLightRefresh = Date.distantPast
     private var lastDashboardHeavyRefresh = Date.distantPast
 
@@ -147,9 +153,23 @@ final class WiredServerViewModel: ObservableObject {
         .init(id: "yearly", title: L("database.events.retention.yearly"))
     ]
 
+    var legacyDataDirectory: String {
+        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("Wired3", isDirectory: true).path
+    }
+
+    var isUsingSystemDirectory: Bool {
+        workingDirectory == Self.systemDataDirectory
+    }
+
+    var systemMigrationAvailable: Bool {
+        !isUsingSystemDirectory && fileManager.fileExists(atPath: workingDirectory)
+    }
+
     init() {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        self.workingDirectory = appSupport.appendingPathComponent("Wired3", isDirectory: true).path
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let defaultDirectory = appSupport.appendingPathComponent("Wired3", isDirectory: true).path
+        self.workingDirectory = UserDefaults.standard.string(forKey: "wired3WorkingDirectory") ?? defaultDirectory
         self.launchServerAtAppStart = userDefaults.bool(forKey: launchAtAppStartKey)
 
         if #available(macOS 13.0, *) {
@@ -265,6 +285,104 @@ final class WiredServerViewModel: ObservableObject {
             saveFilesSettings()
         }
     }
+
+    // MARK: - System Data Directory Migration
+
+    func persistWorkingDirectory() {
+        userDefaults.set(workingDirectory, forKey: workingDirectoryKey)
+    }
+
+    func migrateToSystemDirectory() async {
+        guard !isSystemMigrating, systemMigrationAvailable else { return }
+        isSystemMigrating = true
+        systemMigrationStatus = "Preparing..."
+
+        let source = workingDirectory
+
+        do {
+            if isRunning {
+                systemMigrationStatus = "Stopping server..."
+                stopServer()
+                try await Task.sleep(for: .seconds(2))
+            }
+
+            systemMigrationStatus = "Creating system directory (admin required)..."
+            try createSystemDataDirectory()
+
+            systemMigrationStatus = "Copying data..."
+            try copyDirectoryContents(from: source, to: Self.systemDataDirectory)
+
+            systemMigrationStatus = "Verifying database integrity..."
+            let newDBPath = URL(fileURLWithPath: Self.systemDataDirectory)
+                .appendingPathComponent("wired3.db").path
+            if fileManager.fileExists(atPath: newDBPath) {
+                try verifySystemDatabaseIntegrity(at: newDBPath)
+            }
+
+            systemMigrationStatus = "Switching to system directory..."
+            workingDirectory = Self.systemDataDirectory
+            persistWorkingDirectory()
+            binaryPath = installedBinaryPath
+
+            if launchAtLogin {
+                try configureLaunchAtLogin(enabled: true)
+            }
+
+            systemMigrationStatus = "Done. Backup preserved at: \(source)"
+            refreshAll()
+        } catch {
+            systemMigrationStatus = "Migration failed: \(error.localizedDescription)"
+            publishError("Data migration failed: \(error.localizedDescription)")
+        }
+
+        isSystemMigrating = false
+    }
+
+    private func createSystemDataDirectory() throws {
+        let username = NSUserName()
+        let script = """
+        do shell script "mkdir -p /Library/Wired3 && chown \(username):staff /Library/Wired3 && chmod 755 /Library/Wired3" with administrator privileges
+        """
+        var errorInfo: NSDictionary?
+        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
+        if let err = errorInfo {
+            let msg = (err[NSAppleScript.errorMessage] as? String) ?? "Unknown error"
+            throw WiredServerError.systemDirectoryCreationFailed(msg)
+        }
+        guard fileManager.fileExists(atPath: Self.systemDataDirectory) else {
+            throw WiredServerError.systemDirectoryCreationFailed("Directory missing after creation")
+        }
+    }
+
+    private func copyDirectoryContents(from source: String, to destination: String) throws {
+        let sourceURL = URL(fileURLWithPath: source)
+        let destURL = URL(fileURLWithPath: destination)
+        let items = try fileManager.contentsOfDirectory(at: sourceURL, includingPropertiesForKeys: nil)
+        for item in items {
+            let dest = destURL.appendingPathComponent(item.lastPathComponent)
+            if fileManager.fileExists(atPath: dest.path) {
+                try fileManager.removeItem(at: dest)
+            }
+            try fileManager.copyItem(at: item, to: dest)
+        }
+    }
+
+    private func verifySystemDatabaseIntegrity(at path: String) throws {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            throw WiredServerError.systemMigrationFailed("Cannot open database for verification")
+        }
+        defer { sqlite3_close(db) }
+        var stmt: OpaquePointer?
+        sqlite3_prepare_v2(db, "PRAGMA integrity_check", -1, &stmt, nil)
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_step(stmt) == SQLITE_ROW,
+           let result = sqlite3_column_text(stmt, 0),
+           String(cString: result) == "ok" { return }
+        throw WiredServerError.systemMigrationFailed("Database integrity check failed")
+    }
+
+    // MARK: - Wired 2.5 Migration
 
     func chooseMigrationSource() {
         let panel = NSOpenPanel()
@@ -2180,6 +2298,8 @@ enum WiredServerError: LocalizedError, Equatable {
     case databaseNotInitialized
     case databaseStatementFailed(String)
     case databaseExecutionFailed(String)
+    case systemDirectoryCreationFailed(String)
+    case systemMigrationFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -2203,6 +2323,10 @@ enum WiredServerError: LocalizedError, Equatable {
             return "\(L("error.sql_prepare_failed")): \(sql)"
         case .databaseExecutionFailed(let sql):
             return "\(L("error.sql_execution_failed")): \(sql)"
+        case .systemDirectoryCreationFailed(let msg):
+            return "Failed to create system data directory: \(msg)"
+        case .systemMigrationFailed(let msg):
+            return "Data migration failed: \(msg)"
         }
     }
 }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -753,38 +753,59 @@ final class WiredServerViewModel: ObservableObject {
 
     // MARK: - Privileged execution
 
-    private func runPrivileged(_ shellScript: String, error fallbackError: WiredServerError) throws {
-        // 1. Try Touch ID — if available and a credential is stored
+    // Session cache: password stays valid for 30 s (like sudo timeout)
+    private var sessionPassword: String?
+    private var sessionPasswordExpiry: Date = .distantPast
+
+    private func resolveAdminCredential() -> String? {
+        // 1. In-memory session cache (avoids repeated Touch ID for multi-step operations)
+        if let cached = sessionPassword, Date() < sessionPasswordExpiry {
+            return cached
+        }
+        sessionPassword = nil
+
+        // 2. Keychain via Touch ID
         if BiometricCredentialStore.isAvailable && BiometricCredentialStore.hasStoredCredential {
             if let pw = BiometricCredentialStore.load(reason: L("touchid.reason")) {
-                let succeeded = executePrivileged(shellScript: shellScript, password: pw)
-                if succeeded {
-                    return
-                }
-                // Wrong stored password — clear it and fall through to manual dialog
-                BiometricCredentialStore.delete()
-                hasTouchIDCredential = false
+                cacheSessionPassword(pw)
+                return pw
             }
-            // User cancelled Touch ID — fall through to manual dialog
         }
 
-        // 2. Custom password dialog (so we capture the password for optional Touch ID save)
-        guard let pw = promptAdminPassword() else {
+        // 3. Custom password dialog
+        guard let pw = promptAdminPassword() else { return nil }
+        cacheSessionPassword(pw)
+        return pw
+    }
+
+    private func cacheSessionPassword(_ password: String) {
+        sessionPassword = password
+        sessionPasswordExpiry = Date().addingTimeInterval(30)
+    }
+
+    private func runPrivileged(_ shellScript: String, error fallbackError: WiredServerError) throws {
+        guard let pw = resolveAdminCredential() else {
             throw fallbackError
         }
 
         let succeeded = executePrivileged(shellScript: shellScript, password: pw)
-        guard succeeded else {
+        if !succeeded {
+            // Wrong password — clear cache and Keychain entry if it was from Touch ID
+            sessionPassword = nil
+            if BiometricCredentialStore.hasStoredCredential {
+                BiometricCredentialStore.delete()
+                hasTouchIDCredential = false
+            }
             let msg = L("touchid.wrong_password")
             switch fallbackError {
-            case .launchDaemonInstallFailed: throw WiredServerError.launchDaemonInstallFailed(msg)
-            case .launchDaemonRemoveFailed:  throw WiredServerError.launchDaemonRemoveFailed(msg)
+            case .launchDaemonInstallFailed:     throw WiredServerError.launchDaemonInstallFailed(msg)
+            case .launchDaemonRemoveFailed:      throw WiredServerError.launchDaemonRemoveFailed(msg)
             case .systemDirectoryCreationFailed: throw WiredServerError.systemDirectoryCreationFailed(msg)
-            default:                         throw fallbackError
+            default:                             throw fallbackError
             }
         }
 
-        // 3. Offer to save for Touch ID (only if available and not already stored)
+        // Offer to save for Touch ID after first successful manual entry
         if BiometricCredentialStore.isAvailable && !BiometricCredentialStore.hasStoredCredential {
             offerTouchIDSave(password: pw)
         }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -1532,9 +1532,14 @@ final class WiredServerViewModel: ObservableObject {
 
     /// Reload the identity fingerprint from the key file on disk.
     func refreshIdentityFingerprint() {
-        let keyPath = URL(fileURLWithPath: workingDirectory)
-            .appendingPathComponent("wired-identity.key").path
-        identityFingerprint = ServerIdentity.fingerprintFromKeyFile(at: keyPath) ?? ""
+        let base = URL(fileURLWithPath: workingDirectory)
+        let pubPath = base.appendingPathComponent("wired-identity.pub").path
+        let keyPath = base.appendingPathComponent("wired-identity.key").path
+        // Prefer the world-readable public key file (written by the daemon alongside the private key).
+        // Fall back to reading the private key directly when running as the same user as the server.
+        identityFingerprint = ServerIdentity.fingerprintFromPublicKeyFile(at: pubPath)
+            ?? ServerIdentity.fingerprintFromKeyFile(at: keyPath)
+            ?? ""
     }
 
     /// Opens a save panel so the admin can export the server's identity public key.

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -411,6 +411,33 @@ final class WiredServerViewModel: ObservableObject {
         runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
     }
 
+    // MARK: - External Volume / FDA
+
+    var filesDirectoryIsOnExternalVolume: Bool {
+        let path = currentServerRootPath()
+        let url = URL(fileURLWithPath: path)
+        guard let values = try? url.resourceValues(forKeys: [.volumeURLKey]),
+              let volumeURL = values.volumeURL else { return false }
+        return volumeURL.path.hasPrefix("/Volumes/")
+    }
+
+    // Checks FDA for the wired3 binary via the TCC database (readable only with FDA granted)
+    var wired3HasFullDiskAccess: Bool {
+        let tcc = "/Library/Application Support/com.apple.TCC/TCC.db"
+        guard FileManager.default.isReadableFile(atPath: tcc) else { return false }
+        // TCC.db is readable — query for the wired3 binary
+        let binaryPath = installedBinaryPath
+        let output = runCommand("/usr/bin/sqlite3", [tcc,
+            "SELECT allowed FROM access WHERE service='kTCCServiceSystemPolicyAllFiles' AND client='\(binaryPath)' LIMIT 1"])
+        return output.trimmingCharacters(in: .whitespacesAndNewlines) == "1"
+    }
+
+    func openFullDiskAccessSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
     var launchDaemonInstalled: Bool {
         fileManager.fileExists(atPath: launchDaemonPlistPath)
     }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -2171,6 +2171,45 @@ final class WiredServerViewModel: ObservableObject {
         sendSignal(SIGUSR1)
     }
 
+    /// Send SIGUSR2 to the running wired3 process to trigger an immediate database snapshot.
+    @discardableResult
+    private func sendSnapshotSignal() -> Bool {
+        sendSignal(SIGUSR2)
+    }
+
+    func triggerSnapshotNow() {
+        if installMode == .launchDaemon {
+            // Daemon runs as a different OS user — kill() is rejected by macOS.
+            // Use launchctl, which routes through the system domain and accepts
+            // the signal with root privileges.
+            do {
+                try runPrivileged(
+                    "launchctl kill SIGUSR2 system/\(launchAgentLabel)",
+                    error: .launchDaemonInstallFailed("snapshot")
+                )
+                statusMessage = L("status.snapshot_triggered")
+            } catch {
+                statusMessage = L("status.snapshot_failed")
+            }
+        } else {
+            guard hasPIDFile else {
+                statusMessage = L("status.snapshot_not_running")
+                return
+            }
+            if sendSnapshotSignal() {
+                statusMessage = L("status.snapshot_triggered")
+            } else {
+                statusMessage = L("status.snapshot_failed")
+            }
+        }
+    }
+
+    var hasPIDFile: Bool {
+        let pidPath = URL(fileURLWithPath: workingDirectory)
+            .appendingPathComponent("wired3.pid").path
+        return FileManager.default.fileExists(atPath: pidPath)
+    }
+
     /// Read the PID file and send `signal` to the running wired3 process.
     @discardableResult
     private func sendSignal(_ signal: Int32) -> Bool {

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -1015,6 +1015,15 @@ final class WiredServerViewModel: ObservableObject {
             config["server", "files"] = filesDirectory
             config["settings", "reindex_interval"] = String(filesReindexInterval)
         }
+        // In daemon mode the --root path is baked into the LaunchDaemon plist;
+        // regenerate it whenever the files directory changes.
+        if installMode == .launchDaemon && launchDaemonInstalled {
+            do {
+                try reinstallDaemonPlist()
+            } catch {
+                publishError("Failed to update LaunchDaemon plist: \(error.localizedDescription)")
+            }
+        }
         if launchAtLogin {
             do {
                 try configureLaunchAtLogin(enabled: true)

--- a/Sources/WiredSwift/Core/WiredProtocolSpec.swift
+++ b/Sources/WiredSwift/Core/WiredProtocolSpec.swift
@@ -2,7 +2,21 @@ import Foundation
 
 public enum WiredProtocolSpec {
     public static func bundledSpecURL() -> URL? {
-        Bundle.module.url(forResource: "wired", withExtension: "xml")
+        // Bundle.module crashes with assertionFailure when the SPM .bundle directory
+        // is missing from the app package. Search manually instead, then fall back to
+        // Bundle.main.resourceURL where the build script also copies wired.xml directly.
+        let candidates: [URL?] = [
+            Bundle.main.resourceURL?.appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+            Bundle.main.executableURL?.deletingLastPathComponent()
+                .appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+        ]
+        for case let bundleURL? in candidates {
+            if let b = Bundle(url: bundleURL),
+               let url = b.url(forResource: "wired", withExtension: "xml") {
+                return url
+            }
+        }
+        return Bundle.main.url(forResource: "wired", withExtension: "xml")
     }
 
     public static func bundledSpec() -> P7Spec? {

--- a/Sources/WiredSwift/Core/WiredProtocolSpec.swift
+++ b/Sources/WiredSwift/Core/WiredProtocolSpec.swift
@@ -3,12 +3,21 @@ import Foundation
 public enum WiredProtocolSpec {
     public static func bundledSpecURL() -> URL? {
         // Bundle.module crashes with assertionFailure when the SPM .bundle directory
-        // is missing from the app package. Search manually instead, then fall back to
-        // Bundle.main.resourceURL where the build script also copies wired.xml directly.
+        // is missing from the app package. Search manually instead.
+        //
+        // Path reasoning:
+        //  - Production app:    Bundle.main.resourceURL / Contents/Resources
+        //  - Linux swift test:  executable is in .build/debug/, bundle is beside it
+        //  - macOS swift test:  Bundle.main.bundleURL is the .xctest package;
+        //                       its parent directory is .build/debug/ where the
+        //                       WiredSwift_WiredSwift.bundle actually lives
+        let bundleName = "WiredSwift_WiredSwift"
         let candidates: [URL?] = [
-            Bundle.main.resourceURL?.appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+            Bundle.main.resourceURL?.appendingPathComponent("\(bundleName).bundle"),
             Bundle.main.executableURL?.deletingLastPathComponent()
-                .appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+                .appendingPathComponent("\(bundleName).bundle"),
+            Bundle.main.bundleURL.deletingLastPathComponent()
+                .appendingPathComponent("\(bundleName).bundle"),
         ]
         for case let bundleURL? in candidates {
             if let b = Bundle(url: bundleURL),

--- a/Sources/WiredSwift/Crypto/ServerIdentity.swift
+++ b/Sources/WiredSwift/Crypto/ServerIdentity.swift
@@ -77,6 +77,17 @@ public class ServerIdentity: ServerIdentityProvider {
             privateKey = pk
         }
 
+        // Write a world-readable public key companion file so the GUI (running as the logged-in user)
+        // can display the fingerprint without needing to read the restricted private key file.
+        let pubPath = (workingDirectory as NSString).appendingPathComponent("wired-identity.pub")
+        try? privateKey.publicKey.rawRepresentation.write(
+            to: URL(fileURLWithPath: pubPath), options: .atomic
+        )
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o644 as NSNumber],
+            ofItemAtPath: pubPath
+        )
+
         fingerprint = ServerIdentity.computeFingerprint(privateKey.publicKey.rawRepresentation)
     }
 
@@ -116,6 +127,18 @@ public class ServerIdentity: ServerIdentityProvider {
             return nil
         }
         let fp = computeFingerprint(pk.publicKey.rawRepresentation)
+        return format(fingerprint: fp)
+    }
+
+    /// Load the raw P256 public key from a companion .pub file (world-readable, 0644)
+    /// and return its formatted fingerprint, or nil if the file is missing or invalid.
+    /// Prefer this over fingerprintFromKeyFile when running as a different user than the daemon.
+    public static func fingerprintFromPublicKeyFile(at path: String) -> String? {
+        guard let rawData = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let pk = try? P256.Signing.PublicKey(rawRepresentation: rawData) else {
+            return nil
+        }
+        let fp = computeFingerprint(pk.rawRepresentation)
         return format(fingerprint: fp)
     }
 

--- a/Sources/WiredSwift/Network/Connection.swift
+++ b/Sources/WiredSwift/Network/Connection.swift
@@ -31,6 +31,10 @@ public protocol ConnectionDelegate: class {
 
     func connectionDidLogin(connection: Connection, message: P7Message)
     func connectionDidReceivePriviledges(connection: Connection, message: P7Message)
+    /// Called when the server signals that the account was migrated from Wired 2.5 and the
+    /// user must set a new password before continuing.  The client should present a password-
+    /// change dialog and send `wired.account.change_password` before doing anything else.
+    func connectionRequiresPasswordChange(connection: Connection)
 }
 
 public protocol ClientInfoDelegate: class {
@@ -51,6 +55,7 @@ public extension ConnectionDelegate {
     func connectionDidSendMessage(connection: Connection, message: P7Message) { }
     func connectionDidLogin(connection: Connection, message: P7Message) { }
     func connectionDidReceivePriviledges(connection: Connection, message: P7Message) { }
+    func connectionRequiresPasswordChange(connection: Connection) { }
 }
 
 public extension ClientInfoDelegate {
@@ -552,9 +557,14 @@ open class Connection: NSObject {
             self.userID = uid
         }
 
+        let needsPasswordChange = response.bool(forField: "wired.user.password_must_change") ?? false
+
         DispatchQueue.main.async {
             for d in self.delegates {
                 d.connectionDidLogin(connection: self, message: response)
+                if needsPasswordChange {
+                    d.connectionRequiresPasswordChange(connection: self)
+                }
             }
         }
 

--- a/Sources/WiredSwift/P7/P7Socket.swift
+++ b/Sources/WiredSwift/P7/P7Socket.swift
@@ -300,6 +300,10 @@ public class P7Socket: NSObject {
 
     public var connected: Bool = false
     public var passwordProvider: SocketPasswordDelegate?
+    /// Set to `true` after a successful key exchange in which the server indicated that the
+    /// account uses a legacy SHA1 password hash (migrated from Wired 2.5).  Consumers should
+    /// treat this as a signal to force the user to change their password after login.
+    public var isLegacyAuth: Bool = false
 
     /// Server-side: provides the persistent identity key for TOFU signing.
     /// Set before calling `accept()` on the server side.
@@ -1295,12 +1299,9 @@ public class P7Socket: NSObject {
             throw P7SocketError.keyExchangeFailed(message)
         }
 
-        if self.password == nil || self.password?.isEmpty == true {
-            self.password = "".sha256()
-        } else {
-            self.password = self.password.sha256()
-        }
-        let passwordData = self.password.data(using: .utf8)!
+        // Keep the raw password for deferred hashing: the hash algorithm (SHA1 vs SHA256) is
+        // determined only after receiving the server_challenge in step 4.
+        let rawPassword: String = self.password ?? ""
 
         guard let ecdsa = ECDSA(privateKey: derivedKey) else {
             let message = "Cannot init ECDSA"
@@ -1336,7 +1337,16 @@ public class P7Socket: NSObject {
         }
 
         // Step 5: derive base_hash
-        // If server provided a per-user stored_salt, the expected stored hash is SHA256(storedSalt || SHA256(plain)).
+        // Check whether the server flagged this as a legacy SHA1 account (migrated from Wired 2.5).
+        // If so, hash the password with SHA1; otherwise use SHA256.
+        let isLegacy = challengeMsg.bool(forField: "p7.encryption.legacy_password") ?? false
+        let hashedPassword: String = isLegacy
+            ? (rawPassword.isEmpty ? "".sha1() : rawPassword.sha1())
+            : (rawPassword.isEmpty ? "".sha256() : rawPassword.sha256())
+        let passwordData = hashedPassword.data(using: .utf8)!
+        if isLegacy { self.isLegacyAuth = true }
+
+        // If server provided a per-user stored_salt, derive: SHA256(storedSalt || hashedPassword.utf8).
         // We replicate that derivation so both sides produce the same proof value.
         let baseHashData: Data
         if let encryptedStoredSalt = challengeMsg.data(forField: "p7.encryption.stored_salt"),
@@ -1536,7 +1546,12 @@ public class P7Socket: NSObject {
         // Per-user stored salt for base_hash derivation (nil = not yet assigned)
         let storedSalt = self.passwordProvider?.passwordSaltForUsername(username: self.username)
 
-        // Step 3: send server_challenge {encrypted stored_salt}
+        // Detect legacy SHA1 accounts migrated from Wired 2.5.
+        // A stored password that is exactly 40 hex chars and has no per-user salt is a SHA1 hash.
+        let isLegacyUser = (storedSalt == nil || storedSalt?.isEmpty == true)
+                         && (self.password?.count == 40)
+
+        // Step 3: send server_challenge {encrypted stored_salt [, legacy_password flag]}
         let storedSaltBytes: Data = storedSalt.flatMap { $0.isEmpty ? nil : $0.data(using: .utf8) } ?? Data()
         guard let encryptedStoredSalt = try? self.sslCipher.encrypt(data: storedSaltBytes) else {
             let message = "Cannot encrypt stored_salt for server_challenge"
@@ -1545,6 +1560,9 @@ public class P7Socket: NSObject {
         }
         let challengeMsg = P7Message(withName: "p7.encryption.server_challenge", spec: self.spec)
         challengeMsg.addParameter(field: "p7.encryption.stored_salt", value: encryptedStoredSalt)
+        if isLegacyUser {
+            challengeMsg.addParameter(field: "p7.encryption.legacy_password", value: true)
+        }
         if !self.write(challengeMsg) {
             let message = "Failed to send server_challenge"
             Logger.error(message)
@@ -1604,6 +1622,10 @@ public class P7Socket: NSObject {
             Logger.error(message)
             throw P7SocketError.keyExchangeFailed(message)
         }
+
+        // Record whether this session used legacy SHA1 auth so the application layer can
+        // skip the redundant wired.send_login password check and prompt for a password upgrade.
+        if isLegacyUser { self.isLegacyAuth = true }
 
         // Step 7: send acknowledge {server ECDSA signature}
         guard let ecdsa2 = ECDSA(privateKey: derivedKey) else {

--- a/Sources/WiredSwift/P7/P7Socket.swift
+++ b/Sources/WiredSwift/P7/P7Socket.swift
@@ -33,6 +33,10 @@ public protocol SocketPasswordDelegate: AnyObject {
     /// Returns the per-user stored salt (hex string) used to derive the base hash in key exchange.
     /// Return nil if the account has not yet been assigned a stored salt.
     func passwordSaltForUsername(username: String) -> String?
+    /// Returns whether the account was migrated from Wired 2.5 and still holds a SHA1 password hash.
+    /// The server uses this to signal the client that it must re-hash with SHA1 for this session
+    /// and that a password upgrade is required.
+    func isLegacyUser(username: String) -> Bool
 }
 
 /// Provides the server's persistent identity key for TOFU (Trust On First Use).
@@ -1546,10 +1550,8 @@ public class P7Socket: NSObject {
         // Per-user stored salt for base_hash derivation (nil = not yet assigned)
         let storedSalt = self.passwordProvider?.passwordSaltForUsername(username: self.username)
 
-        // Detect legacy SHA1 accounts migrated from Wired 2.5.
-        // A stored password that is exactly 40 hex chars and has no per-user salt is a SHA1 hash.
-        let isLegacyUser = (storedSalt == nil || storedSalt?.isEmpty == true)
-                         && (self.password?.count == 40)
+        // Detect legacy SHA1 accounts migrated from Wired 2.5 via the dedicated DB flag.
+        let isLegacyUser = self.passwordProvider?.isLegacyUser(username: self.username) ?? false
 
         // Step 3: send server_challenge {encrypted stored_salt [, legacy_password flag]}
         let storedSaltBytes: Data = storedSalt.flatMap { $0.isEmpty ? nil : $0.data(using: .utf8) } ?? Data()

--- a/Sources/WiredSwift/P7/P7Spec.swift
+++ b/Sources/WiredSwift/P7/P7Spec.swift
@@ -133,6 +133,10 @@ public class P7Spec: NSObject, XMLParserDelegate {
     <p7:field name="p7.encryption.server_identity_sig" id="20" type="data" />
     <!-- New in P7 v1.3: if true, clients MUST reject connections when the server identity key changes -->
     <p7:field name="p7.encryption.strict_identity" id="21" type="bool" />
+    <!-- New in P7 v1.4: if true, the account was migrated from Wired 2.5 and uses a SHA1 password hash.
+         The client must hash its password with SHA1 instead of SHA256 for this session, and
+         will be required to set a new password immediately after login. -->
+    <p7:field name="p7.encryption.legacy_password" id="22" type="bool" />
 
     <p7:field name="p7.compatibility_check.specification" id="15" type="string" />
     <p7:field name="p7.compatibility_check.status" id="16" type="bool" />
@@ -188,9 +192,11 @@ public class P7Spec: NSObject, XMLParserDelegate {
       <p7:parameter field="p7.encryption.username"   use="required" />
     </p7:message>
 
-    <!-- New in P7 v1.2: server sends per-user stored salt (encrypted) before client proves password -->
+    <!-- New in P7 v1.2: server sends per-user stored salt (encrypted) before client proves password.
+         In P7 v1.4 the optional legacy_password flag indicates the account uses a SHA1 hash. -->
     <p7:message name="p7.encryption.server_challenge" id="11">
       <p7:parameter field="p7.encryption.stored_salt" use="required" />
+      <p7:parameter field="p7.encryption.legacy_password" />
     </p7:message>
 
     <p7:message name="p7.compatibility_check.specification" id="8">

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -264,6 +264,14 @@
             <p7:enum name="wired.user.state.disconnecting" value="4" version="2.0" />
         </p7:field>
 
+        <p7:field name="wired.user.password_must_change" type="bool" id="3016" version="3.2">
+            <p7:documentation>
+                If true, the account was migrated from Wired 2.5 and only a legacy SHA1 password
+                hash is stored. The client must prompt the user to set a new password immediately
+                after login so that the account is upgraded to a proper SHA256+salt credential.
+            </p7:documentation>
+        </p7:field>
+
         <p7:field name="wired.chat.id" type="uint32" id="4000" version="2.0">
             <p7:documentation>
                 Identification number of a chat. This number should be created when each chat is
@@ -1684,10 +1692,12 @@
 
         <p7:message name="wired.login" id="2005" version="2.0">
             <p7:documentation>
-                Login reply.
+                Login reply. If [field:wired.user.password_must_change] is true, the client must
+                immediately prompt the user to set a new password via [message:wired.account.change_password].
             </p7:documentation>
             <p7:parameter field="wired.transaction" version="2.0" />
             <p7:parameter field="wired.user.id" use="required" version="2.0" />
+            <p7:parameter field="wired.user.password_must_change" version="3.2" />
         </p7:message>
         
         <p7:message name="wired.banned" id="2006" version="2.0">

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -1871,7 +1871,7 @@
                 One entry in the offline user list sent by the server after login.
                 Each message represents a registered account that is not currently connected.
             </p7:documentation>
-            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
             <p7:parameter field="wired.user.nick" version="3.0" />
         </p7:message>
 
@@ -1896,7 +1896,7 @@
                 Required before sending an end-to-end encrypted offline message.
             </p7:documentation>
             <p7:parameter field="wired.transaction" version="3.0" />
-            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.user.public_key" id="3015" version="3.0">
@@ -1905,7 +1905,7 @@
                 If wired.user.public_key is absent, the user has not registered a key.
             </p7:documentation>
             <p7:parameter field="wired.transaction" version="3.0" />
-            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
             <p7:parameter field="wired.user.public_key" version="3.0" />
         </p7:message>
 

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -349,6 +349,16 @@
                 Display nick of the sender at delivery time, derived from last_nick in the server database.
             </p7:documentation>
         </p7:field>
+        <p7:field name="wired.user.public_key" type="data" id="5014" version="3.0">
+            <p7:documentation>
+                X25519 public key for end-to-end encrypted offline messages (raw 32-byte representation).
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.message.offline.encrypted" type="bool" id="5015" version="3.0">
+            <p7:documentation>
+                If true, the message body is an ECIES-encrypted blob rather than plaintext.
+            </p7:documentation>
+        </p7:field>
 
         <p7:field name="wired.board.board" type="string" id="6000" version="2.0">
             <p7:documentation>
@@ -1871,6 +1881,34 @@
             </p7:documentation>
         </p7:message>
 
+        <p7:message name="wired.user.set_public_key" id="3013" version="3.0">
+            <p7:documentation>
+                Upload the client's X25519 public key for end-to-end encrypted offline messaging.
+                The server stores the key associated with the authenticated user's account.
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.0" />
+            <p7:parameter field="wired.user.public_key" use="required" version="3.0" />
+        </p7:message>
+
+        <p7:message name="wired.user.get_public_key" id="3014" version="3.0">
+            <p7:documentation>
+                Request the X25519 public key of another user by login name.
+                Required before sending an end-to-end encrypted offline message.
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.0" />
+            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+        </p7:message>
+
+        <p7:message name="wired.user.public_key" id="3015" version="3.0">
+            <p7:documentation>
+                Server response to wired.user.get_public_key.
+                If wired.user.public_key is absent, the user has not registered a key.
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.0" />
+            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.user.public_key" version="3.0" />
+        </p7:message>
+
         <p7:message name="wired.chat.join_chat" id="4000" version="2.0">
             <p7:documentation>
                 Join chat message.
@@ -2231,6 +2269,7 @@
             <p7:parameter field="wired.transaction" version="3.0" />
             <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
             <p7:parameter field="wired.message.message" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.encrypted" use="optional" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.message.offline_message" id="5011" version="3.0">
@@ -2242,6 +2281,7 @@
             <p7:parameter field="wired.message.message" use="required" version="3.0" />
             <p7:parameter field="wired.message.offline.date" use="required" version="3.0" />
             <p7:parameter field="wired.message.offline.sender_nick" use="optional" version="3.0" />
+            <p7:parameter field="wired.message.offline.encrypted" use="optional" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.board.get_boards" id="6000" version="2.0">

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -344,6 +344,11 @@
                 Original timestamp when the offline message was sent.
             </p7:documentation>
         </p7:field>
+        <p7:field name="wired.message.offline.sender_nick" type="string" id="5013" version="3.0">
+            <p7:documentation>
+                Display nick of the sender at delivery time, derived from last_nick in the server database.
+            </p7:documentation>
+        </p7:field>
 
         <p7:field name="wired.board.board" type="string" id="6000" version="2.0">
             <p7:documentation>
@@ -2236,6 +2241,7 @@
             <p7:parameter field="wired.message.offline.sender_login" use="required" version="3.0" />
             <p7:parameter field="wired.message.message" use="required" version="3.0" />
             <p7:parameter field="wired.message.offline.date" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.sender_nick" use="optional" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.board.get_boards" id="6000" version="2.0">

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -272,6 +272,13 @@
             </p7:documentation>
         </p7:field>
 
+        <p7:field name="wired.user.is_offline" type="bool" id="3017" version="3.0">
+            <p7:documentation>
+                If true, this user entry represents a registered but currently disconnected account,
+                sent as part of the offline user list after login.
+            </p7:documentation>
+        </p7:field>
+
         <p7:field name="wired.chat.id" type="uint32" id="4000" version="2.0">
             <p7:documentation>
                 Identification number of a chat. This number should be created when each chat is
@@ -318,6 +325,23 @@
         <p7:field name="wired.message.broadcast" type="string" id="5001" version="2.0">
             <p7:documentation>
                 A public broadcast message.
+            </p7:documentation>
+        </p7:field>
+
+        <p7:field name="wired.message.offline.sender_login" type="string" id="5010" version="3.0">
+            <p7:documentation>
+                Login name of the sender of an offline message, included when the server delivers
+                a stored offline message to the recipient upon login.
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.message.offline.recipient_login" type="string" id="5011" version="3.0">
+            <p7:documentation>
+                Login name of the intended recipient when sending an offline message.
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.message.offline.date" type="date" id="5012" version="3.0">
+            <p7:documentation>
+                Original timestamp when the offline message was sent.
             </p7:documentation>
         </p7:field>
 
@@ -1827,6 +1851,21 @@
             <p7:parameter field="wired.transaction" version="2.0" />
         </p7:message>
 
+        <p7:message name="wired.user.offline_list" id="3011" version="3.0">
+            <p7:documentation>
+                One entry in the offline user list sent by the server after login.
+                Each message represents a registered account that is not currently connected.
+            </p7:documentation>
+            <p7:parameter field="wired.user.login" use="required" version="3.0" />
+            <p7:parameter field="wired.user.nick" version="3.0" />
+        </p7:message>
+
+        <p7:message name="wired.user.offline_list.done" id="3012" version="3.0">
+            <p7:documentation>
+                Marks the end of the offline user list.
+            </p7:documentation>
+        </p7:message>
+
         <p7:message name="wired.chat.join_chat" id="4000" version="2.0">
             <p7:documentation>
                 Join chat message.
@@ -2176,6 +2215,27 @@
             </p7:documentation>
             <p7:parameter field="wired.user.id" use="required" version="2.0" />
             <p7:parameter field="wired.message.broadcast" use="required" version="2.0" />
+        </p7:message>
+
+        <p7:message name="wired.message.send_offline_message" id="5010" version="3.0">
+            <p7:documentation>
+                Send a private message to a user who is currently offline, addressed by login name.
+                The server stores the message and delivers it when the recipient next logs in.
+                Requires [field:wired.account.message.send_offline_messages] privilege.
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.0" />
+            <p7:parameter field="wired.message.offline.recipient_login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.message" use="required" version="3.0" />
+        </p7:message>
+
+        <p7:message name="wired.message.offline_message" id="5011" version="3.0">
+            <p7:documentation>
+                Delivery of a stored offline message to the recipient upon login.
+                The server sends one of these for each pending offline message.
+            </p7:documentation>
+            <p7:parameter field="wired.message.offline.sender_login" use="required" version="3.0" />
+            <p7:parameter field="wired.message.message" use="required" version="3.0" />
+            <p7:parameter field="wired.message.offline.date" use="required" version="3.0" />
         </p7:message>
 
         <p7:message name="wired.board.get_boards" id="6000" version="2.0">

--- a/Sources/wired3/Controllers/ClientsController.swift
+++ b/Sources/wired3/Controllers/ClientsController.swift
@@ -77,4 +77,18 @@ public class ClientsController {
             Array(self.connectedClients.values)
         }
     }
+
+    /// Returns the login names of all currently connected authenticated clients.
+    public func allConnectedLogins() -> [String] {
+        self.clientsLock.concurrentlyRead {
+            self.connectedClients.values.compactMap { $0.user?.username }
+        }
+    }
+
+    /// Returns the connected client whose account login matches `login`, or `nil`.
+    public func user(withLogin login: String) -> Client? {
+        self.clientsLock.concurrentlyRead {
+            self.connectedClients.values.first { $0.user?.username == login }
+        }
+    }
 }

--- a/Sources/wired3/Controllers/DatabaseController.swift
+++ b/Sources/wired3/Controllers/DatabaseController.swift
@@ -22,7 +22,7 @@ private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.sel
 /// shared `DatabaseController` instance that `AppController` creates at startup.
 public class DatabaseController {
     let baseURL: URL
-    private(set) var dbQueue: DatabaseQueue!
+    public private(set) var dbQueue: DatabaseQueue!
 
     /// Creates a new `DatabaseController` for the database at `baseURL`.
     ///

--- a/Sources/wired3/Controllers/DatabaseController.swift
+++ b/Sources/wired3/Controllers/DatabaseController.swift
@@ -56,6 +56,14 @@ public class DatabaseController {
             WiredMigrations.register(into: &migrator)
             try migrator.migrate(dbQueue)
 
+            // Checkpoint and truncate the WAL from any previous run before we start.
+            // On a fresh server start there are no active readers, so TRUNCATE is safe.
+            // This prevents accumulated stale FTS5 shadow-table writes in the WAL from
+            // causing SQLITE_IOERR on the first write transaction after a crash.
+            try dbQueue.write { db in
+                try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
+            }
+
             Logger.info("Database opened at \(baseURL.path)")
             return true
         } catch {

--- a/Sources/wired3/Controllers/DatabaseController.swift
+++ b/Sources/wired3/Controllers/DatabaseController.swift
@@ -83,10 +83,16 @@ public class DatabaseController {
 
         let tmpURL = destinationURL.appendingPathExtension("tmp")
         try? FileManager.default.removeItem(at: tmpURL)
-        try? FileManager.default.removeItem(at: destinationURL)
 
-        let destination = try DatabaseQueue(path: tmpURL.path)
-        try dbQueue.backup(to: destination)
+        // Write backup to .tmp first; only replace the real .bak after success
+        // so a failed backup never destroys the previous good backup.
+        do {
+            let destination = try DatabaseQueue(path: tmpURL.path)
+            try dbQueue.backup(to: destination)
+        } catch {
+            try? FileManager.default.removeItem(at: tmpURL)
+            throw error
+        }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
             try FileManager.default.removeItem(at: destinationURL)

--- a/Sources/wired3/Controllers/IndexController.swift
+++ b/Sources/wired3/Controllers/IndexController.swift
@@ -312,9 +312,11 @@ public class IndexController: TableController {
         // The trigger is re-created afterwards for incremental addIndex/removeIndex calls.
         do {
             try databaseController.dbQueue.write { db in
-                if hasFTS5 {
-                    try db.execute(sql: "DROP TRIGGER IF EXISTS index_ad")
-                }
+                // Drop unconditionally — hasFTS5 may be false because a previous
+                // recoverIndexAndFTS5() failed, but the trigger can still exist in
+                // the database from an earlier session. Leaving it active causes
+                // SQLITE_IOERR (10) on every bulk delete via the FTS5 shadow tables.
+                try db.execute(sql: "DROP TRIGGER IF EXISTS index_ad")
                 try WiredIndex
                     .filter(Column("generation_id") != newGen)
                     .deleteAll(db)

--- a/Sources/wired3/Controllers/IndexController.swift
+++ b/Sources/wired3/Controllers/IndexController.swift
@@ -28,6 +28,7 @@ public class IndexController: TableController {
     private let indexQueue = DispatchQueue(label: "wired3.index", qos: .utility)
     private var currentGeneration: Int64 = 0
     private var isIndexing: Bool = false
+    private var startupCheckDone = false
     // When a rebuild is running and another request arrives, set this flag so
     // exactly one extra rebuild is scheduled after the current one finishes.
     private var pendingRebuild: Bool = false
@@ -228,6 +229,13 @@ public class IndexController: TableController {
             }
         }
 
+        // On the very first rebuild after startup, probe FTS5 for write-level errors
+        // (e.g. SQLITE_IOERR on shadow tables) before investing time in a full traversal.
+        if !startupCheckDone {
+            startupCheckDone = true
+            performFTS5StartupCheck()
+        }
+
         let newGen = currentGeneration &+ 1
         var newSize: UInt64 = 0
         var newFiles: UInt64 = 0
@@ -404,6 +412,26 @@ public class IndexController: TableController {
         } catch {
             Logger.error("IndexController: FTS5 recovery failed: \(error) — FTS5 search disabled for this session")
             hasFTS5 = false
+        }
+    }
+
+    /// Probes FTS5 write-path health on the first rebuild after startup.
+    /// Runs `integrity-check` against the FTS5 shadow tables; if it throws
+    /// (e.g. SQLITE_IOERR), triggers `recoverIndexAndFTS5()` before the
+    /// expensive filesystem traversal begins. Always called from `indexQueue`.
+    private func performFTS5StartupCheck() {
+        guard hasFTS5 else { return }
+        do {
+            try databaseController.dbQueue.write { db in
+                // integrity-check validates internal FTS5 B-tree consistency and,
+                // for external-content tables, compares against the content table.
+                // We only care whether it throws; result rows are discarded.
+                try db.execute(sql: "INSERT INTO file_search(file_search) VALUES('integrity-check')")
+            }
+            Logger.info("IndexController: FTS5 startup check passed")
+        } catch {
+            Logger.warning("IndexController: FTS5 startup check failed (\(error)) — resetting before rebuild")
+            recoverIndexAndFTS5()
         }
     }
 

--- a/Sources/wired3/Controllers/MigrationController.swift
+++ b/Sources/wired3/Controllers/MigrationController.swift
@@ -297,9 +297,9 @@ public final class MigrationController {
                     result.usersSkipped += 1
                     continue
                 }
-                // password_salt is set to NULL because the migrated hash is SHA1,
-                // not a Wired 3 SHA256 hash. The server will treat it as a legacy
-                // credential and the user must set a new password on first login.
+                // password_salt is set to NULL and is_legacy to 1 because the migrated
+                // hash is SHA1, not a Wired 3 SHA256 hash. The server will treat it as a
+                // legacy credential and the user must set a new password on first login.
                 try db.execute(sql: """
                     UPDATE users SET
                         password=?, full_name=?, comment=?,
@@ -307,7 +307,7 @@ public final class MigrationController {
                         edited_by=?, downloads=?, download_transferred=?,
                         uploads=?, upload_transferred=?,
                         "group"=?, groups=?, color=?, files=?,
-                        password_salt=NULL
+                        password_salt=NULL, is_legacy=1
                     WHERE username=?
                     """,
                     arguments: [
@@ -328,13 +328,13 @@ public final class MigrationController {
             } else {
                 try db.execute(sql: """
                     INSERT INTO users (
-                        username, password, password_salt,
+                        username, password, password_salt, is_legacy,
                         full_name, comment,
                         creation_time, modification_time, login_time,
                         edited_by, downloads, download_transferred,
                         uploads, upload_transferred,
                         "group", groups, color, files
-                    ) VALUES (?,?,NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    ) VALUES (?,?,NULL,1,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                     """,
                     arguments: [
                         username, row["password"],

--- a/Sources/wired3/Controllers/MigrationController.swift
+++ b/Sources/wired3/Controllers/MigrationController.swift
@@ -1,0 +1,715 @@
+//
+//  MigrationController.swift
+//  wired3
+//
+//  Migrates users, groups and bans from a Wired 2.5 SQLite database
+//  into an existing Wired 3 (wired3) SQLite database.
+//
+//  Usage (via CLI):
+//    wired3 --migrate-from /path/to/wired25/database.sqlite3 [--overwrite]
+//
+//  IMPORTANT:
+//  • Make a backup of your Wired 3 database before running.
+//  • Wired 2.5 stores passwords as SHA1 hashes; Wired 3 uses SHA256+salt.
+//    Passwords are copied as-is (password_salt = NULL). Users will need to
+//    reset their passwords on first login.
+
+import Foundation
+import GRDB
+#if os(Linux)
+import CSQLite
+#else
+import SQLite3
+#endif
+
+/// Migrates accounts, privileges and bans from a Wired 2.5 SQLite database
+/// into an already-initialised Wired 3 GRDB `DatabaseQueue`.
+public final class MigrationController {
+
+    // MARK: - Privilege mappings
+
+    /// Wired 2.5 boolean column name → Wired 3 privilege name.
+    private static let boolPrivilegeMap: [(src: String, dst: String)] = [
+        ("user_get_info",                       "wired.account.user.get_info"),
+        ("user_disconnect_users",               "wired.account.user.disconnect_users"),
+        ("user_ban_users",                      "wired.account.user.ban_users"),
+        ("user_cannot_be_disconnected",         "wired.account.user.cannot_be_disconnected"),
+        ("user_cannot_set_nick",                "wired.account.user.cannot_set_nick"),
+        ("user_get_users",                      "wired.account.user.get_users"),
+        ("chat_kick_users",                     "wired.account.chat.kick_users"),
+        ("chat_set_topic",                      "wired.account.chat.set_topic"),
+        ("chat_create_chats",                   "wired.account.chat.create_chats"),
+        ("message_send_messages",               "wired.account.message.send_messages"),
+        ("message_broadcast",                   "wired.account.message.broadcast"),
+        ("file_list_files",                     "wired.account.file.list_files"),
+        ("file_search_files",                   "wired.account.file.search_files"),
+        ("file_get_info",                       "wired.account.file.get_info"),
+        ("file_create_links",                   "wired.account.file.create_links"),
+        ("file_rename_files",                   "wired.account.file.rename_files"),
+        ("file_set_type",                       "wired.account.file.set_type"),
+        ("file_set_comment",                    "wired.account.file.set_comment"),
+        ("file_set_permissions",                "wired.account.file.set_permissions"),
+        ("file_set_executable",                 "wired.account.file.set_executable"),
+        ("file_set_label",                      "wired.account.file.set_label"),
+        ("file_create_directories",             "wired.account.file.create_directories"),
+        ("file_move_files",                     "wired.account.file.move_files"),
+        ("file_delete_files",                   "wired.account.file.delete_files"),
+        ("file_access_all_dropboxes",           "wired.account.file.access_all_dropboxes"),
+        ("account_change_password",             "wired.account.account.change_password"),
+        ("account_list_accounts",               "wired.account.account.list_accounts"),
+        ("account_read_accounts",               "wired.account.account.read_accounts"),
+        ("account_create_users",                "wired.account.account.create_users"),
+        ("account_edit_users",                  "wired.account.account.edit_users"),
+        ("account_delete_users",                "wired.account.account.delete_users"),
+        ("account_create_groups",               "wired.account.account.create_groups"),
+        ("account_edit_groups",                 "wired.account.account.edit_groups"),
+        ("account_delete_groups",               "wired.account.account.delete_groups"),
+        ("account_raise_account_privileges",    "wired.account.account.raise_account_privileges"),
+        ("transfer_download_files",             "wired.account.transfer.download_files"),
+        ("transfer_upload_files",               "wired.account.transfer.upload_files"),
+        ("transfer_upload_anywhere",            "wired.account.transfer.upload_anywhere"),
+        ("transfer_upload_directories",         "wired.account.transfer.upload_directories"),
+        ("board_read_boards",                   "wired.account.board.read_boards"),
+        ("board_add_boards",                    "wired.account.board.add_boards"),
+        ("board_move_boards",                   "wired.account.board.move_boards"),
+        ("board_rename_boards",                 "wired.account.board.rename_boards"),
+        ("board_delete_boards",                 "wired.account.board.delete_boards"),
+        ("board_get_board_info",                "wired.account.board.get_board_info"),
+        ("board_set_board_info",                "wired.account.board.set_board_info"),
+        ("board_add_threads",                   "wired.account.board.add_threads"),
+        ("board_move_threads",                  "wired.account.board.move_threads"),
+        ("board_add_posts",                     "wired.account.board.add_posts"),
+        ("board_edit_own_threads_and_posts",    "wired.account.board.edit_own_threads_and_posts"),
+        ("board_edit_all_threads_and_posts",    "wired.account.board.edit_all_threads_and_posts"),
+        ("board_delete_own_threads_and_posts",  "wired.account.board.delete_own_threads_and_posts"),
+        ("board_delete_all_threads_and_posts",  "wired.account.board.delete_all_threads_and_posts"),
+        ("log_view_log",                        "wired.account.log.view_log"),
+        ("events_view_events",                  "wired.account.events.view_events"),
+        ("settings_get_settings",               "wired.account.settings.get_settings"),
+        ("settings_set_settings",               "wired.account.settings.set_settings"),
+        ("banlist_get_bans",                    "wired.account.banlist.get_bans"),
+        ("banlist_add_bans",                    "wired.account.banlist.add_bans"),
+        ("banlist_delete_bans",                 "wired.account.banlist.delete_bans"),
+        ("tracker_list_servers",                "wired.account.tracker.list_servers"),
+        ("tracker_register_servers",            "wired.account.tracker.register_servers"),
+    ]
+
+    /// Wired 2.5 integer column name → Wired 3 privilege name (stored as integer value).
+    private static let intPrivilegeMap: [(src: String, dst: String)] = [
+        ("file_recursive_list_depth_limit",  "wired.account.file.recursive_list_depth_limit"),
+        ("transfer_download_speed_limit",    "wired.account.transfer.download_speed_limit"),
+        ("transfer_upload_speed_limit",      "wired.account.transfer.upload_speed_limit"),
+        ("transfer_download_limit",          "wired.account.transfer.download_limit"),
+        ("transfer_upload_limit",            "wired.account.transfer.upload_limit"),
+    ]
+
+    // MARK: - Result
+
+    /// Summary counts returned after a completed migration.
+    public struct MigrationResult {
+        public var groupsMigrated  = 0
+        public var groupsSkipped   = 0
+        public var usersMigrated   = 0
+        public var usersSkipped    = 0
+        public var bansMigrated    = 0
+        public var bansSkipped     = 0
+        public var boardsMigrated  = 0
+        public var boardsSkipped   = 0
+        public var threadsMigrated = 0
+        public var threadsSkipped  = 0
+        public var postsMigrated   = 0
+        public var postsSkipped    = 0
+
+        public func printSummary() {
+            print("")
+            print("╔══════════════════════════════════════════════════════════╗")
+            print("║         Wired 2.5 → Wired 3  Migration Summary          ║")
+            print("╠══════════════════════════════════════════════════════════╣")
+            print(String(format: "║  Groups : %3d migrated, %3d skipped                      ║",
+                         groupsMigrated, groupsSkipped))
+            print(String(format: "║  Users  : %3d migrated, %3d skipped                      ║",
+                         usersMigrated, usersSkipped))
+            print(String(format: "║  Bans   : %3d migrated, %3d skipped                      ║",
+                         bansMigrated, bansSkipped))
+            print(String(format: "║  Boards : %3d migrated, %3d skipped                      ║",
+                         boardsMigrated, boardsSkipped))
+            print(String(format: "║  Threads: %3d migrated, %3d skipped                      ║",
+                         threadsMigrated, threadsSkipped))
+            print(String(format: "║  Posts  : %3d migrated, %3d skipped                      ║",
+                         postsMigrated, postsSkipped))
+            print("╠══════════════════════════════════════════════════════════╣")
+            print("║  NOTE: Passwords were migrated as SHA1 hashes.          ║")
+            print("║  Users must reset their passwords on first login.        ║")
+            print("╚══════════════════════════════════════════════════════════╝")
+        }
+    }
+
+    // MARK: - Properties
+
+    private let sourcePath: String
+    private let dbQueue: DatabaseQueue
+    private let overwrite: Bool
+
+    // MARK: - Init
+
+    /// Creates a new `MigrationController`.
+    ///
+    /// - Parameters:
+    ///   - sourcePath: Filesystem path to the Wired 2.5 `database.sqlite3` file.
+    ///   - dbQueue: The already-opened Wired 3 `DatabaseQueue`.
+    ///   - overwrite: When `true`, existing records in Wired 3 are overwritten.
+    public init(sourcePath: String, dbQueue: DatabaseQueue, overwrite: Bool = false) {
+        self.sourcePath = sourcePath
+        self.dbQueue    = dbQueue
+        self.overwrite  = overwrite
+    }
+
+    // MARK: - Public API
+
+    /// Runs the full migration and returns a result summary.
+    ///
+    /// Opens the Wired 2.5 source database read-only, then inside a single
+    /// Wired 3 write transaction migrates groups (with privileges), users
+    /// (with privileges) and bans. The source database is never modified.
+    ///
+    /// - Throws: Any SQLite or file-system error encountered during the migration.
+    /// - Returns: A `MigrationResult` with counts of migrated and skipped records.
+    public func run() throws -> MigrationResult {
+        guard FileManager.default.fileExists(atPath: sourcePath) else {
+            throw MigrationError.sourceNotFound(sourcePath)
+        }
+
+        print("")
+        print("╔══════════════════════════════════════════════════════════╗")
+        print("║         Wired 2.5 → Wired 3  database migration         ║")
+        print("╚══════════════════════════════════════════════════════════╝")
+        print("  Source : \(sourcePath)")
+
+        // Open Wired 2.5 source DB read-only via the raw SQLite3 C API.
+        // We use the C API directly so that GRDB's WAL / migration machinery
+        // does not interfere with the source database.
+        var srcDB: OpaquePointer?
+        let rc = sqlite3_open_v2(sourcePath, &srcDB, SQLITE_OPEN_READONLY, nil)
+        guard rc == SQLITE_OK, let srcDB else {
+            throw MigrationError.cannotOpenSource(sourcePath)
+        }
+        defer { sqlite3_close(srcDB) }
+
+        printSourceSummary(srcDB)
+
+        var result = MigrationResult()
+
+        // All Wired 3 writes happen inside a single GRDB transaction so that
+        // the target database is either fully updated or left untouched.
+        try dbQueue.write { db in
+            try migrateGroups(from: srcDB, into: db, result: &result)
+            try migrateUsers(from: srcDB, into: db, result: &result)
+            try migrateBans(from: srcDB, into: db, result: &result)
+            try migrateBoards(from: srcDB, into: db, result: &result)
+            try migrateThreads(from: srcDB, into: db, result: &result)
+            try migratePosts(from: srcDB, into: db, result: &result)
+        }
+
+        return result
+    }
+
+    // MARK: - Migration steps
+
+    private func migrateGroups(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Groups ───────────────────────────────────────────────")
+        let rows = try queryAll(srcDB, sql: "SELECT name, color FROM groups")
+        print("  Found \(rows.count) group(s) in Wired 2.5")
+
+        for row in rows {
+            guard let name = row["name"] else { continue }
+            let color: String? = row["color"]
+
+            let existingID = try Int64.fetchOne(
+                db,
+                sql: "SELECT id FROM groups WHERE name = ?",
+                arguments: [name]
+            )
+
+            let groupID: Int64
+            if let existingID {
+                guard overwrite else {
+                    print("  SKIP  group '\(name)' (already exists)")
+                    result.groupsSkipped += 1
+                    continue
+                }
+                try db.execute(
+                    sql: "UPDATE groups SET color = ? WHERE name = ?",
+                    arguments: [color, name]
+                )
+                groupID = existingID
+                print("  UPD   group '\(name)'")
+            } else {
+                try db.execute(
+                    sql: "INSERT INTO groups (name, color) VALUES (?, ?)",
+                    arguments: [name, color]
+                )
+                groupID = db.lastInsertedRowID
+                print("  ADD   group '\(name)'")
+            }
+
+            // Fetch the full source row to access all privilege columns.
+            let srcRows = try queryAll(srcDB, sql: "SELECT * FROM groups WHERE name = ?", args: [name])
+            try migratePrivileges(
+                srcRow: srcRows.first ?? [:],
+                into: db,
+                table: "group_privileges",
+                fkColumn: "group_id",
+                fkValue: groupID
+            )
+            result.groupsMigrated += 1
+        }
+
+        print("  → \(result.groupsMigrated) migrated, \(result.groupsSkipped) skipped")
+    }
+
+    private func migrateUsers(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Users ────────────────────────────────────────────────")
+        let rows = try queryAll(srcDB, sql: "SELECT * FROM users")
+        print("  Found \(rows.count) user(s) in Wired 2.5")
+
+        for row in rows {
+            // Wired 2.5 uses "name" as the primary key / login column.
+            guard let username = row["name"] else { continue }
+
+            let existingID = try Int64.fetchOne(
+                db,
+                sql: "SELECT id FROM users WHERE username = ?",
+                arguments: [username]
+            )
+
+            let userID: Int64
+            if let existingID {
+                guard overwrite else {
+                    print("  SKIP  user '\(username)' (already exists)")
+                    result.usersSkipped += 1
+                    continue
+                }
+                // password_salt is set to NULL because the migrated hash is SHA1,
+                // not a Wired 3 SHA256 hash. The server will treat it as a legacy
+                // credential and the user must set a new password on first login.
+                try db.execute(sql: """
+                    UPDATE users SET
+                        password=?, full_name=?, comment=?,
+                        creation_time=?, modification_time=?, login_time=?,
+                        edited_by=?, downloads=?, download_transferred=?,
+                        uploads=?, upload_transferred=?,
+                        "group"=?, groups=?, color=?, files=?,
+                        password_salt=NULL
+                    WHERE username=?
+                    """,
+                    arguments: [
+                        row["password"], row["full_name"], row["comment"],
+                        row["creation_time"], row["modification_time"], row["login_time"],
+                        row["edited_by"],
+                        row["downloads"].flatMap { Int64($0) } ?? 0,
+                        row["download_transferred"].flatMap { Int64($0) } ?? 0,
+                        row["uploads"].flatMap { Int64($0) } ?? 0,
+                        row["upload_transferred"].flatMap { Int64($0) } ?? 0,
+                        row["group"], row["groups"], row["color"], row["files"],
+                        username
+                    ]
+                )
+                try db.execute(sql: "DELETE FROM user_privileges WHERE user_id = ?", arguments: [existingID])
+                userID = existingID
+                print("  UPD   user '\(username)'")
+            } else {
+                try db.execute(sql: """
+                    INSERT INTO users (
+                        username, password, password_salt,
+                        full_name, comment,
+                        creation_time, modification_time, login_time,
+                        edited_by, downloads, download_transferred,
+                        uploads, upload_transferred,
+                        "group", groups, color, files
+                    ) VALUES (?,?,NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    """,
+                    arguments: [
+                        username, row["password"],
+                        row["full_name"], row["comment"],
+                        row["creation_time"], row["modification_time"], row["login_time"],
+                        row["edited_by"],
+                        row["downloads"].flatMap { Int64($0) } ?? 0,
+                        row["download_transferred"].flatMap { Int64($0) } ?? 0,
+                        row["uploads"].flatMap { Int64($0) } ?? 0,
+                        row["upload_transferred"].flatMap { Int64($0) } ?? 0,
+                        row["group"], row["groups"], row["color"], row["files"]
+                    ]
+                )
+                userID = db.lastInsertedRowID
+                print("  ADD   user '\(username)'")
+            }
+
+            try migratePrivileges(
+                srcRow: row,
+                into: db,
+                table: "user_privileges",
+                fkColumn: "user_id",
+                fkValue: userID
+            )
+            result.usersMigrated += 1
+        }
+
+        print("  → \(result.usersMigrated) migrated, \(result.usersSkipped) skipped")
+    }
+
+    private func migrateBans(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Bans ─────────────────────────────────────────────────")
+        let rows = try queryAll(srcDB, sql: "SELECT ip, expiration_date FROM banlist")
+        print("  Found \(rows.count) ban(s) in Wired 2.5")
+
+        for row in rows {
+            guard let ipPattern = row["ip"] else { continue }
+            let expirationDate: String? = row["expiration_date"]
+
+            let existingID = try Int64.fetchOne(
+                db,
+                sql: "SELECT id FROM banlist WHERE ip_pattern = ?",
+                arguments: [ipPattern]
+            )
+
+            if let existingID {
+                guard overwrite else {
+                    print("  SKIP  ban '\(ipPattern)'")
+                    result.bansSkipped += 1
+                    continue
+                }
+                try db.execute(
+                    sql: "UPDATE banlist SET expiration_date = ? WHERE id = ?",
+                    arguments: [expirationDate, existingID]
+                )
+            } else {
+                try db.execute(
+                    sql: "INSERT INTO banlist (ip_pattern, expiration_date) VALUES (?, ?)",
+                    arguments: [ipPattern, expirationDate]
+                )
+            }
+            print("  ADD   ban '\(ipPattern)'  expires=\(expirationDate ?? "never")")
+            result.bansMigrated += 1
+        }
+
+        print("  → \(result.bansMigrated) migrated, \(result.bansSkipped) skipped")
+    }
+
+    // MARK: - Boards / Threads / Posts
+
+    private func migrateBoards(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Boards ───────────────────────────────────────────────")
+        // Note: the column is named `group` (reserved keyword) in Wired 2.5.
+        let rows = try queryAll(srcDB, sql: "SELECT board, owner, `group`, mode FROM boards")
+        print("  Found \(rows.count) board(s) in Wired 2.5")
+
+        for row in rows {
+            guard let path = row["board"] else { continue }
+            let owner     = row["owner"] ?? ""
+            let groupName = row["group"] ?? ""
+            let mode      = Int(row["mode"] ?? "0") ?? 0
+
+            // Decompose Unix permission bits into the 6 Wired 3 boolean columns.
+            let ownerRead    = (mode & 0o400) != 0 ? 1 : 0
+            let ownerWrite   = (mode & 0o200) != 0 ? 1 : 0
+            let groupRead    = (mode & 0o040) != 0 ? 1 : 0
+            let groupWrite   = (mode & 0o020) != 0 ? 1 : 0
+            let everyoneRead  = (mode & 0o004) != 0 ? 1 : 0
+            let everyoneWrite = (mode & 0o002) != 0 ? 1 : 0
+
+            let exists = try String.fetchOne(
+                db, sql: "SELECT path FROM boards WHERE path = ?", arguments: [path]
+            ) != nil
+
+            if exists {
+                guard overwrite else {
+                    print("  SKIP  board '\(path)' (already exists)")
+                    result.boardsSkipped += 1
+                    continue
+                }
+                try db.execute(sql: """
+                    UPDATE boards SET owner=?, group_name=?,
+                        owner_read=?, owner_write=?,
+                        group_read=?, group_write=?,
+                        everyone_read=?, everyone_write=?
+                    WHERE path=?
+                    """,
+                    arguments: [owner, groupName,
+                                ownerRead, ownerWrite, groupRead, groupWrite,
+                                everyoneRead, everyoneWrite, path]
+                )
+                print("  UPD   board '\(path)'")
+            } else {
+                try db.execute(sql: """
+                    INSERT INTO boards
+                        (path, owner, group_name,
+                         owner_read, owner_write,
+                         group_read, group_write,
+                         everyone_read, everyone_write)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [path, owner, groupName,
+                                ownerRead, ownerWrite, groupRead, groupWrite,
+                                everyoneRead, everyoneWrite]
+                )
+                print("  ADD   board '\(path)'")
+            }
+            result.boardsMigrated += 1
+        }
+        print("  → \(result.boardsMigrated) migrated, \(result.boardsSkipped) skipped")
+    }
+
+    private func migrateThreads(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Threads ──────────────────────────────────────────────")
+        // Exclude icon (BLOB) and ip — handled separately or dropped.
+        let rows = try queryAll(srcDB,
+            sql: "SELECT thread, board, subject, text, post_date, edit_date, nick, login FROM threads")
+        print("  Found \(rows.count) thread(s) in Wired 2.5")
+
+        for row in rows {
+            guard let uuid = row["thread"], let boardPath = row["board"] else { continue }
+
+            let exists = try String.fetchOne(
+                db, sql: "SELECT uuid FROM board_threads WHERE uuid = ?", arguments: [uuid]
+            ) != nil
+
+            if exists {
+                guard overwrite else {
+                    print("  SKIP  thread '\(uuid)'")
+                    result.threadsSkipped += 1
+                    continue
+                }
+                try db.execute(sql: "DELETE FROM board_threads WHERE uuid = ?", arguments: [uuid])
+            }
+
+            let icon: Data? = queryBlobColumn(
+                srcDB, sql: "SELECT icon FROM threads WHERE thread = ?", args: [uuid])
+            let postDate = epochFrom(row["post_date"]) ?? 0.0
+            let editDate: Double? = epochFrom(row["edit_date"])
+
+            try db.execute(sql: """
+                INSERT INTO board_threads
+                    (uuid, board_path, subject, text, nick, login, post_date, edit_date, icon)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [uuid, boardPath,
+                            row["subject"] ?? "", row["text"] ?? "",
+                            row["nick"] ?? "", row["login"] ?? "",
+                            postDate, editDate, icon]
+            )
+            print("  ADD   thread '\(uuid)' board='\(boardPath)'")
+            result.threadsMigrated += 1
+        }
+        print("  → \(result.threadsMigrated) migrated, \(result.threadsSkipped) skipped")
+    }
+
+    private func migratePosts(
+        from srcDB: OpaquePointer,
+        into db: Database,
+        result: inout MigrationResult
+    ) throws {
+        print("\n── Posts ─────────────────────────────────────────────────")
+        let rows = try queryAll(srcDB,
+            sql: "SELECT post, thread, text, post_date, edit_date, nick, login FROM posts")
+        print("  Found \(rows.count) post(s) in Wired 2.5")
+
+        for row in rows {
+            guard let uuid = row["post"], let threadUUID = row["thread"] else { continue }
+
+            let exists = try String.fetchOne(
+                db, sql: "SELECT uuid FROM board_posts WHERE uuid = ?", arguments: [uuid]
+            ) != nil
+
+            if exists {
+                guard overwrite else {
+                    print("  SKIP  post '\(uuid)'")
+                    result.postsSkipped += 1
+                    continue
+                }
+                try db.execute(sql: "DELETE FROM board_posts WHERE uuid = ?", arguments: [uuid])
+            }
+
+            let icon: Data? = queryBlobColumn(
+                srcDB, sql: "SELECT icon FROM posts WHERE post = ?", args: [uuid])
+            let postDate = epochFrom(row["post_date"]) ?? 0.0
+            let editDate: Double? = epochFrom(row["edit_date"])
+
+            try db.execute(sql: """
+                INSERT INTO board_posts
+                    (uuid, thread_uuid, text, nick, login, post_date, edit_date, icon)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [uuid, threadUUID,
+                            row["text"] ?? "",
+                            row["nick"] ?? "", row["login"] ?? "",
+                            postDate, editDate, icon]
+            )
+            print("  ADD   post '\(uuid)'")
+            result.postsMigrated += 1
+        }
+        print("  → \(result.postsMigrated) migrated, \(result.postsSkipped) skipped")
+    }
+
+    // MARK: - Privilege helper
+
+    /// Inserts privilege rows for a single user or group.
+    ///
+    /// Non-null source columns are mapped using `boolPrivilegeMap` / `intPrivilegeMap`
+    /// and written to `table` (either `user_privileges` or `group_privileges`).
+    private func migratePrivileges(
+        srcRow: [String: String],
+        into db: Database,
+        table: String,
+        fkColumn: String,
+        fkValue: Int64
+    ) throws {
+        for (srcCol, dstName) in MigrationController.boolPrivilegeMap {
+            guard let raw = srcRow[srcCol] else { continue }
+            let value = (Int(raw) ?? 0) != 0
+            try db.execute(
+                sql: "INSERT OR REPLACE INTO \(table) (name, value, \(fkColumn)) VALUES (?,?,?)",
+                arguments: [dstName, value, fkValue]
+            )
+        }
+        for (srcCol, dstName) in MigrationController.intPrivilegeMap {
+            guard let raw = srcRow[srcCol] else { continue }
+            let value = Int64(raw) ?? 0
+            try db.execute(
+                sql: "INSERT OR REPLACE INTO \(table) (name, value, \(fkColumn)) VALUES (?,?,?)",
+                arguments: [dstName, value, fkValue]
+            )
+        }
+    }
+
+    // MARK: - Raw SQLite helpers
+
+    /// Executes a SELECT on the Wired 2.5 source database using the raw SQLite3
+    /// C API and returns all rows as `[columnName: value]` dictionaries.
+    ///
+    /// NULL columns are omitted from the dictionary (not stored as nil-valued
+    /// keys) so that consumers can use a simple `guard let x = row["col"]` check.
+    private func queryAll(
+        _ db: OpaquePointer,
+        sql: String,
+        args: [String] = []
+    ) throws -> [[String: String]] {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else {
+            throw MigrationError.sqliteError("prepare failed: \(sql)")
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        for (i, arg) in args.enumerated() {
+            sqlite3_bind_text(stmt, Int32(i + 1), (arg as NSString).utf8String, -1, nil)
+        }
+
+        let columnCount = sqlite3_column_count(stmt)
+        var columnNames = [String]()
+        for i in 0..<columnCount {
+            columnNames.append(String(cString: sqlite3_column_name(stmt, i)))
+        }
+
+        var rows = [[String: String]]()
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            var row = [String: String]()
+            for i in 0..<columnCount {
+                guard sqlite3_column_type(stmt, i) != SQLITE_NULL else { continue }
+                if let cStr = sqlite3_column_text(stmt, i) {
+                    row[columnNames[Int(i)]] = String(cString: cStr)
+                }
+            }
+            rows.append(row)
+        }
+        return rows
+    }
+
+    /// Executes a single-row, single-column SELECT on the source database and
+    /// returns the result as `Data` (for BLOB columns).  Returns `nil` when the
+    /// column is NULL or the query produces no rows.
+    private func queryBlobColumn(
+        _ db: OpaquePointer,
+        sql: String,
+        args: [String] = []
+    ) -> Data? {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else { return nil }
+        defer { sqlite3_finalize(stmt) }
+
+        for (i, arg) in args.enumerated() {
+            sqlite3_bind_text(stmt, Int32(i + 1), (arg as NSString).utf8String, -1, nil)
+        }
+
+        guard sqlite3_step(stmt) == SQLITE_ROW,
+              sqlite3_column_type(stmt, 0) != SQLITE_NULL,
+              let ptr = sqlite3_column_blob(stmt, 0) else { return nil }
+
+        let byteCount = Int(sqlite3_column_bytes(stmt, 0))
+        return Data(bytes: ptr, count: byteCount)
+    }
+
+    /// Converts a Wired 2.5 date string ("yyyy-MM-dd HH:mm:ss", UTC) to a
+    /// Unix-epoch `Double` suitable for Wired 3's REAL date columns.
+    private func epochFrom(_ string: String?) -> Double? {
+        guard let string else { return nil }
+        return MigrationController.wiredDateFormatter.date(from: string)?.timeIntervalSince1970
+    }
+
+    private static let wiredDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    // MARK: - Diagnostics
+
+    private func printSourceSummary(_ srcDB: OpaquePointer) {
+        print("\n── Source database summary ───────────────────────────────")
+        for table in ["users", "groups", "banlist", "boards", "threads", "posts"] {
+            if let rows = try? queryAll(srcDB, sql: "SELECT COUNT(*) AS n FROM \(table)"),
+               let first = rows.first,
+               let n = Int(first["n"] ?? "") {
+                let padded = table.padding(toLength: 12, withPad: " ", startingAt: 0)
+                print("  \(padded) \(n) row(s)")
+            }
+        }
+    }
+}
+
+// MARK: - Error type
+
+/// Errors that can be thrown by `MigrationController`.
+public enum MigrationError: Error, CustomStringConvertible {
+    case sourceNotFound(String)
+    case cannotOpenSource(String)
+    case sqliteError(String)
+
+    public var description: String {
+        switch self {
+        case .sourceNotFound(let p):   return "Source database not found: \(p)"
+        case .cannotOpenSource(let p): return "Cannot open source database: \(p)"
+        case .sqliteError(let msg):    return "SQLite error: \(msg)"
+        }
+    }
+}

--- a/Sources/wired3/Controllers/MigrationController.swift
+++ b/Sources/wired3/Controllers/MigrationController.swift
@@ -261,9 +261,7 @@ public final class MigrationController {
             try migratePrivileges(
                 srcRow: srcRows.first ?? [:],
                 into: db,
-                table: "group_privileges",
-                fkColumn: "group_id",
-                fkValue: groupID
+                target: .group(id: groupID)
             )
             result.groupsMigrated += 1
         }
@@ -355,9 +353,7 @@ public final class MigrationController {
             try migratePrivileges(
                 srcRow: row,
                 into: db,
-                table: "user_privileges",
-                fkColumn: "user_id",
-                fkValue: userID
+                target: .user(id: userID)
             )
             result.usersMigrated += 1
         }
@@ -572,31 +568,54 @@ public final class MigrationController {
 
     // MARK: - Privilege helper
 
+    /// Validated target for privilege rows — eliminates raw string interpolation of
+    /// table/column names by restricting callers to an exhaustive closed enum.
+    private enum PrivilegeTarget {
+        case user(id: Int64)
+        case group(id: Int64)
+
+        var tableName: String {
+            switch self {
+            case .user:  return "user_privileges"
+            case .group: return "group_privileges"
+            }
+        }
+        var fkColumnName: String {
+            switch self {
+            case .user:  return "user_id"
+            case .group: return "group_id"
+            }
+        }
+        var id: Int64 {
+            switch self {
+            case .user(let id), .group(let id): return id
+            }
+        }
+    }
+
     /// Inserts privilege rows for a single user or group.
     ///
-    /// Non-null source columns are mapped using `boolPrivilegeMap` / `intPrivilegeMap`
-    /// and written to `table` (either `user_privileges` or `group_privileges`).
+    /// Table and column names are taken from a closed `PrivilegeTarget` enum, not from
+    /// caller-supplied strings, to prevent accidental injection of untrusted identifiers.
     private func migratePrivileges(
         srcRow: [String: String],
         into db: Database,
-        table: String,
-        fkColumn: String,
-        fkValue: Int64
+        target: PrivilegeTarget
     ) throws {
         for (srcCol, dstName) in MigrationController.boolPrivilegeMap {
             guard let raw = srcRow[srcCol] else { continue }
             let value = (Int(raw) ?? 0) != 0
             try db.execute(
-                sql: "INSERT OR REPLACE INTO \(table) (name, value, \(fkColumn)) VALUES (?,?,?)",
-                arguments: [dstName, value, fkValue]
+                sql: "INSERT OR REPLACE INTO \(target.tableName) (name, value, \(target.fkColumnName)) VALUES (?,?,?)",
+                arguments: [dstName, value, target.id]
             )
         }
         for (srcCol, dstName) in MigrationController.intPrivilegeMap {
             guard let raw = srcRow[srcCol] else { continue }
             let value = Int64(raw) ?? 0
             try db.execute(
-                sql: "INSERT OR REPLACE INTO \(table) (name, value, \(fkColumn)) VALUES (?,?,?)",
-                arguments: [dstName, value, fkValue]
+                sql: "INSERT OR REPLACE INTO \(target.tableName) (name, value, \(target.fkColumnName)) VALUES (?,?,?)",
+                arguments: [dstName, value, target.id]
             )
         }
     }

--- a/Sources/wired3/Controllers/UsersController.swift
+++ b/Sources/wired3/Controllers/UsersController.swift
@@ -107,6 +107,13 @@ public class UsersController: TableController, SocketPasswordDelegate {
         }
     }
 
+    /// Returns `true` if a registered account with the given login name exists.
+    public func userExists(withUsername username: String) -> Bool {
+        (try? databaseController.dbQueue.read { db in
+            try User.filter(Column("username") == username).fetchCount(db) > 0
+        }) ?? false
+    }
+
     /// Fetches a user by login name and eagerly loads their privilege set.
     ///
     /// - Parameter username: The account login name.

--- a/Sources/wired3/Controllers/UsersController.swift
+++ b/Sources/wired3/Controllers/UsersController.swift
@@ -426,6 +426,7 @@ public class UsersController: TableController, SocketPasswordDelegate {
         migrateOfflineMessagesTableIfNeeded(db: db)
         migrateAddReactionsPrivilegeIfNeeded(db: db)
         migrateFileMetadataPrivilegesIfNeeded(db: db)
+        migrateSendOfflineMessagesPrivilegeIfNeeded(db: db)
     }
 
     /// For existing installations, grant `wired.account.board.add_reactions` (true) to every
@@ -497,6 +498,37 @@ public class UsersController: TableController, SocketPasswordDelegate {
                 } else {
                     WiredSwift.Logger.info("Migrated \(targetPrivilege) for \(entry.table)")
                 }
+            }
+        }
+    }
+
+    /// For existing installations, grant `wired.account.message.send_offline_messages` to every
+    /// user and group that already has `wired.account.message.send_messages = true`.
+    private func migrateSendOfflineMessagesPrivilegeIfNeeded(db: OpaquePointer) {
+        let targetPrivilege = "wired.account.message.send_offline_messages"
+        let sourcePrivilege = "wired.account.message.send_messages"
+
+        let tables: [(table: String, ownerColumn: String)] = [
+            ("user_privileges", "user_id"),
+            ("group_privileges", "group_id")
+        ]
+
+        for entry in tables {
+            let sql = """
+            INSERT OR IGNORE INTO "\(entry.table)" (name, value, \(entry.ownerColumn))
+            SELECT '\(targetPrivilege)', 1, \(entry.ownerColumn)
+            FROM "\(entry.table)"
+            WHERE name = '\(sourcePrivilege)' AND value = 1
+              AND \(entry.ownerColumn) NOT IN (
+                  SELECT \(entry.ownerColumn) FROM "\(entry.table)" WHERE name = '\(targetPrivilege)'
+              );
+            """
+            if sqliteExec(db: db, sql) != SQLITE_OK {
+                if let msg = sqlite3_errmsg(db) {
+                    WiredSwift.Logger.error("migrateSendOfflineMessagesPrivilege (\(entry.table)): \(String(cString: msg))")
+                }
+            } else {
+                WiredSwift.Logger.info("Migrated \(targetPrivilege) for \(entry.table)")
             }
         }
     }

--- a/Sources/wired3/Controllers/UsersController.swift
+++ b/Sources/wired3/Controllers/UsersController.swift
@@ -427,6 +427,7 @@ public class UsersController: TableController, SocketPasswordDelegate {
         migrateAddReactionsPrivilegeIfNeeded(db: db)
         migrateFileMetadataPrivilegesIfNeeded(db: db)
         migrateSendOfflineMessagesPrivilegeIfNeeded(db: db)
+        migrateListOfflineUsersPrivilegeIfNeeded(db: db)
     }
 
     /// For existing installations, grant `wired.account.board.add_reactions` (true) to every
@@ -498,6 +499,37 @@ public class UsersController: TableController, SocketPasswordDelegate {
                 } else {
                     WiredSwift.Logger.info("Migrated \(targetPrivilege) for \(entry.table)")
                 }
+            }
+        }
+    }
+
+    /// For existing installations, grant `wired.account.user.list_offline_users` to every
+    /// user and group that already has `wired.account.message.send_offline_messages = true`.
+    private func migrateListOfflineUsersPrivilegeIfNeeded(db: OpaquePointer) {
+        let targetPrivilege = "wired.account.user.list_offline_users"
+        let sourcePrivilege = "wired.account.message.send_offline_messages"
+
+        let tables: [(table: String, ownerColumn: String)] = [
+            ("user_privileges", "user_id"),
+            ("group_privileges", "group_id")
+        ]
+
+        for entry in tables {
+            let sql = """
+            INSERT OR IGNORE INTO "\(entry.table)" (name, value, \(entry.ownerColumn))
+            SELECT '\(targetPrivilege)', 1, \(entry.ownerColumn)
+            FROM "\(entry.table)"
+            WHERE name = '\(sourcePrivilege)' AND value = 1
+              AND \(entry.ownerColumn) NOT IN (
+                  SELECT \(entry.ownerColumn) FROM "\(entry.table)" WHERE name = '\(targetPrivilege)'
+              );
+            """
+            if sqliteExec(db: db, sql) != SQLITE_OK {
+                if let msg = sqlite3_errmsg(db) {
+                    WiredSwift.Logger.error("migrateListOfflineUsersPrivilege (\(entry.table)): \(String(cString: msg))")
+                }
+            } else {
+                WiredSwift.Logger.info("Migrated \(targetPrivilege) for \(entry.table)")
             }
         }
     }

--- a/Sources/wired3/Controllers/UsersController.swift
+++ b/Sources/wired3/Controllers/UsersController.swift
@@ -53,6 +53,10 @@ public class UsersController: TableController, SocketPasswordDelegate {
         user(withUsername: username)?.passwordSalt
     }
 
+    public func isLegacyUser(username: String) -> Bool {
+        user(withUsername: username)?.isLegacy ?? false
+    }
+
     // MARK: - Fetch
 
     /// Authenticates a user by verifying the supplied SHA-256 password hash.

--- a/Sources/wired3/Core/AppController.swift
+++ b/Sources/wired3/Core/AppController.swift
@@ -331,7 +331,7 @@ public class AppController {
         timer.resume()
     }
 
-    private func createDatabaseSnapshot() {
+    public func createDatabaseSnapshot() {
         guard let databaseController = self.databaseController else { return }
 
         do {

--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -1231,25 +1231,8 @@ extension ServerController {
     }
 
     private func broadcastNewOfflineUser(username: String) {
-        let onlineLogins = Set(App.clientsController.allConnectedLogins())
-        guard !onlineLogins.contains(username) else { return }
-
-        // New accounts have no last_nick yet; use full_name or username as fallback
-        let displayNick: String
-        if let user = App.usersController.user(withUsername: username) {
-            displayNick = [user.fullName].compactMap({ $0?.isEmpty == false ? $0 : nil }).first ?? username
-        } else {
-            displayNick = username
-        }
-
-        let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
-        msg.addParameter(field: "wired.user.login", value: username)
-        msg.addParameter(field: "wired.user.nick", value: displayNick)
-
-        for connectedClient in App.clientsController.connectedClientsSnapshot() {
-            guard connectedClient.state == .LOGGED_IN else { continue }
-            _ = self.send(message: msg, client: connectedClient)
-        }
+        // New accounts have no last_nick yet — don't expose login or full_name.
+        // The account will appear automatically after their first login.
     }
 
     private func broadcastAccountsChangedToSubscribers() {

--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -1234,10 +1234,10 @@ extension ServerController {
         let onlineLogins = Set(App.clientsController.allConnectedLogins())
         guard !onlineLogins.contains(username) else { return }
 
+        // New accounts have no last_nick yet; use full_name or username as fallback
         let displayNick: String
-        if let user = App.usersController.user(withUsername: username),
-           let fullName = user.fullName, !fullName.isEmpty {
-            displayNick = fullName
+        if let user = App.usersController.user(withUsername: username) {
+            displayNick = [user.fullName].compactMap({ $0?.isEmpty == false ? $0 : nil }).first ?? username
         } else {
             displayNick = username
         }

--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -711,6 +711,7 @@ extension ServerController {
         let result = normalizedPasswordForStorage(password)
         account.password = result.hash
         account.passwordSalt = result.salt
+        account.isLegacy = false
 
         guard App.usersController.save(user: account) else {
             App.serverController.replyError(client: client, error: "wired.error.internal_error", message: message)

--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -627,6 +627,7 @@ extension ServerController {
 
         App.serverController.replyOK(client: client, message: message)
         self.broadcastAccountsChangedToSubscribers()
+        self.broadcastNewOfflineUser(username: name)
         self.recordEvent(.accountCreatedUser, client: client, parameters: [name])
     }
 
@@ -1227,6 +1228,28 @@ extension ServerController {
         let hash = isHexSHA256 ? password.lowercased() : password.sha256()
         let salt = UUID().uuidString.replacingOccurrences(of: "-", with: "")
         return (hash: hash, salt: salt)
+    }
+
+    private func broadcastNewOfflineUser(username: String) {
+        let onlineLogins = Set(App.clientsController.allConnectedLogins())
+        guard !onlineLogins.contains(username) else { return }
+
+        let displayNick: String
+        if let user = App.usersController.user(withUsername: username),
+           let fullName = user.fullName, !fullName.isEmpty {
+            displayNick = fullName
+        } else {
+            displayNick = username
+        }
+
+        let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
+        msg.addParameter(field: "wired.user.login", value: username)
+        msg.addParameter(field: "wired.user.nick", value: displayNick)
+
+        for connectedClient in App.clientsController.connectedClientsSnapshot() {
+            guard connectedClient.state == .LOGGED_IN else { continue }
+            _ = self.send(message: msg, client: connectedClient)
+        }
     }
 
     private func broadcastAccountsChangedToSubscribers() {

--- a/Sources/wired3/Core/ServerController+Auth.swift
+++ b/Sources/wired3/Core/ServerController+Auth.swift
@@ -159,6 +159,10 @@ extension ServerController {
             loginOverride: login
         )
 
+        // Send list of offline registered users, then deliver any queued offline messages
+        self.sendOfflineUserList(to: client)
+        self.deliverOfflineMessages(to: client)
+
         return true
     }
 }

--- a/Sources/wired3/Core/ServerController+Auth.swift
+++ b/Sources/wired3/Core/ServerController+Auth.swift
@@ -91,14 +91,11 @@ extension ServerController {
         let isLegacy = client.socket.isLegacyAuth
         let user: User?
         if isLegacy {
+            // Do NOT assign a salt here. The salt is only written when the user actually
+            // completes the password-change flow (receiveAccountChangePassword). Writing it
+            // now would cause the next login attempt to take the SHA-256 path against a
+            // still-SHA1 stored hash, permanently locking the account out.
             user = App.usersController.userWithPrivileges(withUsername: login)
-            // Assign a stored_salt on the spot (same lazy-migration path as normal login)
-            if let u = user, u.passwordSalt == nil || u.passwordSalt!.isEmpty {
-                let salt = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-                         + UUID().uuidString.replacingOccurrences(of: "-", with: "")
-                u.passwordSalt = salt
-                App.usersController.save(user: u)
-            }
         } else {
             user = App.usersController.user(withUsername: login, password: password)
         }

--- a/Sources/wired3/Core/ServerController+Auth.swift
+++ b/Sources/wired3/Core/ServerController+Auth.swift
@@ -149,10 +149,17 @@ extension ServerController {
         client.idleTime = client.loginTime
 
         try? App.databaseController.dbQueue.write { db in
-            try db.execute(
-                sql: "UPDATE users SET last_login_at = ? WHERE username = ?",
-                arguments: [Date().timeIntervalSince1970, login]
-            )
+            if let nick = client.nick, !nick.isEmpty {
+                try db.execute(
+                    sql: "UPDATE users SET last_login_at = ?, last_nick = ? WHERE username = ?",
+                    arguments: [Date().timeIntervalSince1970, nick, login]
+                )
+            } else {
+                try db.execute(
+                    sql: "UPDATE users SET last_login_at = ? WHERE username = ?",
+                    arguments: [Date().timeIntervalSince1970, login]
+                )
+            }
         }
 
         let clientInfo = [client.applicationName, client.applicationVersion]

--- a/Sources/wired3/Core/ServerController+Auth.swift
+++ b/Sources/wired3/Core/ServerController+Auth.swift
@@ -85,14 +85,31 @@ extension ServerController {
             return false
         }
 
-        guard let user = App.usersController.user(withUsername: login, password: password) else {
+        // Legacy SHA1 accounts (migrated from Wired 2.5) are authenticated by the P7 ECDSA key
+        // exchange which already used their stored SHA1 hash.  Bypass the redundant application-
+        // level hash comparison so that the SHA256 value sent in wired.send_login doesn't fail.
+        let isLegacy = client.socket.isLegacyAuth
+        let user: User?
+        if isLegacy {
+            user = App.usersController.userWithPrivileges(withUsername: login)
+            // Assign a stored_salt on the spot (same lazy-migration path as normal login)
+            if let u = user, u.passwordSalt == nil || u.passwordSalt!.isEmpty {
+                let salt = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+                         + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+                u.passwordSalt = salt
+                App.usersController.save(user: u)
+            }
+        } else {
+            user = App.usersController.user(withUsername: login, password: password)
+        }
+
+        guard let user else {
             // SECURITY (FINDING_A_014): Perform dummy SHA-256 to prevent username enumeration via timing
             _ = (UUID().uuidString + password).sha256()
 
             let reply = P7Message(withName: "wired.error", spec: message.spec)
             reply.addParameter(field: "wired.error.string", value: "Login failed")
-            reply.addParameter(field: "wired.error", value: UInt32(4
-            ))
+            reply.addParameter(field: "wired.error", value: UInt32(4))
             App.serverController.reply(client: client, reply: reply, message: message)
 
             Logger.warning("Login from \(clientIP) failed for '\(login)': Wrong password")
@@ -123,6 +140,11 @@ extension ServerController {
 
         let response = P7Message(withName: "wired.login", spec: self.spec)
         response.addParameter(field: "wired.user.id", value: client.userID)
+        // Inform the client that this is a legacy account and a password change is required.
+        if isLegacy {
+            response.addParameter(field: "wired.user.password_must_change", value: true)
+            Logger.info("Legacy SHA1 user '\(login)' logged in — client must prompt for password change")
+        }
         App.serverController.reply(client: client, reply: response, message: message)
 
         client.loginTime = Date()

--- a/Sources/wired3/Core/ServerController+Auth.swift
+++ b/Sources/wired3/Core/ServerController+Auth.swift
@@ -3,6 +3,7 @@
 //  wired3
 //
 import Foundation
+import GRDB
 import WiredSwift
 
 extension ServerController {
@@ -146,6 +147,13 @@ extension ServerController {
 
         client.loginTime = Date()
         client.idleTime = client.loginTime
+
+        try? App.databaseController.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE users SET last_login_at = ? WHERE username = ?",
+                arguments: [Date().timeIntervalSince1970, login]
+            )
+        }
 
         let clientInfo = [client.applicationName, client.applicationVersion]
             .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " ")

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -290,6 +290,11 @@ extension ServerController {
     }
 
     func sendOfflineUserList(to client: Client) {
+        guard let user = client.user,
+              user.hasPrivilege(name: "wired.account.user.list_offline_users") else {
+            return
+        }
+
         let onlineLogins = Set(App.clientsController.allConnectedLogins())
 
         let entries: [(login: String, nick: String)]

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -164,11 +164,13 @@ extension ServerController {
         }
 
         let senderLogin = senderUser.username ?? ""
+        let isEncrypted = message.bool(forField: "wired.message.offline.encrypted") ?? false
         var offlineMessage = OfflineMessage(
             senderLogin: senderLogin,
             recipientLogin: recipientLogin,
             body: body,
-            sentAt: Date()
+            sentAt: Date(),
+            isEncrypted: isEncrypted
         )
 
         do {
@@ -193,24 +195,27 @@ extension ServerController {
             let senderNick: String?
             let body: String
             let sentAt: Date
+            let isEncrypted: Bool
         }
 
         let messages: [PendingMessage]
         do {
             messages = try App.databaseController.dbQueue.read { db in
                 let rows = try Row.fetchAll(db, sql: """
-                    SELECT om.sender_login, om.body, om.sent_at, u.last_nick AS sender_nick
+                    SELECT om.sender_login, om.body, om.sent_at, om.is_encrypted, u.last_nick AS sender_nick
                     FROM offline_messages om
                     LEFT JOIN users u ON u.username = om.sender_login
                     WHERE om.recipient_login = ?
                     ORDER BY om.sent_at ASC
                 """, arguments: [recipientLogin])
                 return rows.map {
-                    PendingMessage(
+                    let encryptedInt: Int = $0["is_encrypted"] ?? 0
+                    return PendingMessage(
                         senderLogin: $0["sender_login"],
                         senderNick: $0["sender_nick"],
                         body: $0["body"],
-                        sentAt: Date(timeIntervalSince1970: $0["sent_at"])
+                        sentAt: Date(timeIntervalSince1970: $0["sent_at"]),
+                        isEncrypted: encryptedInt != 0
                     )
                 }
             }
@@ -228,6 +233,9 @@ extension ServerController {
             delivery.addParameter(field: "wired.message.offline.date", value: msg.sentAt)
             if let nick = msg.senderNick, !nick.isEmpty {
                 delivery.addParameter(field: "wired.message.offline.sender_nick", value: nick)
+            }
+            if msg.isEncrypted {
+                delivery.addParameter(field: "wired.message.offline.encrypted", value: true)
             }
             _ = self.send(message: delivery, client: client)
         }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -165,6 +165,25 @@ extension ServerController {
 
         let senderLogin = senderUser.username ?? ""
         let isEncrypted = message.bool(forField: "wired.message.offline.encrypted") ?? false
+
+        // Enforce encryption when the recipient has registered an offline public key.
+        // A client that supports E2E offline messaging must encrypt before sending;
+        // accepting plaintext bodies when a key is on file would silently store
+        // readable content in the database.
+        let recipientHasKey: Bool = (try? App.databaseController.dbQueue.read { db in
+            let row = try Row.fetchOne(db,
+                sql: "SELECT offline_public_key FROM users WHERE username = ?",
+                arguments: [recipientLogin])
+            let keyData = row?["offline_public_key"] as? Data
+            return keyData != nil && !keyData!.isEmpty
+        }) ?? false
+
+        if recipientHasKey && !isEncrypted {
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+            Logger.warning("Rejected unencrypted offline message for '\(recipientLogin)' — recipient has a public key registered")
+            return
+        }
+
         var offlineMessage = OfflineMessage(
             senderLogin: senderLogin,
             recipientLogin: recipientLogin,
@@ -191,6 +210,7 @@ extension ServerController {
         guard let recipientLogin = client.user?.username else { return }
 
         struct PendingMessage {
+            let id: Int64
             let senderLogin: String
             let senderNick: String?
             let body: String
@@ -202,7 +222,8 @@ extension ServerController {
         do {
             messages = try App.databaseController.dbQueue.read { db in
                 let rows = try Row.fetchAll(db, sql: """
-                    SELECT om.sender_login, om.body, om.sent_at, om.is_encrypted, u.last_nick AS sender_nick
+                    SELECT om.id, om.sender_login, om.body, om.sent_at, om.is_encrypted,
+                           u.last_nick AS sender_nick
                     FROM offline_messages om
                     LEFT JOIN users u ON u.username = om.sender_login
                     WHERE om.recipient_login = ?
@@ -211,6 +232,7 @@ extension ServerController {
                 return rows.map {
                     let encryptedInt: Int = $0["is_encrypted"] ?? 0
                     return PendingMessage(
+                        id: $0["id"],
                         senderLogin: $0["sender_login"],
                         senderNick: $0["sender_nick"],
                         body: $0["body"],
@@ -226,6 +248,11 @@ extension ServerController {
 
         guard !messages.isEmpty else { return }
 
+        // Track which message IDs were successfully written to the socket.
+        // Only those are deleted — if the connection drops mid-delivery the
+        // remaining messages stay in the DB and will be re-delivered on next login.
+        var deliveredIDs: [Int64] = []
+
         for msg in messages {
             let delivery = P7Message(withName: "wired.message.offline_message", spec: self.spec)
             delivery.addParameter(field: "wired.message.offline.sender_login", value: msg.senderLogin)
@@ -237,20 +264,24 @@ extension ServerController {
             if msg.isEncrypted {
                 delivery.addParameter(field: "wired.message.offline.encrypted", value: true)
             }
-            _ = self.send(message: delivery, client: client)
+            if self.send(message: delivery, client: client) {
+                deliveredIDs.append(msg.id)
+            }
         }
 
+        guard !deliveredIDs.isEmpty else { return }
+
         do {
-            try App.databaseController.dbQueue.write { db in
+            _ = try App.databaseController.dbQueue.write { db in
                 try OfflineMessage
-                    .filter(Column("recipient_login") == recipientLogin)
+                    .filter(deliveredIDs.contains(Column("id")))
                     .deleteAll(db)
             }
         } catch {
             Logger.error("Failed to delete delivered offline messages for '\(recipientLogin)': \(error)")
         }
 
-        Logger.info("Delivered \(messages.count) offline message(s) to '\(recipientLogin)'")
+        Logger.info("Delivered \(deliveredIDs.count)/\(messages.count) offline message(s) to '\(recipientLogin)'")
     }
 
     func sendOfflineUserList(to client: Client) {
@@ -259,8 +290,10 @@ extension ServerController {
         let entries: [(login: String, nick: String)]
         do {
             entries = try App.databaseController.dbQueue.read { db in
-                // Only include users who have a last_nick set (i.e. connected at least once
-                // since v15). This avoids exposing login names or account full names.
+                // Returns login + last_nick for users active within the last 30 days.
+                // wired.user.login IS sent to the requester so the client can address
+                // the offline message. Only users who have a last_nick set are included
+                // (connected at least once since v15); account full_name is never sent.
                 let rows = try Row.fetchAll(db, sql: """
                     SELECT username, last_nick FROM users
                     WHERE username IS NOT NULL AND username != ''

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -231,15 +231,18 @@ extension ServerController {
         do {
             entries = try App.databaseController.dbQueue.read { db in
                 let rows = try Row.fetchAll(db, sql: """
-                    SELECT username, full_name FROM users
+                    SELECT username, last_nick, full_name FROM users
                     WHERE username IS NOT NULL AND username != ''
                       AND (last_login_at IS NULL OR last_login_at > unixepoch('now') - 2592000)
                     ORDER BY username ASC
                 """)
                 return rows.map { row in
                     let login: String = row["username"]
+                    let lastNick: String? = row["last_nick"]
                     let fullName: String? = row["full_name"]
-                    let nick = (fullName.flatMap { $0.isEmpty ? nil : $0 }) ?? login
+                    let nick = lastNick.flatMap { $0.isEmpty ? nil : $0 }
+                           ?? fullName.flatMap { $0.isEmpty ? nil : $0 }
+                           ?? login
                     return (login: login, nick: nick)
                 }
             }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -214,7 +214,7 @@ extension ServerController {
                         senderLogin: $0["sender_login"],
                         senderNick: $0["sender_nick"],
                         body: $0["body"],
-                        sentAt: Date(timeIntervalSince1970: $0["sent_at"]),
+                        sentAt: $0["sent_at"],
                         isEncrypted: encryptedInt != 0
                     )
                 }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -230,21 +230,18 @@ extension ServerController {
         let entries: [(login: String, nick: String)]
         do {
             entries = try App.databaseController.dbQueue.read { db in
+                // Only include users who have a last_nick set (i.e. connected at least once
+                // since v15). This avoids exposing login names or account full names.
                 let rows = try Row.fetchAll(db, sql: """
-                    SELECT username, last_nick, full_name FROM users
+                    SELECT username, last_nick FROM users
                     WHERE username IS NOT NULL AND username != ''
                       AND last_login_at IS NOT NULL
                       AND last_login_at > unixepoch('now') - 2592000
-                    ORDER BY username ASC
+                      AND last_nick IS NOT NULL AND last_nick != ''
+                    ORDER BY last_nick ASC
                 """)
                 return rows.map { row in
-                    let login: String = row["username"]
-                    let lastNick: String? = row["last_nick"]
-                    let fullName: String? = row["full_name"]
-                    let nick = lastNick.flatMap { $0.isEmpty ? nil : $0 }
-                           ?? fullName.flatMap { $0.isEmpty ? nil : $0 }
-                           ?? login
-                    return (login: login, nick: nick)
+                    (login: row["username"] as String, nick: row["last_nick"] as String)
                 }
             }
         } catch {

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -233,7 +233,8 @@ extension ServerController {
                 let rows = try Row.fetchAll(db, sql: """
                     SELECT username, last_nick, full_name FROM users
                     WHERE username IS NOT NULL AND username != ''
-                      AND (last_login_at IS NULL OR last_login_at > unixepoch('now') - 2592000)
+                      AND last_login_at IS NOT NULL
+                      AND last_login_at > unixepoch('now') - 2592000
                     ORDER BY username ASC
                 """)
                 return rows.map { row in

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -301,8 +301,8 @@ extension ServerController {
         do {
             entries = try App.databaseController.dbQueue.read { db in
                 // Returns login + last_nick for users active within the last 30 days.
-                // wired.user.login IS sent to the requester so the client can address
-                // the offline message. Only users who have a last_nick set are included
+                // wired.message.offline.recipient_login is used (not wired.user.login) to avoid
+                // exposing the auth credential field to non-admin clients. Only users who have a last_nick set are included
                 // (connected at least once since v15); account full_name is never sent.
                 let rows = try Row.fetchAll(db, sql: """
                     SELECT username, last_nick FROM users
@@ -323,7 +323,7 @@ extension ServerController {
 
         for entry in entries where !onlineLogins.contains(entry.login) {
             let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
-            msg.addParameter(field: "wired.user.login", value: entry.login)
+            msg.addParameter(field: "wired.message.offline.recipient_login", value: entry.login)
             msg.addParameter(field: "wired.user.nick", value: entry.nick)
             _ = self.send(message: msg, client: client)
         }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -166,21 +166,26 @@ extension ServerController {
         let senderLogin = senderUser.username ?? ""
         let isEncrypted = message.bool(forField: "wired.message.offline.encrypted") ?? false
 
-        // Enforce encryption when the recipient has registered an offline public key.
-        // A client that supports E2E offline messaging must encrypt before sending;
-        // accepting plaintext bodies when a key is on file would silently store
-        // readable content in the database.
-        let recipientHasKey: Bool = (try? App.databaseController.dbQueue.read { db in
+        // Offline messages are always stored encrypted. The recipient must have registered
+        // a public key (so the sender can encrypt), and the client must set is_encrypted=true.
+        // Plaintext storage is never acceptable — it would let server admins read private messages.
+        let recipientPublicKey: Data? = (try? App.databaseController.dbQueue.read { db in
             let row = try Row.fetchOne(db,
                 sql: "SELECT offline_public_key FROM users WHERE username = ?",
                 arguments: [recipientLogin])
             let keyData = row?["offline_public_key"] as? Data
-            return keyData != nil && !keyData!.isEmpty
-        }) ?? false
+            return (keyData != nil && !keyData!.isEmpty) ? keyData : nil
+        }) ?? nil
 
-        if recipientHasKey && !isEncrypted {
+        guard let _ = recipientPublicKey else {
             App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
-            Logger.warning("Rejected unencrypted offline message for '\(recipientLogin)' — recipient has a public key registered")
+            Logger.warning("Rejected offline message for '\(recipientLogin)' — no public key registered (encryption required)")
+            return
+        }
+
+        guard isEncrypted else {
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+            Logger.warning("Rejected unencrypted offline message for '\(recipientLogin)' — is_encrypted must be true")
             return
         }
 

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -188,13 +188,31 @@ extension ServerController {
     func deliverOfflineMessages(to client: Client) {
         guard let recipientLogin = client.user?.username else { return }
 
-        let messages: [OfflineMessage]
+        struct PendingMessage {
+            let senderLogin: String
+            let senderNick: String?
+            let body: String
+            let sentAt: Date
+        }
+
+        let messages: [PendingMessage]
         do {
             messages = try App.databaseController.dbQueue.read { db in
-                try OfflineMessage
-                    .filter(Column("recipient_login") == recipientLogin)
-                    .order(Column("sent_at").asc)
-                    .fetchAll(db)
+                let rows = try Row.fetchAll(db, sql: """
+                    SELECT om.sender_login, om.body, om.sent_at, u.last_nick AS sender_nick
+                    FROM offline_messages om
+                    LEFT JOIN users u ON u.username = om.sender_login
+                    WHERE om.recipient_login = ?
+                    ORDER BY om.sent_at ASC
+                """, arguments: [recipientLogin])
+                return rows.map {
+                    PendingMessage(
+                        senderLogin: $0["sender_login"],
+                        senderNick: $0["sender_nick"],
+                        body: $0["body"],
+                        sentAt: Date(timeIntervalSince1970: $0["sent_at"])
+                    )
+                }
             }
         } catch {
             Logger.error("Failed to load offline messages for '\(recipientLogin)': \(error)")
@@ -208,6 +226,9 @@ extension ServerController {
             delivery.addParameter(field: "wired.message.offline.sender_login", value: msg.senderLogin)
             delivery.addParameter(field: "wired.message.message", value: msg.body)
             delivery.addParameter(field: "wired.message.offline.date", value: msg.sentAt)
+            if let nick = msg.senderNick, !nick.isEmpty {
+                delivery.addParameter(field: "wired.message.offline.sender_nick", value: nick)
+            }
             _ = self.send(message: delivery, client: client)
         }
 

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import GRDB
 import WiredSwift
 
 extension ServerController {
@@ -119,5 +120,135 @@ extension ServerController {
         App.clientsController.broadcast(message: broadcast)
         App.serverController.replyOK(client: client, message: message)
         self.recordEvent(.messageBroadcasted, client: client)
+    }
+
+    // MARK: - Offline messages
+
+    func receiveMessageSendOfflineMessage(client: Client, message: P7Message) {
+        guard let senderUser = client.user else {
+            App.serverController.replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
+            return
+        }
+
+        guard senderUser.hasPrivilege(name: "wired.account.message.send_offline_messages") else {
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+            return
+        }
+
+        guard let recipientLogin = message.string(forField: "wired.message.offline.recipient_login"),
+              !recipientLogin.isEmpty else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+
+        guard let body = message.string(forField: "wired.message.message"),
+              !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+
+        // Verify the recipient account exists
+        guard App.usersController.userExists(withUsername: recipientLogin) else {
+            App.serverController.replyError(client: client, error: "wired.error.user_not_found", message: message)
+            return
+        }
+
+        // If the recipient is currently online, deliver immediately instead
+        if let onlineClient = App.clientsController.user(withLogin: recipientLogin) {
+            let reply = P7Message(withName: "wired.message.message", spec: self.spec)
+            reply.addParameter(field: "wired.user.id", value: client.userID)
+            reply.addParameter(field: "wired.message.message", value: body)
+            _ = self.send(message: reply, client: onlineClient)
+            App.serverController.replyOK(client: client, message: message)
+            return
+        }
+
+        let senderLogin = senderUser.username ?? ""
+        var offlineMessage = OfflineMessage(
+            senderLogin: senderLogin,
+            recipientLogin: recipientLogin,
+            body: body,
+            sentAt: Date()
+        )
+
+        do {
+            try App.databaseController.dbQueue.write { db in
+                try offlineMessage.insert(db)
+            }
+        } catch {
+            Logger.error("Failed to store offline message for '\(recipientLogin)': \(error)")
+            App.serverController.replyError(client: client, error: "wired.error.internal_error", message: message)
+            return
+        }
+
+        App.serverController.replyOK(client: client, message: message)
+        Logger.info("Offline message from '\(senderLogin)' stored for '\(recipientLogin)'")
+    }
+
+    func deliverOfflineMessages(to client: Client) {
+        guard let recipientLogin = client.user?.username else { return }
+
+        let messages: [OfflineMessage]
+        do {
+            messages = try App.databaseController.dbQueue.read { db in
+                try OfflineMessage
+                    .filter(Column("recipient_login") == recipientLogin)
+                    .order(Column("sent_at").asc)
+                    .fetchAll(db)
+            }
+        } catch {
+            Logger.error("Failed to load offline messages for '\(recipientLogin)': \(error)")
+            return
+        }
+
+        guard !messages.isEmpty else { return }
+
+        for msg in messages {
+            let delivery = P7Message(withName: "wired.message.offline_message", spec: self.spec)
+            delivery.addParameter(field: "wired.message.offline.sender_login", value: msg.senderLogin)
+            delivery.addParameter(field: "wired.message.message", value: msg.body)
+            delivery.addParameter(field: "wired.message.offline.date", value: msg.sentAt)
+            _ = self.send(message: delivery, client: client)
+        }
+
+        do {
+            try App.databaseController.dbQueue.write { db in
+                try OfflineMessage
+                    .filter(Column("recipient_login") == recipientLogin)
+                    .deleteAll(db)
+            }
+        } catch {
+            Logger.error("Failed to delete delivered offline messages for '\(recipientLogin)': \(error)")
+        }
+
+        Logger.info("Delivered \(messages.count) offline message(s) to '\(recipientLogin)'")
+    }
+
+    func sendOfflineUserList(to client: Client) {
+        let onlineLogins = Set(App.clientsController.allConnectedLogins())
+
+        let allLogins: [String]
+        do {
+            allLogins = try App.databaseController.dbQueue.read { db in
+                try String.fetchAll(db, sql: """
+                    SELECT username FROM users
+                    WHERE username IS NOT NULL AND username != ''
+                    ORDER BY username ASC
+                """)
+            }
+        } catch {
+            Logger.error("Failed to load offline user list: \(error)")
+            return
+        }
+
+        for login in allLogins where !onlineLogins.contains(login) {
+            let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
+            msg.addParameter(field: "wired.user.login", value: login)
+            msg.addParameter(field: "wired.user.nick", value: login)
+            _ = self.send(message: msg, client: client)
+        }
+
+        let done = P7Message(withName: "wired.user.offline_list.done", spec: self.spec)
+        _ = self.send(message: done, client: client)
     }
 }

--- a/Sources/wired3/Core/ServerController+Chat.swift
+++ b/Sources/wired3/Core/ServerController+Chat.swift
@@ -227,24 +227,31 @@ extension ServerController {
     func sendOfflineUserList(to client: Client) {
         let onlineLogins = Set(App.clientsController.allConnectedLogins())
 
-        let allLogins: [String]
+        let entries: [(login: String, nick: String)]
         do {
-            allLogins = try App.databaseController.dbQueue.read { db in
-                try String.fetchAll(db, sql: """
-                    SELECT username FROM users
+            entries = try App.databaseController.dbQueue.read { db in
+                let rows = try Row.fetchAll(db, sql: """
+                    SELECT username, full_name FROM users
                     WHERE username IS NOT NULL AND username != ''
+                      AND (last_login_at IS NULL OR last_login_at > unixepoch('now') - 2592000)
                     ORDER BY username ASC
                 """)
+                return rows.map { row in
+                    let login: String = row["username"]
+                    let fullName: String? = row["full_name"]
+                    let nick = (fullName.flatMap { $0.isEmpty ? nil : $0 }) ?? login
+                    return (login: login, nick: nick)
+                }
             }
         } catch {
             Logger.error("Failed to load offline user list: \(error)")
             return
         }
 
-        for login in allLogins where !onlineLogins.contains(login) {
+        for entry in entries where !onlineLogins.contains(entry.login) {
             let msg = P7Message(withName: "wired.user.offline_list", spec: self.spec)
-            msg.addParameter(field: "wired.user.login", value: login)
-            msg.addParameter(field: "wired.user.nick", value: login)
+            msg.addParameter(field: "wired.user.login", value: entry.login)
+            msg.addParameter(field: "wired.user.nick", value: entry.nick)
             _ = self.send(message: msg, client: client)
         }
 

--- a/Sources/wired3/Core/ServerController+Users.swift
+++ b/Sources/wired3/Core/ServerController+Users.swift
@@ -3,6 +3,7 @@
 //  wired3
 //
 import Foundation
+import GRDB
 import WiredSwift
 
 extension ServerController {
@@ -59,12 +60,23 @@ extension ServerController {
         App.serverController.reply(client: client, reply: response, message: message)
 
         // broadcast if already logged in
-        if client.state == .LOGGED_IN && client.user != nil {
+        if client.state == .LOGGED_IN, let username = client.user?.username {
             let newNick = client.nick ?? ""
             if previousNick != newNick {
                 self.recordEvent(.userChangedNick, client: client, parameters: [previousNick, newNick])
+                persistLastNick(newNick, forUsername: username)
             }
             self.sendUserStatus(forClient: client)
+        }
+    }
+
+    func persistLastNick(_ nick: String, forUsername username: String) {
+        guard !nick.isEmpty else { return }
+        try? App.databaseController.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE users SET last_nick = ? WHERE username = ?",
+                arguments: [nick, username]
+            )
         }
     }
 

--- a/Sources/wired3/Core/ServerController+Users.swift
+++ b/Sources/wired3/Core/ServerController+Users.swift
@@ -70,6 +70,49 @@ extension ServerController {
         }
     }
 
+    func receiveUserSetPublicKey(_ client: Client, _ message: P7Message) {
+        guard client.user != nil else {
+            replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
+            return
+        }
+        guard let keyData = message.data(forField: "wired.user.public_key"),
+              keyData.count == 32 else {
+            replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        let username = client.user?.username ?? ""
+        try? App.databaseController.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE users SET offline_public_key = ?, offline_key_id = 'x25519' WHERE username = ?",
+                arguments: [keyData, username]
+            )
+        }
+        replyOK(client: client, message: message)
+    }
+
+    func receiveUserGetPublicKey(_ client: Client, _ message: P7Message) {
+        guard client.user != nil else {
+            replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
+            return
+        }
+        guard let login = message.string(forField: "wired.user.login"), !login.isEmpty else {
+            replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        let keyData: Data? = try? App.databaseController.dbQueue.read { db in
+            guard let row = try Row.fetchOne(db, sql: "SELECT offline_public_key FROM users WHERE username = ?", arguments: [login]) else {
+                return nil
+            }
+            return row["offline_public_key"] as? Data
+        }
+        let reply = P7Message(withName: "wired.user.public_key", spec: self.spec)
+        reply.addParameter(field: "wired.user.login", value: login)
+        if let data = keyData, !data.isEmpty {
+            reply.addParameter(field: "wired.user.public_key", value: data)
+        }
+        self.reply(client: client, reply: reply, message: message)
+    }
+
     func persistLastNick(_ nick: String, forUsername username: String) {
         guard !nick.isEmpty else { return }
         try? App.databaseController.dbQueue.write { db in

--- a/Sources/wired3/Core/ServerController+Users.swift
+++ b/Sources/wired3/Core/ServerController+Users.swift
@@ -95,7 +95,7 @@ extension ServerController {
             replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
             return
         }
-        guard let login = message.string(forField: "wired.user.login"), !login.isEmpty else {
+        guard let login = message.string(forField: "wired.message.offline.recipient_login"), !login.isEmpty else {
             replyError(client: client, error: "wired.error.invalid_message", message: message)
             return
         }
@@ -106,7 +106,7 @@ extension ServerController {
             return row["offline_public_key"] as? Data
         }
         let reply = P7Message(withName: "wired.user.public_key", spec: self.spec)
-        reply.addParameter(field: "wired.user.login", value: login)
+        reply.addParameter(field: "wired.message.offline.recipient_login", value: login)
         if let data = keyData, !data.isEmpty {
             reply.addParameter(field: "wired.user.public_key", value: data)
         }

--- a/Sources/wired3/Core/ServerController.swift
+++ b/Sources/wired3/Core/ServerController.swift
@@ -711,6 +711,8 @@ public class ServerController: ServerDelegate {
             App.chatsController.kickUser(message: message, client: client)
         } else if message.name == "wired.message.send_message" {
             self.receiveMessageSendMessage(client: client, message: message)
+        } else if message.name == "wired.message.send_offline_message" {
+            self.receiveMessageSendOfflineMessage(client: client, message: message)
         } else if message.name == "wired.message.send_broadcast" {
             self.receiveMessageSendBroadcast(client: client, message: message)
         } else if message.name == "wired.attachment.create" {

--- a/Sources/wired3/Core/ServerController.swift
+++ b/Sources/wired3/Core/ServerController.swift
@@ -683,6 +683,10 @@ public class ServerController: ServerDelegate {
             self.receiveUserDisconnectUser(client: client, message: message)
         } else if message.name == "wired.user.ban_user" {
             self.receiveUserBanUser(client: client, message: message)
+        } else if message.name == "wired.user.set_public_key" {
+            self.receiveUserSetPublicKey(client, message)
+        } else if message.name == "wired.user.get_public_key" {
+            self.receiveUserGetPublicKey(client, message)
         } else if message.name == "wired.chat.get_chats" {
             App.chatsController.getChats(message: message, client: client)
         } else if message.name == "wired.chat.create_public_chat" {

--- a/Sources/wired3/Core/ServerController.swift
+++ b/Sources/wired3/Core/ServerController.swift
@@ -900,12 +900,12 @@ public class ServerController: ServerDelegate {
 
         message.addParameter(field: "wired.info.os.version", value: ProcessInfo.processInfo.operatingSystemVersionString)
 
-        #if os(iOS)
-        message.addParameter(field: "wired.info.arch", value: "armv7")
-        #elseif os(macOS)
+        #if arch(arm64)
+        message.addParameter(field: "wired.info.arch", value: "arm64")
+        #elseif arch(x86_64)
         message.addParameter(field: "wired.info.arch", value: "x86_64")
         #else
-        message.addParameter(field: "wired.info.arch", value: "x86_64")
+        message.addParameter(field: "wired.info.arch", value: "unknown")
         #endif
 
         message.addParameter(field: "wired.info.supports_rsrc", value: false)

--- a/Sources/wired3/Core/Version.swift
+++ b/Sources/wired3/Core/Version.swift
@@ -3,7 +3,7 @@ import Foundation
 public enum WiredServerVersion {
     public static let marketingVersion = "3.0-beta.23"
     public static let buildNumber = "43"
-    public static let commit = "a478981"
+    public static let commit = "33d2065"
     public static let number = marketingVersion
     public static let display = "wired3 \(marketingVersion) (\(buildNumber)+\(commit))"
 }

--- a/Sources/wired3/Core/Version.swift
+++ b/Sources/wired3/Core/Version.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public enum WiredServerVersion {
-    public static let marketingVersion = "3.0"
-    public static let buildNumber = "42"
-    public static let commit = "local"
+    public static let marketingVersion = "3.0-beta.23"
+    public static let buildNumber = "43"
+    public static let commit = "a478981"
     public static let number = marketingVersion
     public static let display = "wired3 \(marketingVersion) (\(buildNumber)+\(commit))"
 }

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -41,6 +41,9 @@ enum WiredMigrations {
         migrator.registerMigration("v11_tracked_servers") { db in
             try WiredMigrations.v11(db)
         }
+        migrator.registerMigration("v12_add_is_legacy") { db in
+            try WiredMigrations.v12(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -202,6 +205,18 @@ enum WiredMigrations {
                       on: "tracked_servers",
                       columns: ["last_seen_at"],
                       ifNotExists: true)
+    }
+
+    static func v12(_ db: Database) throws {
+        try db.alter(table: "users") { t in
+            t.add(column: "is_legacy", .boolean).notNull().defaults(to: false)
+        }
+        // Back-fill: any account that still has no salt and a 40-char (SHA1) hash is legacy.
+        try db.execute(sql: """
+            UPDATE users SET is_legacy = 1
+            WHERE (password_salt IS NULL OR password_salt = '')
+              AND length(password) = 40
+        """)
     }
 
     // SECURITY (FINDING_A_004): Add password_salt column for salted SHA-256 hashing

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -50,6 +50,9 @@ enum WiredMigrations {
         migrator.registerMigration("v14_last_login_at") { db in
             try WiredMigrations.v14(db)
         }
+        migrator.registerMigration("v15_last_nick") { db in
+            try WiredMigrations.v15(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -431,6 +434,13 @@ enum WiredMigrations {
                        WHERE recipient_identity = NEW.recipient_identity) >= 100;
             END;
         """)
+    }
+
+    // v15: Persist the user's last known chat nick so the offline user list can show it.
+    static func v15(_ db: Database) throws {
+        try db.alter(table: "users") { t in
+            t.add(column: "last_nick", .text)
+        }
     }
 
     // v14: Add last_login_at to users so we can filter the offline user list to recent accounts.

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -53,6 +53,9 @@ enum WiredMigrations {
         migrator.registerMigration("v15_last_nick") { db in
             try WiredMigrations.v15(db)
         }
+        migrator.registerMigration("v16_offline_messages_encrypted") { db in
+            try WiredMigrations.v16(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -434,6 +437,12 @@ enum WiredMigrations {
                        WHERE recipient_identity = NEW.recipient_identity) >= 100;
             END;
         """)
+    }
+
+    static func v16(_ db: Database) throws {
+        try db.alter(table: "offline_messages") { t in
+            t.add(column: "is_encrypted", .integer).notNull().defaults(to: 0)
+        }
     }
 
     // v15: Persist the user's last known chat nick so the offline user list can show it.

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -47,6 +47,9 @@ enum WiredMigrations {
         migrator.registerMigration("v13_offline_messages") { db in
             try WiredMigrations.v13(db)
         }
+        migrator.registerMigration("v14_last_login_at") { db in
+            try WiredMigrations.v14(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -428,6 +431,13 @@ enum WiredMigrations {
                        WHERE recipient_identity = NEW.recipient_identity) >= 100;
             END;
         """)
+    }
+
+    // v14: Add last_login_at to users so we can filter the offline user list to recent accounts.
+    static func v14(_ db: Database) throws {
+        try db.alter(table: "users") { t in
+            t.add(column: "last_login_at", .real)
+        }
     }
 
     // v13: Replace the speculative E2E-encrypted offline_messages schema (never used)

--- a/Sources/wired3/Database/WiredMigrations.swift
+++ b/Sources/wired3/Database/WiredMigrations.swift
@@ -44,6 +44,9 @@ enum WiredMigrations {
         migrator.registerMigration("v12_add_is_legacy") { db in
             try WiredMigrations.v12(db)
         }
+        migrator.registerMigration("v13_offline_messages") { db in
+            try WiredMigrations.v13(db)
+        }
     }
 
     static func v2(_ db: Database) throws {
@@ -423,6 +426,39 @@ enum WiredMigrations {
                 SELECT RAISE(ABORT, 'per-recipient offline message limit exceeded')
                 WHERE (SELECT COUNT(*) FROM offline_messages
                        WHERE recipient_identity = NEW.recipient_identity) >= 100;
+            END;
+        """)
+    }
+
+    // v13: Replace the speculative E2E-encrypted offline_messages schema (never used)
+    //      with a simple plaintext table that matches our actual implementation.
+    static func v13(_ db: Database) throws {
+        try db.execute(sql: "DROP TRIGGER IF EXISTS offline_messages_per_recipient_limit")
+        try db.execute(sql: "DROP INDEX IF EXISTS offline_messages_recipient_index")
+        try db.execute(sql: "DROP INDEX IF EXISTS offline_messages_expires_index")
+        try db.execute(sql: "DROP TABLE IF EXISTS offline_messages")
+
+        try db.create(table: "offline_messages") { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("sender_login", .text).notNull()
+            t.column("recipient_login", .text).notNull()
+            t.column("body", .text).notNull()
+            t.column("sent_at", .datetime).notNull()
+        }
+        try db.create(
+            index: "offline_messages_recipient_index",
+            on: "offline_messages",
+            columns: ["recipient_login"]
+        )
+
+        // Limit: max 100 queued messages per recipient to prevent storage DoS
+        try db.execute(sql: """
+            CREATE TRIGGER offline_messages_per_recipient_limit
+            BEFORE INSERT ON offline_messages
+            BEGIN
+                SELECT RAISE(ABORT, 'per-recipient offline message limit exceeded')
+                WHERE (SELECT COUNT(*) FROM offline_messages
+                       WHERE recipient_login = NEW.recipient_login) >= 100;
             END;
         """)
     }

--- a/Sources/wired3/Models/OfflineMessage.swift
+++ b/Sources/wired3/Models/OfflineMessage.swift
@@ -1,0 +1,29 @@
+//
+//  OfflineMessage.swift
+//  wired3
+//
+
+import GRDB
+import Foundation
+
+struct OfflineMessage: Codable, FetchableRecord, MutablePersistableRecord {
+    static let databaseTableName = "offline_messages"
+
+    var id: Int64?
+    var senderLogin: String
+    var recipientLogin: String
+    var body: String
+    var sentAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case senderLogin    = "sender_login"
+        case recipientLogin = "recipient_login"
+        case body
+        case sentAt         = "sent_at"
+    }
+
+    mutating func didInsert(_ inserted: InsertionSuccess) {
+        id = inserted.rowID
+    }
+}

--- a/Sources/wired3/Models/OfflineMessage.swift
+++ b/Sources/wired3/Models/OfflineMessage.swift
@@ -14,6 +14,7 @@ struct OfflineMessage: Codable, FetchableRecord, MutablePersistableRecord {
     var recipientLogin: String
     var body: String
     var sentAt: Date
+    var isEncrypted: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -21,6 +22,7 @@ struct OfflineMessage: Codable, FetchableRecord, MutablePersistableRecord {
         case recipientLogin = "recipient_login"
         case body
         case sentAt         = "sent_at"
+        case isEncrypted    = "is_encrypted"
     }
 
     mutating func didInsert(_ inserted: InsertionSuccess) {

--- a/Sources/wired3/Models/User.swift
+++ b/Sources/wired3/Models/User.swift
@@ -40,6 +40,9 @@ public class User: Codable, FetchableRecord, PersistableRecord {
     public var username: String?
     public var password: String?
     public var passwordSalt: String?
+    /// `true` when the account was migrated from Wired 2.5 and still holds a raw SHA1 hash.
+    /// Cleared to `false` once the user completes a password-change flow.
+    public var isLegacy: Bool
     public var fullName: String?
     public var identity: String?
     public var comment: String?
@@ -64,6 +67,7 @@ public class User: Codable, FetchableRecord, PersistableRecord {
         case username
         case password
         case passwordSalt = "password_salt"
+        case isLegacy = "is_legacy"
         case fullName = "full_name"
         case identity
         case comment
@@ -92,6 +96,7 @@ public class User: Codable, FetchableRecord, PersistableRecord {
         username            = try c.decodeIfPresent(String.self, forKey: .username)
         password            = try c.decodeIfPresent(String.self, forKey: .password)
         passwordSalt        = try c.decodeIfPresent(String.self, forKey: .passwordSalt)
+        isLegacy            = (try? c.decode(Bool.self, forKey: .isLegacy)) ?? false
         fullName            = try c.decodeIfPresent(String.self, forKey: .fullName)
         identity            = try c.decodeIfPresent(String.self, forKey: .identity)
         comment             = try c.decodeIfPresent(String.self, forKey: .comment)
@@ -121,9 +126,10 @@ public class User: Codable, FetchableRecord, PersistableRecord {
     /// - Parameters:
     ///   - username: The account login name.
     ///   - password: The hashed password string.
-    public init(username: String, password: String) {
+    public init(username: String, password: String, isLegacy: Bool = false) {
         self.username = username
         self.password = password
+        self.isLegacy = isLegacy
     }
 
     /// Returns whether this user belongs to the named group.

--- a/Sources/wired3/main.swift
+++ b/Sources/wired3/main.swift
@@ -55,10 +55,24 @@ struct Wired: ParsableCommand {
           help: "When used with --migrate-from: overwrite existing records in the Wired 3 database.")
     var overwrite = false
 
+    @Option(name: .customLong("check-access"),
+            help: "Test whether this binary can read the given path, then exit (0 = ok, 1 = denied). Used by WiredServerApp for FDA status checks.")
+    var checkAccess: String?
+
     @Argument(help: "Optional working directory path. For compatibility, an .xml path here is treated as the specification file path.")
     var path: String?
 
     mutating func run() throws {
+        if let accessPath = checkAccess {
+            let url = URL(fileURLWithPath: (accessPath as NSString).expandingTildeInPath)
+            do {
+                _ = try FileManager.default.contentsOfDirectory(atPath: url.path)
+                Foundation.exit(0)
+            } catch {
+                Foundation.exit(1)
+            }
+        }
+
         if showVersion {
             print(WiredServerVersion.display)
             return

--- a/Sources/wired3/main.swift
+++ b/Sources/wired3/main.swift
@@ -149,10 +149,20 @@ struct Wired: ParsableCommand {
         }
         sigusr1Source.resume()
 
+        // Install SIGUSR2 handler for on-demand database snapshot.
+        signal(SIGUSR2, SIG_IGN)
+        let sigusr2Source = DispatchSource.makeSignalSource(signal: SIGUSR2, queue: DispatchQueue.global())
+        sigusr2Source.setEventHandler {
+            Logger.info("SIGUSR2 received, triggering database snapshot...")
+            App.createDatabaseSnapshot()
+        }
+        sigusr2Source.resume()
+
         App.start()
 
         sighupSource.cancel()
         sigusr1Source.cancel()
+        sigusr2Source.cancel()
         try? FileManager.default.removeItem(atPath: resolved.pidPath)
     }
 

--- a/Sources/wired3/main.swift
+++ b/Sources/wired3/main.swift
@@ -47,6 +47,14 @@ struct Wired: ParsableCommand {
     @Option(help: "Path to XML specification file")
     var spec: String?
 
+    @Option(name: .customLong("migrate-from"),
+            help: "Path to a Wired 2.5 SQLite database. Migrates users, groups and bans into the Wired 3 database, then exits.")
+    var migrateFrom: String?
+
+    @Flag(name: .customLong("overwrite"),
+          help: "When used with --migrate-from: overwrite existing records in the Wired 3 database.")
+    var overwrite = false
+
     @Argument(help: "Optional working directory path. For compatibility, an .xml path here is treated as the specification file path.")
     var path: String?
 
@@ -74,6 +82,40 @@ struct Wired: ParsableCommand {
         }
         bootstrapRuntimeFiles(using: resolved)
         configureLogger(logFilePath: resolved.logPath, configPath: resolved.configPath)
+
+        // ── Wired 2.5 → Wired 3 migration ────────────────────────────────────────
+        if let rawSourcePath = migrateFrom {
+            // Disable C-stdio buffering so every print() call writes immediately.
+            // Without this, output is fully-buffered on pipes/files and gets lost on crash.
+            setvbuf(stdout, nil, _IONBF, 0)
+            setvbuf(stderr, nil, _IONBF, 0)
+            let expandedSourcePath = (rawSourcePath as NSString).expandingTildeInPath
+            guard let spec = P7Spec(withUrl: URL(fileURLWithPath: resolved.specPath)) else {
+                fputs("wired3: cannot load spec at \(resolved.specPath)\n", stderr)
+                Foundation.exit(1)
+            }
+            let dbController = DatabaseController(
+                baseURL: URL(fileURLWithPath: resolved.dbPath),
+                spec: spec
+            )
+            guard dbController.initDatabase() else {
+                fputs("wired3: cannot open database at \(resolved.dbPath)\n", stderr)
+                Foundation.exit(1)
+            }
+            let migrator = MigrationController(
+                sourcePath: expandedSourcePath,
+                dbQueue: dbController.dbQueue,
+                overwrite: overwrite
+            )
+            do {
+                let result = try migrator.run()
+                result.printSummary()
+            } catch {
+                fputs("wired3: migration failed: \(error)\n", stderr)
+                Foundation.exit(1)
+            }
+            return
+        }
 
         Logger.info("Starting \(WiredServerVersion.display)")
 

--- a/Tests/wired3Tests/MigrationControllerTests.swift
+++ b/Tests/wired3Tests/MigrationControllerTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+import GRDB
+@testable import wired3Lib
+
+final class MigrationControllerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Creates a minimal Wired 2.5 SQLite database at `url` with the given users.
+    private func makeWired25DB(at url: URL, users: [(name: String, password: String)] = []) throws {
+        let db = try DatabaseQueue(path: url.path)
+        try db.write { db in
+            try db.execute(sql: """
+                CREATE TABLE users (
+                    name TEXT PRIMARY KEY,
+                    password TEXT NOT NULL,
+                    full_name TEXT, comment TEXT,
+                    creation_time TEXT, modification_time TEXT, login_time TEXT,
+                    edited_by TEXT,
+                    downloads INTEGER DEFAULT 0, download_transferred INTEGER DEFAULT 0,
+                    uploads INTEGER DEFAULT 0, upload_transferred INTEGER DEFAULT 0,
+                    "group" TEXT, groups TEXT, color TEXT, files TEXT,
+                    user_get_info INTEGER DEFAULT 0,
+                    account_change_password INTEGER DEFAULT 1
+                )
+            """)
+            try db.execute(sql: """
+                CREATE TABLE groups (
+                    name TEXT PRIMARY KEY, color TEXT,
+                    user_get_info INTEGER DEFAULT 0
+                )
+            """)
+            try db.execute(sql: """
+                CREATE TABLE banlist (ip TEXT PRIMARY KEY, expiration_date TEXT)
+            """)
+            try db.execute(sql: """
+                CREATE TABLE boards (board TEXT PRIMARY KEY, owner TEXT, "group" TEXT, mode INTEGER DEFAULT 420)
+            """)
+            try db.execute(sql: "CREATE TABLE threads (thread TEXT PRIMARY KEY, board TEXT, subject TEXT, text TEXT, post_date TEXT, edit_date TEXT, nick TEXT, login TEXT, icon BLOB)")
+            try db.execute(sql: "CREATE TABLE posts   (post   TEXT PRIMARY KEY, thread TEXT, text TEXT, post_date TEXT, edit_date TEXT, nick TEXT, login TEXT, icon BLOB)")
+
+            for user in users {
+                try db.execute(
+                    sql: "INSERT INTO users (name, password) VALUES (?, ?)",
+                    arguments: [user.name, user.password]
+                )
+            }
+        }
+    }
+
+    // MARK: - Migration: is_legacy flag
+
+    func testMigratedUserHasIsLegacySet() throws {
+        let tempDir = try makeTemporaryDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: tempDir) }
+
+        let srcURL = tempDir.appendingPathComponent("wired25.sqlite")
+        let sha1Hash = String(repeating: "a", count: 40) // fake 40-char SHA1
+
+        try makeWired25DB(at: srcURL, users: [("alice", sha1Hash)])
+
+        let dc = makeDatabaseController(tempDir: tempDir)
+        let controller = MigrationController(
+            sourcePath: srcURL.path,
+            dbQueue: dc.dbQueue,
+            overwrite: false
+        )
+        let result = try controller.run()
+
+        XCTAssertEqual(result.usersMigrated, 1)
+        XCTAssertEqual(result.usersSkipped, 0)
+
+        let user = try dc.dbQueue.read { db in
+            try User.filter(Column("username") == "alice").fetchOne(db)
+        }
+        XCTAssertNotNil(user)
+        XCTAssertTrue(user!.isLegacy, "Migrated user must have is_legacy = true")
+        XCTAssertNil(user!.passwordSalt, "Migrated user must have no salt yet")
+    }
+
+    func testMigratedUserSkippedWithoutOverwrite() throws {
+        let tempDir = try makeTemporaryDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: tempDir) }
+
+        let srcURL = tempDir.appendingPathComponent("wired25.sqlite")
+        try makeWired25DB(at: srcURL, users: [("bob", String(repeating: "b", count: 40))])
+
+        let dc = makeDatabaseController(tempDir: tempDir)
+
+        // First migration — inserts bob
+        let first = MigrationController(sourcePath: srcURL.path, dbQueue: dc.dbQueue, overwrite: false)
+        let r1 = try first.run()
+        XCTAssertEqual(r1.usersMigrated, 1)
+
+        // Second migration without --overwrite — bob must be skipped
+        let second = MigrationController(sourcePath: srcURL.path, dbQueue: dc.dbQueue, overwrite: false)
+        let r2 = try second.run()
+        XCTAssertEqual(r2.usersMigrated, 0)
+        XCTAssertEqual(r2.usersSkipped, 1)
+    }
+
+    func testMigratedUserOverwritten() throws {
+        let tempDir = try makeTemporaryDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: tempDir) }
+
+        let srcURL = tempDir.appendingPathComponent("wired25.sqlite")
+        let hash1 = String(repeating: "c", count: 40)
+        try makeWired25DB(at: srcURL, users: [("carol", hash1)])
+
+        let dc = makeDatabaseController(tempDir: tempDir)
+
+        let first = MigrationController(sourcePath: srcURL.path, dbQueue: dc.dbQueue, overwrite: false)
+        _ = try first.run()
+
+        let second = MigrationController(sourcePath: srcURL.path, dbQueue: dc.dbQueue, overwrite: true)
+        let r2 = try second.run()
+        XCTAssertEqual(r2.usersMigrated, 1)
+        XCTAssertEqual(r2.usersSkipped, 0)
+    }
+
+    // MARK: - Legacy auth detection
+
+    func testIsLegacyUserReturnsTrueAfterMigration() throws {
+        let tempDir = try makeTemporaryDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: tempDir) }
+
+        let srcURL = tempDir.appendingPathComponent("wired25.sqlite")
+        try makeWired25DB(at: srcURL, users: [("dan", String(repeating: "d", count: 40))])
+
+        let dc = makeDatabaseController(tempDir: tempDir)
+        let controller = MigrationController(sourcePath: srcURL.path, dbQueue: dc.dbQueue, overwrite: false)
+        _ = try controller.run()
+
+        let usersController = UsersController(databaseController: dc)
+        XCTAssertTrue(usersController.isLegacyUser(username: "dan"))
+    }
+
+    func testIsLegacyUserReturnsFalseForNormalAccount() throws {
+        let tempDir = try makeTemporaryDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: tempDir) }
+
+        let dc = makeDatabaseController(tempDir: tempDir)
+        let usersController = UsersController(databaseController: dc)
+
+        // admin account created by initDatabase() is a normal SHA256 account
+        XCTAssertFalse(usersController.isLegacyUser(username: "admin"))
+    }
+
+    func testIsLegacyFlagClearedAfterPasswordSaved() throws {
+        let tempDir = try makeTemporaryDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: tempDir) }
+
+        let srcURL = tempDir.appendingPathComponent("wired25.sqlite")
+        try makeWired25DB(at: srcURL, users: [("eve", String(repeating: "e", count: 40))])
+
+        let dc = makeDatabaseController(tempDir: tempDir)
+        _ = try MigrationController(sourcePath: srcURL.path, dbQueue: dc.dbQueue, overwrite: false).run()
+
+        // Simulate password upgrade: set SHA256 password + salt + clear is_legacy
+        let user = try dc.dbQueue.read { db in try User.filter(Column("username") == "eve").fetchOne(db)! }
+        user.password = "newpassword".sha256()
+        user.passwordSalt = "somesalt"
+        user.isLegacy = false
+
+        let usersController = UsersController(databaseController: dc)
+        XCTAssertTrue(usersController.save(user: user))
+
+        XCTAssertFalse(usersController.isLegacyUser(username: "eve"))
+    }
+
+    // MARK: - is_legacy column behaviour
+
+    func testIsLegacyColumnDefaultsToFalseForNewAccounts() throws {
+        let tempDir = try makeTemporaryDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: tempDir) }
+
+        let dc = makeDatabaseController(tempDir: tempDir)
+        let usersController = UsersController(databaseController: dc)
+
+        let user = User(username: "frank", password: "password".sha256())
+        XCTAssertTrue(usersController.save(user: user))
+        XCTAssertFalse(usersController.isLegacyUser(username: "frank"))
+    }
+
+    func testIsLegacyColumnReadCorrectlyWhenSetDirectly() throws {
+        // Verifies that isLegacyUser() reads the is_legacy column — mirrors what the
+        // v12 back-fill UPDATE produces in a database upgraded from an earlier version.
+        let tempDir = try makeTemporaryDirectory()
+        addTeardownBlock { try? FileManager.default.removeItem(at: tempDir) }
+
+        let dc = makeDatabaseController(tempDir: tempDir)
+
+        try dc.dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO users (username, password, is_legacy) VALUES (?, ?, 1)",
+                arguments: ["grace", String(repeating: "g", count: 40)]
+            )
+        }
+
+        let usersController = UsersController(databaseController: dc)
+        XCTAssertTrue(usersController.isLegacyUser(username: "grace"))
+    }
+}


### PR DESCRIPTION
## Summary

### Manual database snapshot
- **\"Create Snapshot Now\" button** — new button in the Database settings tab triggers a SQLite backup on demand without waiting for the automatic interval
- **SIGUSR2 signal handler** — added to `main.swift`, follows the same pattern as the existing SIGUSR1 (reindex) handler; `AppController.createDatabaseSnapshot()` promoted from `private` to `public` to cross the module boundary
- **Daemon mode** — signal is delivered via `launchctl kill SIGUSR2 system/fr.read-write.wired3.server` (privileged, same Touch ID/password flow as stop/start), because a plain `kill()` is rejected by macOS when the app and daemon run as different OS users (`maertin` vs `_wired`)
- **Button state** — enabled based on PID file existence (not `isRunning`), so it works correctly in daemon mode where `isRunning` is not set

### Snapshot safety fix
- `DatabaseController.createSnapshot()` previously deleted the existing `.bak` *before* the new backup succeeded — a failed backup destroyed the previous good backup
- Fixed: `.bak` is only replaced after the new backup completes successfully; a failed backup also cleans up its `.tmp` immediately instead of leaving a stale 0-byte file behind

### Binary code-signing fix after install
- After `installBinaryWithStagingRollback` copies `wired3` from the app bundle to `/Library/Wired3/bin/`, macOS killed it immediately with `SIGKILL (Code Signature Invalid / Invalid Page)`
- Root cause: `codesign --deep` on the app bundle overwrites the embedded server binary's standalone signature with a bundle-context one that fails validation when the binary runs as a standalone process outside the bundle
- Fix: `installBinaryWithStagingRollback` now runs `codesign --force --sign -` on the destination binary after all content hash checks pass, giving it a fresh standalone ad-hoc signature

### Dashboard Live Status fix
- PID, Uptime, CPU, and Memory fields were always blank in daemon mode
- Root cause: `activeServerPIDs()` uses `lsof -t <dbPath>` which requires root to see processes owned by a different OS user (`_wired`), returning nothing for the app user
- Fix: in daemon mode, the PID is read directly from the `wired3.pid` file the server writes on startup; agent mode keeps the existing `lsof` approach

## Test plan

- [ ] Build with `bash Scripts/release.sh`, install new app, trigger binary update
- [ ] Server restarts cleanly — no SIGKILL crash; app log shows `binary-update: ad-hoc signature applied`
- [ ] Dashboard → Live Status: PID, Uptime, CPU, Memory populate within ~2 seconds of daemon start
- [ ] Database tab → \"Create Snapshot Now\" button is enabled while daemon is running, disabled when stopped
- [ ] Click button — Touch ID / password prompt appears, server log shows `Database snapshot written to ...`, `wired3.db.bak` is created/updated
- [ ] Kill server mid-snapshot (if possible) — old `.bak` is preserved, no stale `.tmp` on next start

🤖 Generated with [Claude Code](https://claude.com/claude-code)