### PR TITLE
fix(server): report actual CPU architecture instead of hardcoded x86_64

### DIFF
--- a/Sources/wired3/Core/ServerController.swift
+++ b/Sources/wired3/Core/ServerController.swift
@@ -894,12 +894,12 @@ public class ServerController: ServerDelegate {
 
         message.addParameter(field: "wired.info.os.version", value: ProcessInfo.processInfo.operatingSystemVersionString)
 
-        #if os(iOS)
-        message.addParameter(field: "wired.info.arch", value: "armv7")
-        #elseif os(macOS)
+        #if arch(arm64)
+        message.addParameter(field: "wired.info.arch", value: "arm64")
+        #elseif arch(x86_64)
         message.addParameter(field: "wired.info.arch", value: "x86_64")
         #else
-        message.addParameter(field: "wired.info.arch", value: "x86_64")
+        message.addParameter(field: "wired.info.arch", value: "unknown")
         #endif
 
         message.addParameter(field: "wired.info.supports_rsrc", value: false)


### PR DESCRIPTION
## Problem

`ServerController` reported the server architecture via a compile-time OS check
(`#if os(macOS)`) that always resolves to `"x86_64"`, regardless of the actual
CPU architecture the binary is running on. On Apple Silicon Macs the process
runs as `arm64` but Wired clients see `x86_64` in the Server Info view.

## Fix

Replace the `#if os(…)` guard with compile-time **architecture** detection so
the correct value is baked into each binary slice at build time:

```swift
// Before
#if os(iOS)
message.addParameter(field: "wired.info.arch", value: "armv7")
#elseif os(macOS)
message.addParameter(field: "wired.info.arch", value: "x86_64")  // wrong on arm64
#else
message.addParameter(field: "wired.info.arch", value: "x86_64")
#endif

// After
#if arch(arm64)
message.addParameter(field: "wired.info.arch", value: "arm64")
#elseif arch(x86_64)
message.addParameter(field: "wired.info.arch", value: "x86_64")
#else
message.addParameter(field: "wired.info.arch", value: "unknown")
#endif
```

Universal binaries (arm64 + x86_64 fat binary) report the correct slice at
runtime. An `"unknown"` fallback is provided for any future architecture.

## Verified

Tested on Apple Silicon (M-series): Server Info in the Wired client now
correctly shows `arm64` instead of `x86_64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)