### PR TITLE
fix(server-app): re-sign binary after install + fix dashboard PID in daemon mode

### DIFF
--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -1179,6 +1179,17 @@ final class WiredServerViewModel: ObservableObject {
                 throw WiredServerError.binaryIntegrityCheckFailed("installed hash mismatch")
             }
 
+            // Re-sign with an ad-hoc signature. When the wired3 binary is extracted
+            // from the app bundle and placed at /Library/Wired3/bin/ as a standalone
+            // executable, macOS code-signing validation (SIGKILL/Invalid Page) requires
+            // an individual signature — the bundle signature it inherited is not enough.
+            let signResult = runProcess("/usr/bin/codesign", ["--force", "--sign", "-", destinationURL.path])
+            if signResult.status != 0 {
+                appendRuntimeLog("binary-update: codesign warning — \(signResult.output.trimmingCharacters(in: .whitespacesAndNewlines))")
+            } else {
+                appendRuntimeLog("binary-update: ad-hoc signature applied")
+            }
+
             if fileManager.fileExists(atPath: backupURL.path) {
                 try? fileManager.removeItem(at: backupURL)
             }
@@ -1281,8 +1292,13 @@ final class WiredServerViewModel: ObservableObject {
     private func refreshDashboardLightweight() {
         dashboardHostUptime = formattedDuration(ProcessInfo.processInfo.systemUptime)
 
-        let activePIDs = activeServerPIDs()
-        if let pid = activePIDs.first {
+        // In daemon mode lsof can't cross the user boundary (_wired vs. maertin),
+        // so read the PID directly from the PID file the server writes on startup.
+        let pid: Int32? = installMode == .launchDaemon
+            ? serverPIDFromFile()
+            : activeServerPIDs().first
+
+        if let pid {
             dashboardServerPID = String(pid)
             let metrics = processMetrics(for: pid)
             dashboardServerUptime = metrics.uptime
@@ -1298,6 +1314,13 @@ final class WiredServerViewModel: ObservableObject {
         }
 
         dashboardLastErrorLine = extractLastErrorLine(from: logsText)
+    }
+
+    private func serverPIDFromFile() -> Int32? {
+        let pidPath = URL(fileURLWithPath: workingDirectory)
+            .appendingPathComponent("wired3.pid").path
+        guard let raw = try? String(contentsOfFile: pidPath, encoding: .utf8) else { return nil }
+        return pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
     private func refreshDashboardHeavyweight() {

--- a/Sources/WiredSwift/Core/WiredProtocolSpec.swift
+++ b/Sources/WiredSwift/Core/WiredProtocolSpec.swift
@@ -2,7 +2,21 @@ import Foundation
 
 public enum WiredProtocolSpec {
     public static func bundledSpecURL() -> URL? {
-        Bundle.module.url(forResource: "wired", withExtension: "xml")
+        // Bundle.module crashes with assertionFailure when the SPM .bundle directory
+        // is missing from the app package. Search manually instead, then fall back to
+        // Bundle.main.resourceURL where the build script also copies wired.xml directly.
+        let candidates: [URL?] = [
+            Bundle.main.resourceURL?.appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+            Bundle.main.executableURL?.deletingLastPathComponent()
+                .appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+        ]
+        for case let bundleURL? in candidates {
+            if let b = Bundle(url: bundleURL),
+               let url = b.url(forResource: "wired", withExtension: "xml") {
+                return url
+            }
+        }
+        return Bundle.main.url(forResource: "wired", withExtension: "xml")
     }
 
     public static func bundledSpec() -> P7Spec? {

--- a/Sources/WiredSwift/Core/WiredProtocolSpec.swift
+++ b/Sources/WiredSwift/Core/WiredProtocolSpec.swift
@@ -3,12 +3,21 @@ import Foundation
 public enum WiredProtocolSpec {
     public static func bundledSpecURL() -> URL? {
         // Bundle.module crashes with assertionFailure when the SPM .bundle directory
-        // is missing from the app package. Search manually instead, then fall back to
-        // Bundle.main.resourceURL where the build script also copies wired.xml directly.
+        // is missing from the app package. Search manually instead.
+        //
+        // Path reasoning:
+        //  - Production app:    Bundle.main.resourceURL / Contents/Resources
+        //  - Linux swift test:  executable is in .build/debug/, bundle is beside it
+        //  - macOS swift test:  Bundle.main.bundleURL is the .xctest package;
+        //                       its parent directory is .build/debug/ where the
+        //                       WiredSwift_WiredSwift.bundle actually lives
+        let bundleName = "WiredSwift_WiredSwift"
         let candidates: [URL?] = [
-            Bundle.main.resourceURL?.appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+            Bundle.main.resourceURL?.appendingPathComponent("\(bundleName).bundle"),
             Bundle.main.executableURL?.deletingLastPathComponent()
-                .appendingPathComponent("WiredSwift_WiredSwift.bundle"),
+                .appendingPathComponent("\(bundleName).bundle"),
+            Bundle.main.bundleURL.deletingLastPathComponent()
+                .appendingPathComponent("\(bundleName).bundle"),
         ]
         for case let bundleURL? in candidates {
             if let b = Bundle(url: bundleURL),


### PR DESCRIPTION
> **Note:** This PR depends on #77 (LaunchDaemon mode) being merged first. The macOS CI failure is a missing-symbol error (`installMode`, `ServerInstallMode`) introduced by that PR. Everything compiles cleanly on top of #77.

## Summary

- **Binary re-signing after install**: After copying `wired3` from the app bundle to `/Library/Wired3/bin/`, the bundle-context code signature is no longer valid as a standalone executable. macOS kills it immediately with SIGKILL (Code Signature Invalid / Invalid Page). Now re-signs with `codesign --force --sign -` after content hash checks pass, giving the extracted binary a fresh standalone ad-hoc signature.

- **Dashboard PID detection in daemon mode**: PID, uptime, CPU, and memory fields were always blank in daemon mode because `activeServerPIDs()` uses `lsof -t <dbPath>`, which requires root to see processes owned by another user (`_wired`). In daemon mode, the PID is now read directly from the `wired3.pid` file that the server writes on startup. Agent mode keeps the existing `lsof` approach.

## Test plan

- [ ] Install server binary via the app, confirm it starts and stays running (no SIGKILL)
- [ ] In daemon mode, verify Dashboard shows PID, uptime, CPU, and memory after server starts
- [ ] In agent mode, verify existing PID detection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)