### PR TITLE
feat(i18n): German localization + i18n fixes for WiredServerApp

### DIFF
--- a/Sources/WiredServerApp/Localization.swift
+++ b/Sources/WiredServerApp/Localization.swift
@@ -77,17 +77,7 @@ private final class Localizer {
     }
 
     private static func candidateBundles() -> [Bundle] {
-        var bundles: [Bundle] = [Bundle.main]
-
-        if let resourceBundles = Bundle.main.urls(forResourcesWithExtension: "bundle", subdirectory: nil) {
-            for url in resourceBundles {
-                if let bundle = Bundle(url: url) {
-                    bundles.append(bundle)
-                }
-            }
-        }
-
-        return bundles
+        [.module, .main]
     }
 }
 

--- a/Sources/WiredServerApp/Localization.swift
+++ b/Sources/WiredServerApp/Localization.swift
@@ -3,6 +3,7 @@ import Foundation
 private enum AppLanguage: String {
     case en
     case fr
+    case de
 }
 
 private final class Localizer {
@@ -17,7 +18,8 @@ private final class Localizer {
         self.selectedLanguage = selected
         self.tableByLanguage = [
             .en: Localizer.loadTable(for: .en),
-            .fr: Localizer.loadTable(for: .fr)
+            .fr: Localizer.loadTable(for: .fr),
+            .de: Localizer.loadTable(for: .de)
         ]
     }
 
@@ -40,6 +42,9 @@ private final class Localizer {
                 .first?
                 .lowercased()
 
+            if languageCode == AppLanguage.de.rawValue {
+                return .de
+            }
             if languageCode == AppLanguage.fr.rawValue {
                 return .fr
             }

--- a/Sources/WiredServerApp/Localization.swift
+++ b/Sources/WiredServerApp/Localization.swift
@@ -34,25 +34,17 @@ private final class Localizer {
     }
 
     private static func resolveLanguage() -> AppLanguage {
-        let preferred = Bundle.main.preferredLocalizations + Locale.preferredLanguages
-        for value in preferred {
+        for value in Locale.preferredLanguages {
             let languageCode = value
                 .replacingOccurrences(of: "_", with: "-")
                 .split(separator: "-")
                 .first?
                 .lowercased()
 
-            if languageCode == AppLanguage.de.rawValue {
-                return .de
-            }
-            if languageCode == AppLanguage.fr.rawValue {
-                return .fr
-            }
-            if languageCode == AppLanguage.en.rawValue {
-                return .en
-            }
+            if languageCode == AppLanguage.de.rawValue { return .de }
+            if languageCode == AppLanguage.fr.rawValue { return .fr }
+            if languageCode == AppLanguage.en.rawValue { return .en }
         }
-
         return .en
     }
 

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -37,9 +37,33 @@
 "general.execution.section" = "Ausführung";
 "general.execution.running" = "Server läuft";
 "general.execution.stopped" = "Server läuft nicht";
+"general.execution.running_daemon" = "Läuft (Daemon)";
+"general.execution.stopped_daemon" = "Gestoppt (Daemon)";
 "general.execution.start" = "Starten";
 "general.execution.stop" = "Stoppen";
 "general.execution.start_on_login" = "Automatisch beim Systemstart starten";
+"general.execution.start_at_boot" = "Beim Systemstart starten";
+
+"general.system_data_dir.section" = "Systemweites Datenverzeichnis";
+"general.system_data_dir.migrate_description" = "Serverdaten nach /Library/Wired3/ migrieren, um den LaunchDaemon-Modus zu aktivieren. Die ursprünglichen Daten werden als Backup aufbewahrt.";
+"general.system_data_dir.migrate_button" = "Nach /Library/Wired3/ migrieren";
+
+"general.install_mode.section" = "Installationsmodus";
+"general.install_mode.migrate_warning" = "Zuerst nach /Library/Wired3/ migrieren, um den LaunchDaemon-Modus zu aktivieren.";
+"general.install_mode.mode" = "Modus";
+"general.install_mode.launch_agent" = "LaunchAgent (aktueller Benutzer)";
+"general.install_mode.launch_daemon" = "LaunchDaemon (Systemdienst)";
+"general.install_mode.daemon_user" = "Daemon-Benutzer";
+"general.install_mode.group" = "Gruppe";
+
+"general.versions.section" = "Versionen";
+
+"fda.check.passed" = "Daemon-Zugriffsprüfung erfolgreich.";
+"fda.external_volume" = "Dateiverzeichnis liegt auf einem externen Volume.";
+"fda.check.passed.detail" = "Der Daemon-Benutzer hat scheinbar Lesezugriff. Nach einem Binary-Update kann eine Neusignierung diesen Zugriff entziehen — prüfe das Server-Protokoll auf \"0 files, 0 dirs\".";
+"fda.check.failed.detail" = "Sicherstellen, dass das Dateiverzeichnis für den Daemon-Benutzer lesbar ist, dann auf \"Erneut prüfen\" klicken.";
+"fda.recheck" = "Erneut prüfen";
+"fda.restart_daemon" = "Daemon neu starten";
 
 "network.section" = "Netzwerk";
 "network.port" = "Listening-Port";

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -1,14 +1,27 @@
 "window.title" = "Wired Server";
 "alert.error.title" = "Fehler";
+"alert.binary_updated.title" = "Server aktualisiert";
+"alert.binary_updated.message" = "Eine neue Version der Server-Binary wurde installiert. Der laufende Server verwendet noch die alte Version. Möchten Sie ihn jetzt neu starten?";
+"alert.binary_updated.restart" = "Jetzt neu starten";
+"alert.binary_updated.later" = "Später";
+"alert.privileged_update.title" = "Server-Update verfügbar";
+"alert.privileged_update.message" = "Eine neue Version der Server-Binary ist in dieser App enthalten. Jetzt installieren? Ihr Administrator-Passwort wird benötigt.";
+"alert.privileged_update.install" = "Jetzt installieren";
+"alert.privileged_update.later" = "Später";
+"alert.initial_password.title" = "Erstes Admin-Passwort";
+"alert.initial_password.message" = "Der Server wurde mit einem zufälligen Admin-Passwort initialisiert. Notieren Sie es jetzt — es wird nicht erneut angezeigt.";
+"alert.initial_password.copy" = "In Zwischenablage kopieren";
 "common.ok" = "OK";
 "common.choose" = "Auswählen";
 "common.select" = "Auswählen";
 "common.save" = "Speichern";
 
 "pane.general" = "Allgemein";
+"pane.dashboard" = "Dashboard";
 "pane.network" = "Netzwerk";
 "pane.files" = "Dateien";
-"pane.advanced" = "Erweitert";
+"pane.database" = "Datenbank";
+"pane.security" = "Sicherheit";
 "pane.logs" = "Protokolle";
 
 "general.installation.section" = "Installation";
@@ -17,7 +30,9 @@
 "general.install.state.installed" = "Installiert";
 "general.install.state.uninstalled" = "Nicht installiert";
 "general.install.directory" = "Installationsverzeichnis";
-"general.install.version" = "Version";
+"general.install.version" = "Server-Version";
+"general.install.p7_version" = "P7-Protokoll";
+"general.install.wired_protocol" = "Wired-Protokoll";
 
 "general.execution.section" = "Ausführung";
 "general.execution.running" = "Server läuft";
@@ -30,9 +45,10 @@
 "network.port" = "Listening-Port";
 "network.check" = "Prüfen";
 "network.restart_required" = "Der Server muss nach einer Port-Änderung neu gestartet werden.";
-"network.port_status.unknown" = "Port-Status unbekannt";
-"network.port_status.open" = "Port ist geöffnet";
-"network.port_status.closed" = "Port ist geschlossen";
+"network.port_status.unknown" = "Externer Portcheck läuft…";
+"network.port_status.open" = "Von außen erreichbar";
+"network.port_status.closed" = "Von außen nicht erreichbar";
+"network.port_status.error" = "Portcheck fehlgeschlagen (kein Internet?)";
 
 "files.section" = "Dateien";
 "files.directory" = "Dateiverzeichnis";
@@ -40,6 +56,91 @@
 "files.index.every" = "Server-Dateien neu indizieren alle";
 "files.index.seconds" = "Sek.";
 "files.index.now" = "Neu indizieren";
+
+"dashboard.title" = "Server-Dashboard";
+"dashboard.subtitle" = "Schnellübersicht: Gesundheit, Laufzeit, Speicher und Überwachung.";
+"dashboard.section.live" = "Live-Status";
+"dashboard.section.storage" = "Speicher";
+"dashboard.section.database" = "Datenbank";
+"dashboard.section.attention" = "Aufmerksamkeit";
+"dashboard.metric.server_status" = "Server-Status";
+"dashboard.metric.connected_users" = "Verbundene Benutzer";
+"dashboard.metric.connected_users.help" = "Geschätzt aus aktiven Verbindungen.";
+"dashboard.metric.pid" = "Prozess-ID";
+"dashboard.metric.server_uptime" = "Server-Uptime";
+"dashboard.metric.cpu" = "CPU";
+"dashboard.metric.memory" = "Arbeitsspeicher";
+"dashboard.metric.files_size" = "Dateigröße";
+"dashboard.metric.database_size" = "Datenbankgröße";
+"dashboard.metric.snapshot" = "Letzter Snapshot";
+"dashboard.metric.disk_free" = "Freier Speicher";
+"dashboard.metric.disk_total" = "Gesamtspeicher";
+"dashboard.metric.host_uptime" = "Host-Uptime";
+"dashboard.metric.port" = "Listening-Port";
+"dashboard.metric.accounts" = "Konten";
+"dashboard.metric.groups" = "Gruppen";
+"dashboard.metric.events" = "Ereignisse";
+"dashboard.metric.boards" = "Boards";
+"dashboard.metric.snapshot_interval" = "Snapshot-Intervall";
+"dashboard.metric.event_retention" = "Ereignisaufbewahrung";
+"dashboard.metric.last_error" = "Letzter Fehlereintrag";
+"dashboard.snapshot.disabled" = "Deaktiviert";
+"dashboard.snapshot.pending" = "Warten auf ersten Snapshot";
+"dashboard.errors.none" = "Keine aktuellen Fehler erkannt";
+"dashboard.health.server" = "Server";
+"dashboard.health.host" = "Host";
+"dashboard.health.database" = "Datenbank";
+"dashboard.health.files" = "Dateien";
+"dashboard.health.good" = "Gut";
+"dashboard.health.warning" = "Warnung";
+"dashboard.health.critical" = "Kritisch";
+"dashboard.health.unknown" = "Unbekannt";
+"dashboard.health.server.not_installed" = "Die Server-Binary ist noch nicht installiert.";
+"dashboard.health.server.stopped" = "Der Server ist installiert, aber aktuell gestoppt.";
+"dashboard.health.server.port_closed" = "Der Prozess läuft, aber der konfigurierte Port scheint geschlossen.";
+"dashboard.health.server.admin_unsecured" = "Das Admin-Konto hat noch kein wirksames Passwort.";
+"dashboard.health.server.recent_error" = "Aktuelle Fehlereinträge erfordern Aufmerksamkeit.";
+"dashboard.health.server.ok" = "Server-Prozess und Core-Runtime sehen gesund aus.";
+"dashboard.health.host.unknown" = "Host-Festplatteninformationen sind nicht verfügbar.";
+"dashboard.health.host.disk_critical" = "Der freie Speicherplatz des Hosts ist kritisch niedrig.";
+"dashboard.health.host.disk_warning" = "Der freie Speicherplatz des Hosts wird knapp.";
+"dashboard.health.host.ok" = "Host-Speicher sieht gesund aus.";
+"dashboard.health.database.not_initialized" = "Die Datenbank wurde noch nicht initialisiert.";
+"dashboard.health.database.snapshot_pending" = "Snapshots sind aktiviert, aber noch kein Snapshot vorhanden.";
+"dashboard.health.database.ok" = "Datenbank und Aufbewahrungseinstellungen sehen gesund aus.";
+"dashboard.health.files.missing" = "Das konfigurierte Dateiverzeichnis existiert nicht.";
+"dashboard.health.files.ok" = "Das Dateistammverzeichnis ist vorhanden und lesbar.";
+
+"database.snapshot.section" = "SQLite-Snapshot";
+"database.snapshot.interval" = "Snapshot alle";
+"database.snapshot.seconds" = "Sek.";
+"database.snapshot.help" = "Erstellt eine lokale SQLite-Sicherungskopie im konfigurierten Intervall. Auf 0 setzen, um automatische Snapshots zu deaktivieren.";
+"database.snapshot.trigger_now" = "Snapshot jetzt erstellen";
+"status.snapshot_triggered" = "Datenbank-Snapshot ausgelöst.";
+"status.snapshot_not_running" = "Der Server läuft nicht.";
+"status.snapshot_failed" = "Snapshot konnte nicht ausgelöst werden — PID-Datei nicht gefunden.";
+"database.events.section" = "Ereignisaufbewahrung";
+"database.events.retention" = "Ereignisse automatisch löschen";
+"database.events.help" = "Löscht Ereignisse, die älter als das gewählte Aufbewahrungsfenster sind.";
+"database.events.retention.never" = "Nie";
+"database.events.retention.daily" = "Täglich";
+"database.events.retention.weekly" = "Wöchentlich";
+"database.events.retention.monthly" = "Monatlich";
+"database.events.retention.yearly" = "Jährlich";
+
+"touchid.section" = "Touch ID / Apple Watch";
+"touchid.status.enabled" = "Touch ID für Admin-Operationen aktiviert";
+"touchid.status.disabled" = "Touch ID nicht aktiviert";
+"touchid.description" = "Wenn aktiviert, verwenden Admin-Operationen (Start/Stopp Daemon, Installation) Touch ID statt einer Passwort-Eingabe.";
+"touchid.forget" = "Passwort vergessen";
+"touchid.reason" = "Authentifizierung zur Kontrolle des Wired-Servers";
+"touchid.dialog.title" = "Administrator-Passwort erforderlich";
+"touchid.dialog.message" = "Geben Sie Ihr macOS-Administrator-Passwort ein, um fortzufahren.";
+"touchid.dialog.placeholder" = "Passwort";
+"touchid.save.title" = "Touch ID aktivieren?";
+"touchid.save.message" = "Speichern Sie Ihr Administrator-Passwort mit Touch ID, damit zukünftige Operationen keine Passwort-Eingabe erfordern.";
+"touchid.save.enable" = "Touch ID aktivieren";
+"touchid.wrong_password" = "Authentifizierung fehlgeschlagen — falsches Passwort.";
 
 "advanced.admin.section" = "Admin-Konto";
 "advanced.admin.password.placeholder" = "Admin-Passwort";
@@ -56,7 +157,16 @@
 "advanced.security.compression" = "Bevorzugte Komprimierung";
 "advanced.security.cipher" = "Bevorzugte Verschlüsselung";
 "advanced.security.checksum" = "Bevorzugte Prüfsumme";
-"advanced.save" = "Erweiterte Einstellungen speichern";
+
+"advanced.identity.section" = "Server-Identität (TOFU)";
+"advanced.identity.fingerprint" = "Fingerabdruck";
+"advanced.identity.fingerprint.none" = "Kein Identitätsschlüssel — Server einmal starten, um ihn zu generieren";
+"advanced.identity.strict" = "Strikter Modus";
+"advanced.identity.strict.help" = "Clients müssen die Verbindung ablehnen, wenn sich der Server-Schlüssel ändert (empfohlen).";
+"advanced.identity.export" = "Öffentlichen Schlüssel exportieren";
+"advanced.identity.copied" = "Fingerabdruck kopiert!";
+
+"security.save" = "Sicherheitseinstellungen speichern";
 
 "logs.open" = "Protokolle öffnen";
 "logs.empty" = "Noch keine Protokolle";
@@ -69,9 +179,14 @@
 "status.port_saved_restart_required" = "Port gespeichert. Neustart erforderlich.";
 "status.port_saved" = "Port gespeichert";
 "status.files_settings_saved" = "Dateieinstellungen gespeichert";
+"status.files_settings_saved_reloaded" = "Dateieinstellungen gespeichert und angewendet";
+"status.database_settings_saved" = "Datenbankeinstellungen gespeichert";
+"status.database_settings_saved_reloaded" = "Datenbankeinstellungen gespeichert und angewendet";
 "status.reindex_on_next_start" = "Neu-Indizierung wird beim nächsten Start durchgeführt";
+"status.reindex_triggered" = "Neu-Indizierung ausgelöst";
 "status.server_restarted_reindex" = "Server neu gestartet, Neu-Indizierung ausgelöst";
 "status.advanced_saved" = "Erweiterte Einstellungen gespeichert";
+"status.advanced_saved_reloaded" = "Erweiterte Einstellungen gespeichert und angewendet";
 "status.admin_password_updated" = "Admin-Passwort aktualisiert";
 "status.admin_user_created" = "Admin-Benutzer erstellt";
 "status.building_binary" = "wired3-Binary wird kompiliert...";
@@ -95,6 +210,10 @@
 "error.database_not_initialized" = "Datenbank nicht initialisiert: Server zunächst einmal starten";
 "error.sql_prepare_failed" = "SQL-Vorbereitung fehlgeschlagen";
 "error.sql_execution_failed" = "SQL-Ausführung fehlgeschlagen";
+"error.migration_no_source" = "Keine Quelldatenbank ausgewählt.";
+"error.migration_server_running" = "Stoppen Sie den Server, bevor Sie die Migration starten.";
+"error.migration_failed" = "Migration fehlgeschlagen";
+"error.migration_timed_out" = "Die Migration wurde nach 5 Minuten abgebrochen.";
 
 "database.migration.section" = "Migration von Wired 2.5";
 "database.migration.source" = "Wired 2.5-Datenbank";
@@ -104,7 +223,3 @@
 "database.migration.running" = "Migration läuft…";
 "database.migration.server_warning" = "Der Server muss gestoppt sein, bevor die Migration gestartet wird.";
 "database.migration.help" = "Migriert Benutzer, Gruppen und Sperren aus einer Wired 2.5-SQLite-Datenbank. Passwörter werden unverändert übernommen (SHA1) – Benutzer müssen beim ersten Login ein neues Passwort setzen.";
-"error.migration_no_source" = "Keine Quelldatenbank ausgewählt.";
-"error.migration_server_running" = "Stoppen Sie den Server, bevor Sie die Migration starten.";
-"error.migration_failed" = "Migration fehlgeschlagen";
-"error.migration_timed_out" = "Die Migration wurde nach 5 Minuten abgebrochen.";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -33,9 +33,33 @@
 "general.execution.section" = "Execution";
 "general.execution.running" = "Server is running";
 "general.execution.stopped" = "Server is not running";
+"general.execution.running_daemon" = "Running (daemon)";
+"general.execution.stopped_daemon" = "Stopped (daemon)";
 "general.execution.start" = "Start";
 "general.execution.stop" = "Stop";
 "general.execution.start_on_login" = "Automatically start on system startup";
+"general.execution.start_at_boot" = "Start at Boot";
+
+"general.system_data_dir.section" = "System Data Directory";
+"general.system_data_dir.migrate_description" = "Migrate server data to /Library/Wired3/ to enable LaunchDaemon support. The original data will be preserved as a backup.";
+"general.system_data_dir.migrate_button" = "Migrate to /Library/Wired3/";
+
+"general.install_mode.section" = "Install Mode";
+"general.install_mode.migrate_warning" = "Migrate to /Library/Wired3/ first to enable LaunchDaemon mode.";
+"general.install_mode.mode" = "Mode";
+"general.install_mode.launch_agent" = "LaunchAgent (current user)";
+"general.install_mode.launch_daemon" = "LaunchDaemon (system service)";
+"general.install_mode.daemon_user" = "Daemon User";
+"general.install_mode.group" = "Group";
+
+"general.versions.section" = "Versions";
+
+"fda.check.passed" = "Daemon access check passed.";
+"fda.external_volume" = "Files directory is on an external volume.";
+"fda.check.passed.detail" = "The daemon user appears to have read access. After a binary update, re-signing may revoke this — verify by checking the server log for \"0 files, 0 dirs\".";
+"fda.check.failed.detail" = "Ensure the files directory is readable by the daemon user, then click Re-check.";
+"fda.recheck" = "Re-check";
+"fda.restart_daemon" = "Restart Daemon";
 
 "network.section" = "Network";
 "network.port" = "Listening Port";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -33,9 +33,33 @@
 "general.execution.section" = "Exécution";
 "general.execution.running" = "Serveur actif";
 "general.execution.stopped" = "Serveur arrêté";
+"general.execution.running_daemon" = "En cours (daemon)";
+"general.execution.stopped_daemon" = "Arrêté (daemon)";
 "general.execution.start" = "Démarrer";
 "general.execution.stop" = "Arrêter";
 "general.execution.start_on_login" = "Démarrer automatiquement à la connexion macOS";
+"general.execution.start_at_boot" = "Démarrer au démarrage";
+
+"general.system_data_dir.section" = "Répertoire système des données";
+"general.system_data_dir.migrate_description" = "Migrer les données du serveur vers /Library/Wired3/ pour activer le mode LaunchDaemon. Les données d'origine seront conservées en sauvegarde.";
+"general.system_data_dir.migrate_button" = "Migrer vers /Library/Wired3/";
+
+"general.install_mode.section" = "Mode d'installation";
+"general.install_mode.migrate_warning" = "Migrer d'abord vers /Library/Wired3/ pour activer le mode LaunchDaemon.";
+"general.install_mode.mode" = "Mode";
+"general.install_mode.launch_agent" = "LaunchAgent (utilisateur courant)";
+"general.install_mode.launch_daemon" = "LaunchDaemon (service système)";
+"general.install_mode.daemon_user" = "Utilisateur daemon";
+"general.install_mode.group" = "Groupe";
+
+"general.versions.section" = "Versions";
+
+"fda.check.passed" = "Vérification d'accès daemon réussie.";
+"fda.external_volume" = "Le répertoire de fichiers est sur un volume externe.";
+"fda.check.passed.detail" = "L'utilisateur daemon semble avoir accès en lecture. Après une mise à jour binaire, la re-signature peut révoquer cet accès — vérifiez le journal serveur pour \"0 files, 0 dirs\".";
+"fda.check.failed.detail" = "Assurez-vous que le répertoire de fichiers est lisible par l'utilisateur daemon, puis cliquez sur Revérifier.";
+"fda.recheck" = "Revérifier";
+"fda.restart_daemon" = "Redémarrer le daemon";
 
 "network.section" = "Réseau";
 "network.port" = "Port en écoute";

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -89,6 +89,54 @@ private struct KeyValueRow<Control: View>: View {
 }
 
 @available(macOS 12.0, *)
+private struct ExternalVolumeWarningView: View {
+    @EnvironmentObject private var model: WiredServerViewModel
+    let hasFDA: Bool
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: hasFDA ? "externaldrive.fill.badge.checkmark" : "externaldrive.badge.exclamationmark")
+                .foregroundStyle(hasFDA ? .green : .orange)
+                .font(.title3)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(hasFDA ? L("fda.check.passed") : L("fda.external_volume"))
+                    .font(.footnote).bold()
+                    .foregroundStyle(hasFDA ? Color.primary : Color.orange)
+                Text(hasFDA
+                    ? L("fda.check.passed.detail")
+                    : L("fda.check.failed.detail")
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if !hasFDA {
+                Button(L("fda.recheck")) {
+                    model.refreshFDAStatusPrivileged()
+                }
+                .font(.footnote)
+
+                Button(L("fda.restart_daemon")) {
+                    model.stopDaemon()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        model.startDaemon()
+                    }
+                }
+                .font(.footnote)
+                .disabled(!model.isDaemonRunning)
+            }
+        }
+        .padding(8)
+        .background((hasFDA ? Color.green : Color.orange).opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+@available(macOS 12.0, *)
 private struct StatusDot: View {
     let color: Color
 
@@ -153,7 +201,108 @@ struct GeneralTabView: View {
                     }
                 }
 
-                Section("Versions") {
+                Section(L("general.system_data_dir.section")) {
+                    if model.isUsingSystemDirectory {
+                        HStack(spacing: 8) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Text("/Library/Wired3/ (system-wide)")
+                                .textSelection(.enabled)
+                        }
+                    } else if model.systemMigrationAvailable {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(L("general.system_data_dir.migrate_description"))
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+
+                            HStack(spacing: 10) {
+                                Button(L("general.system_data_dir.migrate_button")) {
+                                    Task { await model.migrateToSystemDirectory() }
+                                }
+                                .disabled(model.isSystemMigrating || model.isBusy)
+
+                                if model.isSystemMigrating {
+                                    ProgressView().controlSize(.small)
+                                }
+                            }
+
+                            if !model.systemMigrationStatus.isEmpty {
+                                Text(model.systemMigrationStatus)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                                    .textSelection(.enabled)
+                            }
+                        }
+                    }
+                }
+
+                Section(L("general.install_mode.section")) {
+                    if !model.isUsingSystemDirectory {
+                        Label(L("general.install_mode.migrate_warning"), systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.orange)
+                            .font(.footnote)
+                    } else {
+                        Picker(L("general.install_mode.mode"), selection: Binding(
+                            get: { model.installMode },
+                            set: { newMode in
+                                Task { await model.switchInstallMode(to: newMode) }
+                            }
+                        )) {
+                            Text(L("general.install_mode.launch_agent")).tag(ServerInstallMode.launchAgent)
+                            Text(L("general.install_mode.launch_daemon")).tag(ServerInstallMode.launchDaemon)
+                        }
+                        .disabled(model.isSwitchingMode || model.isBusy)
+
+                        HStack(spacing: 8) {
+                            Text(L("general.install_mode.daemon_user"))
+                                .bold()
+                                .frame(width: 90, alignment: .leading)
+                            TextField("_wired", text: $model.daemonUserName)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 100)
+                                .disabled(model.isSwitchingMode)
+                            Image(systemName: model.isDaemonUserExists ? "person.fill.checkmark" : "person.fill.xmark")
+                                .foregroundStyle(model.isDaemonUserExists ? .green : .secondary)
+
+                            Text(L("general.install_mode.group"))
+                                .bold()
+                                .frame(width: 44, alignment: .leading)
+                            TextField("daemon", text: $model.daemonGroupName)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 100)
+                                .disabled(model.isSwitchingMode)
+                            Image(systemName: model.isDaemonGroupExists ? "checkmark.circle.fill" : "xmark.circle")
+                                .foregroundStyle(model.isDaemonGroupExists ? .green : .secondary)
+
+                            Spacer()
+                            Button(L("common.save")) { model.saveDaemonSettings() }
+                                .disabled(model.isSwitchingMode)
+                        }
+                        .labelsHidden()
+
+                        if model.installMode == .launchDaemon && model.filesDirectoryIsOnExternalVolume {
+                            ExternalVolumeWarningView(hasFDA: model.wired3HasFullDiskAccess) {
+                                model.openFullDiskAccessSettings()
+                            }
+                        }
+
+                        if model.isSwitchingMode {
+                            HStack(spacing: 8) {
+                                ProgressView().controlSize(.small)
+                                Text(model.modeSwitchStatus)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } else if !model.modeSwitchStatus.isEmpty {
+                            Text(model.modeSwitchStatus)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+
+                Section(L("general.versions.section")) {
                     HStack(spacing: 8) {
                         Text(L("general.install.version"))
                             .bold()
@@ -187,17 +336,31 @@ struct GeneralTabView: View {
                 }
 
                 Section(L("general.execution.section")) {
-                    HStack {
-                        StatusDot(color: model.isRunning ? .green : .red)
-                        Text(model.isRunning ? L("general.execution.running") : L("general.execution.stopped"))
+                    if model.installMode == .launchDaemon {
+                        HStack {
+                            StatusDot(color: model.isDaemonRunning ? .green : .red)
+                            Text(model.isDaemonRunning ? L("general.execution.running_daemon") : L("general.execution.stopped_daemon"))
+                            Spacer()
+                            Button(model.isDaemonRunning ? L("general.execution.stop") : L("general.execution.start")) {
+                                if model.isDaemonRunning { model.stopDaemon() }
+                                else { model.startDaemon() }
+                            }
+                            .disabled(!model.launchDaemonInstalled)
+                        }
 
-                        Spacer()
-
-                        Button(model.isRunning ? L("general.execution.stop") : L("general.execution.start")) {
-                            if model.isRunning {
-                                model.stopServer()
-                            } else {
-                                Task { await model.startServer() }
+                        Toggle(L("general.execution.start_at_boot"), isOn: Binding(
+                            get: { model.daemonStartAtBoot },
+                            set: { model.toggleDaemonStartAtBoot($0) }
+                        ))
+                        .disabled(!model.launchDaemonInstalled)
+                    } else {
+                        HStack {
+                            StatusDot(color: model.isRunning ? .green : .red)
+                            Text(model.isRunning ? L("general.execution.running") : L("general.execution.stopped"))
+                            Spacer()
+                            Button(model.isRunning ? L("general.execution.stop") : L("general.execution.start")) {
+                                if model.isRunning { model.stopServer() }
+                                else { Task { await model.startServer() } }
                             }
                         }
                     }


### PR DESCRIPTION
> **Note:** This PR depends on #77 (LaunchDaemon mode) being merged first. The macOS CI failure is a missing-symbol error (`ServerInstallMode`, `refreshFDAStatusPrivileged`) introduced by that PR. Everything compiles cleanly on top of #77.

## Summary

- Add German (`de`) localization to `WiredServerApp`: completes all missing keys in `de.lproj/Localizable.strings` (dashboard, database, snapshot, Touch ID, identity, security, status, error messages) and registers `de` in `Localization.swift`
- Fix `Bundle.module` usage so the SPM resource bundle (`WiredSwift_WiredServerApp.bundle`) is found correctly at runtime
- Fix `Locale.preferredLanguages` resolution so the user's actual system language is detected (not always `en` from `Bundle.main.preferredLocalizations`)
- Localize remaining hardcoded strings in `GeneralTabView`: section headers (System Data Directory, Install Mode, Versions), Picker/Toggle labels, daemon status strings, migration description/button, and the full FDA/external-volume warning panel — all three locale files kept in sync

## Test plan

- [ ] Launch WiredServerApp with macOS language set to German — all General tab strings appear in German
- [ ] Launch with French — French strings appear
- [ ] Launch with English (or any unsupported language) — English fallback applies
- [ ] External-volume / FDA warning banner shows translated text in all three languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)