### PR TITLE
fix(fda): fix false-positive FDA check + add Full Disk Access deep link

### DIFF
--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -26,6 +26,29 @@
 "general.execution.start" = "Starten";
 "general.execution.stop" = "Stoppen";
 "general.execution.start_on_login" = "Automatisch beim Systemstart starten";
+"general.execution.start_at_boot" = "Beim Systemstart starten";
+
+"general.system_data_dir.section" = "Systemweites Datenverzeichnis";
+"general.system_data_dir.migrate_description" = "Serverdaten nach /Library/Wired3/ migrieren, um den LaunchDaemon-Modus zu aktivieren. Die ursprünglichen Daten werden als Backup aufbewahrt.";
+"general.system_data_dir.migrate_button" = "Nach /Library/Wired3/ migrieren";
+
+"general.install_mode.section" = "Installationsmodus";
+"general.install_mode.migrate_warning" = "Zuerst nach /Library/Wired3/ migrieren, um den LaunchDaemon-Modus zu aktivieren.";
+"general.install_mode.mode" = "Modus";
+"general.install_mode.launch_agent" = "LaunchAgent (aktueller Benutzer)";
+"general.install_mode.launch_daemon" = "LaunchDaemon (Systemdienst)";
+"general.install_mode.daemon_user" = "Daemon-Benutzer";
+"general.install_mode.group" = "Gruppe";
+
+"general.versions.section" = "Versionen";
+
+"fda.check.passed" = "Daemon-Zugriffsprüfung erfolgreich.";
+"fda.external_volume" = "Dateiverzeichnis liegt auf einem externen Volume.";
+"fda.check.passed.detail" = "Der Daemon-Benutzer hat scheinbar Lesezugriff. Nach einem Binary-Update kann eine Neusignierung diesen Zugriff entziehen — prüfe das Server-Protokoll auf \"0 files, 0 dirs\".";
+"fda.check.failed.detail" = "Sicherstellen, dass das Dateiverzeichnis für den Daemon-Benutzer lesbar ist, dann auf \"Erneut prüfen\" klicken.";
+"fda.open_settings" = "Festplattenvollzugriff öffnen…";
+"fda.recheck" = "Erneut prüfen";
+"fda.restart_daemon" = "Daemon neu starten";
 
 "network.section" = "Netzwerk";
 "network.port" = "Listening-Port";

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -1,6 +1,7 @@
 "window.title" = "Wired Server";
 "alert.error.title" = "Fehler";
 "common.ok" = "OK";
+"common.cancel" = "Abbrechen";
 "common.choose" = "Auswählen";
 "common.select" = "Auswählen";
 "common.save" = "Speichern";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "alert.initial_password.message" = "The server has been initialized with a random admin password. Save it now — it will not be shown again.";
 "alert.initial_password.copy" = "Copy to Clipboard";
 "common.ok" = "OK";
+"common.cancel" = "Cancel";
 "common.choose" = "Choose";
 "common.select" = "Select";
 "common.save" = "Save";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -37,6 +37,29 @@
 "general.execution.start" = "Start";
 "general.execution.stop" = "Stop";
 "general.execution.start_on_login" = "Automatically start on system startup";
+"general.execution.start_at_boot" = "Start at Boot";
+
+"general.system_data_dir.section" = "System Data Directory";
+"general.system_data_dir.migrate_description" = "Migrate server data to /Library/Wired3/ to enable LaunchDaemon support. The original data will be preserved as a backup.";
+"general.system_data_dir.migrate_button" = "Migrate to /Library/Wired3/";
+
+"general.install_mode.section" = "Install Mode";
+"general.install_mode.migrate_warning" = "Migrate to /Library/Wired3/ first to enable LaunchDaemon mode.";
+"general.install_mode.mode" = "Mode";
+"general.install_mode.launch_agent" = "LaunchAgent (current user)";
+"general.install_mode.launch_daemon" = "LaunchDaemon (system service)";
+"general.install_mode.daemon_user" = "Daemon User";
+"general.install_mode.group" = "Group";
+
+"general.versions.section" = "Versions";
+
+"fda.check.passed" = "Daemon access check passed.";
+"fda.external_volume" = "Files directory is on an external volume.";
+"fda.check.passed.detail" = "The daemon user appears to have read access. After a binary update, re-signing may revoke this — verify by checking the server log for \"0 files, 0 dirs\".";
+"fda.check.failed.detail" = "Ensure the files directory is readable by the daemon user, then click Re-check.";
+"fda.open_settings" = "Open Full Disk Access…";
+"fda.recheck" = "Re-check";
+"fda.restart_daemon" = "Restart Daemon";
 
 "network.section" = "Network";
 "network.port" = "Listening Port";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -37,6 +37,29 @@
 "general.execution.start" = "Démarrer";
 "general.execution.stop" = "Arrêter";
 "general.execution.start_on_login" = "Démarrer automatiquement à la connexion macOS";
+"general.execution.start_at_boot" = "Démarrer au démarrage";
+
+"general.system_data_dir.section" = "Répertoire système des données";
+"general.system_data_dir.migrate_description" = "Migrer les données du serveur vers /Library/Wired3/ pour activer le mode LaunchDaemon. Les données d'origine seront conservées en sauvegarde.";
+"general.system_data_dir.migrate_button" = "Migrer vers /Library/Wired3/";
+
+"general.install_mode.section" = "Mode d'installation";
+"general.install_mode.migrate_warning" = "Migrer d'abord vers /Library/Wired3/ pour activer le mode LaunchDaemon.";
+"general.install_mode.mode" = "Mode";
+"general.install_mode.launch_agent" = "LaunchAgent (utilisateur courant)";
+"general.install_mode.launch_daemon" = "LaunchDaemon (service système)";
+"general.install_mode.daemon_user" = "Utilisateur daemon";
+"general.install_mode.group" = "Groupe";
+
+"general.versions.section" = "Versions";
+
+"fda.check.passed" = "Vérification d'accès daemon réussie.";
+"fda.external_volume" = "Le répertoire de fichiers est sur un volume externe.";
+"fda.check.passed.detail" = "L'utilisateur daemon semble avoir accès en lecture. Après une mise à jour binaire, la re-signature peut révoquer cet accès — vérifiez le journal serveur pour \"0 files, 0 dirs\".";
+"fda.check.failed.detail" = "Assurez-vous que le répertoire de fichiers est lisible par l'utilisateur daemon, puis cliquez sur Revérifier.";
+"fda.open_settings" = "Ouvrir Accès disque complet…";
+"fda.recheck" = "Revérifier";
+"fda.restart_daemon" = "Redémarrer le daemon";
 
 "network.section" = "Réseau";
 "network.port" = "Port en écoute";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "alert.initial_password.message" = "Le serveur a été initialisé avec un mot de passe admin aléatoire. Notez-le maintenant, il ne sera plus affiché.";
 "alert.initial_password.copy" = "Copier";
 "common.ok" = "OK";
+"common.cancel" = "Annuler";
 "common.choose" = "Choisir";
 "common.select" = "Sélectionner";
 "common.save" = "Enregistrer";

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -115,19 +115,26 @@ private struct ExternalVolumeWarningView: View {
             Spacer()
 
             if !hasFDA {
-                Button("Re-check") {
-                    model.refreshFDAStatusPrivileged()
-                }
-                .font(.footnote)
-
-                Button("Restart Daemon") {
-                    model.stopDaemon()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                        model.startDaemon()
+                VStack(alignment: .trailing, spacing: 6) {
+                    Button(L("fda.open_settings")) {
+                        onOpenSettings()
                     }
+                    .font(.footnote)
+
+                    Button(L("fda.recheck")) {
+                        model.refreshFDAStatusPrivileged()
+                    }
+                    .font(.footnote)
+
+                    Button(L("fda.restart_daemon")) {
+                        model.stopDaemon()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                            model.startDaemon()
+                        }
+                    }
+                    .font(.footnote)
+                    .disabled(!model.isDaemonRunning)
                 }
-                .font(.footnote)
-                .disabled(!model.isDaemonRunning)
             }
         }
         .padding(8)

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -89,6 +89,54 @@ private struct KeyValueRow<Control: View>: View {
 }
 
 @available(macOS 12.0, *)
+private struct ExternalVolumeWarningView: View {
+    @EnvironmentObject private var model: WiredServerViewModel
+    let hasFDA: Bool
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: hasFDA ? "externaldrive.fill.badge.checkmark" : "externaldrive.badge.exclamationmark")
+                .foregroundStyle(hasFDA ? .green : .orange)
+                .font(.title3)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(hasFDA ? "Daemon access check passed." : "Files directory is on an external volume.")
+                    .font(.footnote).bold()
+                    .foregroundStyle(hasFDA ? Color.primary : Color.orange)
+                Text(hasFDA
+                    ? "The daemon user appears to have read access. After a binary update, re-signing may revoke this — verify by checking the server log for \"0 files, 0 dirs\"."
+                    : "Ensure the files directory is readable by the daemon user, then click Re-check."
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if !hasFDA {
+                Button("Re-check") {
+                    model.refreshFDAStatusPrivileged()
+                }
+                .font(.footnote)
+
+                Button("Restart Daemon") {
+                    model.stopDaemon()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        model.startDaemon()
+                    }
+                }
+                .font(.footnote)
+                .disabled(!model.isDaemonRunning)
+            }
+        }
+        .padding(8)
+        .background((hasFDA ? Color.green : Color.orange).opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+@available(macOS 12.0, *)
 private struct StatusDot: View {
     let color: Color
 

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -383,13 +383,13 @@ final class WiredServerViewModel: ObservableObject {
         return path.hasPrefix("/Volumes/")
     }
 
-    // Writes a shell script that tests whether the daemon user can list the files directory.
-    // Uses `su -m` rather than `sudo -u` so the subprocess runs with the daemon user's process
-    // identity — `sudo -u` launched from root inherits root's TCC context and can bypass macOS
-    // Removable Volumes / Full Disk Access checks that the actual daemon binary would hit.
-    // NOTE: This check is still approximate. If the server log shows "0 files, 0 dirs" after
-    // a binary update, re-grant FDA to /Library/Wired3/bin/wired3 in
-    // System Settings → Privacy & Security → Full Disk Access.
+    // Writes a shell script that tests whether the daemon binary can list the files directory.
+    // Uses `sudo -u` to run as the daemon user. `su -m user -c cmd` cannot be used because
+    // _wired is created with UserShell=/usr/bin/false, so su delegates to false and always
+    // exits 1 before running the command. FDA grants in the system TCC.db are keyed by the
+    // binary's code signature, not by UID, so sudo -u gives correct TCC enforcement.
+    // NOTE: If the server log shows "0 files, 0 dirs" after a binary update, re-grant FDA
+    // to /Library/Wired3/bin/wired3 in System Settings → Privacy & Security → Full Disk Access.
     private func writeFDACheckScript(filesDir: String, daemonUser: String, outputFile: String, to scriptPath: String) {
         let sh = """
         #!/bin/sh
@@ -397,10 +397,10 @@ final class WiredServerViewModel: ObservableObject {
         FILES='\(filesDir)'
         DUSER='\(daemonUser)'
 
-        # Test whether the daemon user can read the files directory.
-        # su -m preserves the current environment but switches UID, giving a better TCC context
-        # than sudo -u (which inherits root's TCC grants).
-        if su -m "$DUSER" -c "/bin/ls \\"$FILES\\"" >/dev/null 2>&1; then
+        # Run the actual wired3 binary (which holds the FDA/Removable-Volumes TCC grant)
+        # to probe the files directory. Using /bin/ls would fail because the TCC grant
+        # is bound to wired3's code signature, not to a generic tool.
+        if sudo -u "$DUSER" "$WIRED3" --check-access "$FILES" >/dev/null 2>&1; then
             echo 1 > "$OUT"
         else
             echo 0 > "$OUT"

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -383,11 +383,11 @@ final class WiredServerViewModel: ObservableObject {
         return path.hasPrefix("/Volumes/")
     }
 
-    // Writes a shell script that tests whether the daemon binary can list the files directory.
-    // Uses `sudo -u` to run as the daemon user. `su -m user -c cmd` cannot be used because
-    // _wired is created with UserShell=/usr/bin/false, so su delegates to false and always
-    // exits 1 before running the command. FDA grants in the system TCC.db are keyed by the
-    // binary's code signature, not by UID, so sudo -u gives correct TCC enforcement.
+    // Writes a shell script that tests whether the wired3 binary can list the files directory.
+    // Runs as root (the script is already privileged via AppleScript admin auth). On macOS 12+
+    // TCC is enforced even for root — the FDA grant in the system TCC.db is keyed by wired3's
+    // code signature, not by UID. Neither `su -m` (_wired has UserShell=/usr/bin/false) nor
+    // `sudo -u` (can block in a non-interactive AppleScript shell) are used.
     // NOTE: If the server log shows "0 files, 0 dirs" after a binary update, re-grant FDA
     // to /Library/Wired3/bin/wired3 in System Settings → Privacy & Security → Full Disk Access.
     private func writeFDACheckScript(filesDir: String, daemonUser: String, outputFile: String, to scriptPath: String) {
@@ -395,12 +395,12 @@ final class WiredServerViewModel: ObservableObject {
         #!/bin/sh
         OUT='\(outputFile)'
         FILES='\(filesDir)'
-        DUSER='\(daemonUser)'
+        WIRED3='\(wired3Binary)'
 
         # Run the actual wired3 binary (which holds the FDA/Removable-Volumes TCC grant)
-        # to probe the files directory. Using /bin/ls would fail because the TCC grant
-        # is bound to wired3's code signature, not to a generic tool.
-        if sudo -u "$DUSER" "$WIRED3" --check-access "$FILES" >/dev/null 2>&1; then
+        # to probe the files directory. Runs as root — TCC checks the binary's code signature,
+        # not the UID, so the result reflects whether the grant is in place.
+        if "$WIRED3" --check-access "$FILES" >/dev/null 2>&1; then
             echo 1 > "$OUT"
         else
             echo 0 > "$OUT"

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -428,7 +428,13 @@ final class WiredServerViewModel: ObservableObject {
     }
 
     func openFullDiskAccessSettings() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles") {
+        let urlString: String
+        if #available(macOS 13, *) {
+            urlString = "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_AllFiles"
+        } else {
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+        }
+        if let url = URL(string: urlString) {
             NSWorkspace.shared.open(url)
         }
     }

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -266,7 +266,577 @@ final class WiredServerViewModel: ObservableObject {
         }
     }
 
-    func chooseMigrationSource() {
+    // MARK: - System Data Directory Migration
+
+    func persistWorkingDirectory() {
+        userDefaults.set(workingDirectory, forKey: workingDirectoryKey)
+    }
+
+    func migrateToSystemDirectory() async {
+        guard !isSystemMigrating, systemMigrationAvailable else { return }
+        isSystemMigrating = true
+        systemMigrationStatus = "Preparing..."
+
+        let source = workingDirectory
+
+        do {
+            if isRunning {
+                systemMigrationStatus = "Stopping server..."
+                stopServer()
+                try await Task.sleep(for: .seconds(2))
+            }
+
+            systemMigrationStatus = "Creating system directory (admin required)..."
+            try createSystemDataDirectory()
+
+            systemMigrationStatus = "Copying data..."
+            try copyDirectoryContents(from: source, to: Self.systemDataDirectory)
+
+            systemMigrationStatus = "Verifying database integrity..."
+            let newDBPath = URL(fileURLWithPath: Self.systemDataDirectory)
+                .appendingPathComponent("wired3.db").path
+            if fileManager.fileExists(atPath: newDBPath) {
+                try verifySystemDatabaseIntegrity(at: newDBPath)
+            }
+
+            systemMigrationStatus = "Switching to system directory..."
+            workingDirectory = Self.systemDataDirectory
+            persistWorkingDirectory()
+            binaryPath = installedBinaryPath
+
+            if launchAtLogin {
+                try configureLaunchAtLogin(enabled: true)
+            }
+
+            systemMigrationStatus = "Done. Backup preserved at: \(source)"
+            refreshAll()
+        } catch {
+            systemMigrationStatus = "Migration failed: \(error.localizedDescription)"
+            publishError("Data migration failed: \(error.localizedDescription)")
+        }
+
+        isSystemMigrating = false
+    }
+
+    private func createSystemDataDirectory() throws {
+        let username = NSUserName()
+        try runPrivileged(
+            "mkdir -p /Library/Wired3 && chown \(username):staff /Library/Wired3 && chmod 755 /Library/Wired3",
+            error: .systemDirectoryCreationFailed("")
+        )
+        guard fileManager.fileExists(atPath: Self.systemDataDirectory) else {
+            throw WiredServerError.systemDirectoryCreationFailed("Directory missing after creation")
+        }
+    }
+
+    private func copyDirectoryContents(from source: String, to destination: String) throws {
+        let sourceURL = URL(fileURLWithPath: source)
+        let destURL = URL(fileURLWithPath: destination)
+        let items = try fileManager.contentsOfDirectory(at: sourceURL, includingPropertiesForKeys: nil)
+        for item in items {
+            let dest = destURL.appendingPathComponent(item.lastPathComponent)
+            if fileManager.fileExists(atPath: dest.path) {
+                try fileManager.removeItem(at: dest)
+            }
+            try fileManager.copyItem(at: item, to: dest)
+        }
+    }
+
+    private func verifySystemDatabaseIntegrity(at path: String) throws {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            throw WiredServerError.systemMigrationFailed("Cannot open database for verification")
+        }
+        defer { sqlite3_close(db) }
+        var stmt: OpaquePointer?
+        sqlite3_prepare_v2(db, "PRAGMA integrity_check", -1, &stmt, nil)
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_step(stmt) == SQLITE_ROW,
+           let result = sqlite3_column_text(stmt, 0),
+           String(cString: result) == "ok" { return }
+        throw WiredServerError.systemMigrationFailed("Database integrity check failed")
+    }
+
+    // MARK: - LaunchDaemon / LaunchAgent Mode Switching
+
+    private var daemonAccountsVerified = false
+
+    func refreshDaemonStatus() {
+        // pgrep works without root and is faster/more reliable than launchctl print for
+        // detecting whether the daemon process is actually running.
+        isDaemonRunning = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).status == 0
+        if !daemonAccountsVerified {
+            isDaemonUserExists = runProcess("/usr/bin/dscl", [".", "-read", "/Users/\(daemonUserName)"]).status == 0
+            isDaemonGroupExists = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status == 0
+            daemonAccountsVerified = true
+        }
+    }
+
+    func invalidateDaemonAccountsCache() {
+        daemonAccountsVerified = false
+    }
+
+    // MARK: - External Volume / FDA
+
+    var filesDirectoryIsOnExternalVolume: Bool {
+        let path = currentServerRootPath()
+        return path.hasPrefix("/Volumes/")
+    }
+
+    // Writes a shell script that tests whether the daemon user can list the files directory.
+    // Uses `su -m` rather than `sudo -u` so the subprocess runs with the daemon user's process
+    // identity — `sudo -u` launched from root inherits root's TCC context and can bypass macOS
+    // Removable Volumes / Full Disk Access checks that the actual daemon binary would hit.
+    // NOTE: This check is still approximate. If the server log shows "0 files, 0 dirs" after
+    // a binary update, re-grant FDA to /Library/Wired3/bin/wired3 in
+    // System Settings → Privacy & Security → Full Disk Access.
+    private func writeFDACheckScript(filesDir: String, daemonUser: String, outputFile: String, to scriptPath: String) {
+        let sh = """
+        #!/bin/sh
+        OUT='\(outputFile)'
+        FILES='\(filesDir)'
+        DUSER='\(daemonUser)'
+
+        # Test whether the daemon user can read the files directory.
+        # su -m preserves the current environment but switches UID, giving a better TCC context
+        # than sudo -u (which inherits root's TCC grants).
+        if su -m "$DUSER" -c "/bin/ls \\"$FILES\\"" >/dev/null 2>&1; then
+            echo 1 > "$OUT"
+        else
+            echo 0 > "$OUT"
+        fi
+        """
+        try? sh.write(toFile: scriptPath, atomically: true, encoding: .utf8)
+    }
+
+    // Privileged access check — runs as root (AppleScript admin auth) to test _wired user access.
+    func refreshFDAStatusPrivileged() {
+        guard filesDirectoryIsOnExternalVolume else {
+            wired3HasFullDiskAccess = false
+            return
+        }
+        let filesDir = currentServerRootPath()
+        let ts = Int(Date().timeIntervalSince1970)
+        let fdaTmpFile = "/tmp/.wired3fda_\(ts)"
+        let fdaShFile  = "/tmp/.wired3sh_\(ts).sh"
+        writeFDACheckScript(filesDir: filesDir, daemonUser: daemonUserName, outputFile: fdaTmpFile, to: fdaShFile)
+        try? runPrivileged("sh '\(fdaShFile)'; true", error: .launchDaemonInstallFailed(""))
+        let raw = (try? String(contentsOfFile: fdaTmpFile, encoding: .utf8)) ?? "0"
+        try? FileManager.default.removeItem(atPath: fdaTmpFile)
+        try? FileManager.default.removeItem(atPath: fdaShFile)
+        wired3HasFullDiskAccess = raw.trimmingCharacters(in: .whitespacesAndNewlines) == "1"
+    }
+
+    func openFullDiskAccessSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    var launchDaemonInstalled: Bool {
+        fileManager.fileExists(atPath: launchDaemonPlistPath)
+    }
+
+    func saveDaemonSettings() {
+        userDefaults.set(daemonUserName, forKey: daemonUserNameKey)
+        userDefaults.set(daemonGroupName, forKey: daemonGroupNameKey)
+        userDefaults.set(daemonStartAtBoot, forKey: daemonStartAtBootKey)
+    }
+
+    func switchInstallMode(to mode: ServerInstallMode) async {
+        guard mode != installMode, !isSwitchingMode else { return }
+        guard isUsingSystemDirectory else {
+            publishError("Please migrate data to /Library/Wired3/ before switching to LaunchDaemon mode.")
+            return
+        }
+        isSwitchingMode = true
+        modeSwitchStatus = "Preparing..."
+        refreshDaemonStatus()
+
+        do {
+            if isRunning {
+                modeSwitchStatus = "Stopping server..."
+                stopServer()
+                try await Task.sleep(for: .seconds(2))
+            }
+
+            switch mode {
+            case .launchDaemon:
+                if launchAtLogin {
+                    try configureLaunchAtLogin(enabled: false)
+                    launchAtLogin = false
+                }
+                modeSwitchStatus = "Activating LaunchDaemon (one admin dialog)..."
+                try activateLaunchDaemon(name: daemonUserName, createUser: !isDaemonUserExists)
+
+            case .launchAgent:
+                modeSwitchStatus = "Deactivating LaunchDaemon (one admin dialog)..."
+                try deactivateLaunchDaemon(restoreUser: NSUserName())
+            }
+
+            installMode = mode
+            userDefaults.set(mode.rawValue, forKey: installModeKey)
+            modeSwitchStatus = "Done."
+        } catch {
+            modeSwitchStatus = "Failed: \(error.localizedDescription)"
+            publishError("Mode switch failed: \(error.localizedDescription)")
+        }
+
+        isSwitchingMode = false
+        refreshAll()
+    }
+
+    func toggleDaemonStartAtBoot(_ enabled: Bool) {
+        daemonStartAtBoot = enabled
+        userDefaults.set(enabled, forKey: daemonStartAtBootKey)
+        guard launchDaemonInstalled else { return }
+        do {
+            try reinstallDaemonPlist()
+        } catch {
+            publishError("Failed to update LaunchDaemon: \(error.localizedDescription)")
+        }
+    }
+
+    func startDaemon() {
+        // Kill any stale LaunchAgent wired3 process (running from user home, not /Library/Wired3/).
+        // This can happen when switching from LaunchAgent to LaunchDaemon mode while a server
+        // is still running, or if stopServer() was skipped. Without this the daemon cannot
+        // bind port 4871.
+        let pgrepOut = runProcess("/usr/bin/pgrep", ["-x", "wired3"]).output
+        let allWiredPIDs = pgrepOut.split(separator: "\n").compactMap { Int32($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        let staleAgentPIDs = allWiredPIDs.filter { pid in
+            let args = runProcess("/bin/ps", ["-p", "\(pid)", "-o", "args="]).output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !args.hasPrefix("/Library/Wired3/bin/wired3")
+        }
+        for pid in staleAgentPIDs {
+            kill(pid, SIGTERM)
+        }
+        if !staleAgentPIDs.isEmpty {
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+
+        // bootstrap registers the service (no-op if already registered).
+        // kickstart starts it regardless of RunAtLoad value.
+        // If files dir is on an external volume, embed a TCC/FDA check in the SAME privileged
+        // script so only ONE admin auth dialog is shown.
+        let onExternal = filesDirectoryIsOnExternalVolume
+        let ts = Int(Date().timeIntervalSince1970)
+        let fdaTmpFile = "/tmp/.wired3fda_\(ts)"
+        let fdaShFile  = "/tmp/.wired3sh_\(ts).sh"
+
+        if onExternal {
+            writeFDACheckScript(filesDir: currentServerRootPath(), daemonUser: daemonUserName, outputFile: fdaTmpFile, to: fdaShFile)
+        }
+
+        var cmd = "launchctl bootstrap system '\(launchDaemonPlistPath)' 2>/dev/null"
+        cmd += "; launchctl kickstart system/\(launchAgentLabel) 2>/dev/null"
+        if onExternal {
+            cmd += "; sh '\(fdaShFile)'"
+        }
+        cmd += "; true"
+
+        do {
+            try runPrivileged(cmd, error: .launchDaemonInstallFailed("start"))
+            if onExternal {
+                let raw = (try? String(contentsOfFile: fdaTmpFile, encoding: .utf8)) ?? "0"
+                try? FileManager.default.removeItem(atPath: fdaTmpFile)
+                try? FileManager.default.removeItem(atPath: fdaShFile)
+                wired3HasFullDiskAccess = raw.trimmingCharacters(in: .whitespacesAndNewlines) == "1"
+            }
+        } catch {
+            publishError("Failed to start daemon: \(error.localizedDescription)")
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.refreshDaemonStatus()
+        }
+    }
+
+    func stopDaemon() {
+        do {
+            try runPrivileged("launchctl bootout system/\(launchAgentLabel) 2>/dev/null; true",
+                              error: .launchDaemonRemoveFailed("stop"))
+        } catch {
+            publishError("Failed to stop daemon: \(error.localizedDescription)")
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.refreshDaemonStatus()
+            // After daemon stops, check if a privileged binary update is available
+            if let self, self.installMode == .launchDaemon, !self.isDaemonRunning,
+               !self.showPrivilegedUpdateAlert, self.isBinaryUpdateAvailable() {
+                self.showPrivilegedUpdateAlert = true
+            }
+        }
+    }
+
+    private func validateDaemonIdentifier(_ value: String) throws {
+        let pattern = "^[a-z_][a-z0-9_-]{0,31}$"
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              regex.firstMatch(in: value, range: NSRange(value.startIndex..., in: value)) != nil else {
+            throw WiredServerError.launchDaemonInstallFailed(
+                "Invalid account name '\(value)'. Use only lowercase letters, digits, underscores, or hyphens (max 32 chars)."
+            )
+        }
+    }
+
+    // One admin dialog: create group (optional) + create user (optional) + chown + install plist
+    private func activateLaunchDaemon(name: String, createUser: Bool) throws {
+        try validateDaemonIdentifier(name)
+        try validateDaemonIdentifier(daemonGroupName)
+        let tempURL = try writeDaemonPlistToTemp()
+        let group = daemonGroupName
+        let createGroup = runProcess("/usr/bin/dscl", [".", "-read", "/Groups/\(daemonGroupName)"]).status != 0
+
+        var cmds: [String] = []
+
+        if createGroup {
+            let gid = try findFreeSystemGID()
+            cmds += [
+                "dscl . -create /Groups/\(group)",
+                "dscl . -create /Groups/\(group) PrimaryGroupID \(gid)",
+                "dscl . -create /Groups/\(group) Password '*'",
+                "dscl . -create /Groups/\(group) RealName 'Wired Server'"
+            ]
+        }
+
+        if createUser {
+            let uid = try findFreeSystemUID()
+            let gid = groupGID(for: group)
+            cmds += [
+                "dscl . -create /Users/\(name)",
+                "dscl . -create /Users/\(name) UserShell /usr/bin/false",
+                "dscl . -create /Users/\(name) RealName 'Wired Server'",
+                "dscl . -create /Users/\(name) UniqueID \(uid)",
+                "dscl . -create /Users/\(name) PrimaryGroupID \(gid)",
+                "dscl . -create /Users/\(name) NFSHomeDirectory /var/empty",
+                "dscl . -create /Users/\(name) IsHidden 1"
+            ]
+        }
+
+        cmds += [
+            "chown -R \(name):\(group) /Library/Wired3",
+            // bin/ uses staff group so the admin user can write the binary (admin is not in daemon group)
+            "chown \(name):staff /Library/Wired3/bin",
+            "chmod 775 /Library/Wired3/bin",
+            // Remove stale .updates dir: chown -R would have set it to _wired:daemon,
+            // preventing admin (not in daemon group) from writing inside it.
+            "rm -rf '/Library/Wired3/bin/.updates'",
+            "chmod 755 /Library/Wired3/bin/wired3 2>/dev/null || true",
+            // etc/ uses staff group so the admin user can write config.ini
+            "chown \(name):staff /Library/Wired3/etc",
+            "chmod 775 /Library/Wired3/etc",
+            "chown \(name):staff /Library/Wired3/etc/config.ini 2>/dev/null || true",
+            "chmod 664 /Library/Wired3/etc/config.ini 2>/dev/null || true",
+            "cp '\(tempURL.path)' '\(launchDaemonPlistPath)'",
+            "chmod 644 '\(launchDaemonPlistPath)'",
+            "chown root:wheel '\(launchDaemonPlistPath)'"
+        ]
+
+        try runPrivileged(cmds.joined(separator: " && "),
+                          error: WiredServerError.launchDaemonInstallFailed(""))
+        daemonAccountsVerified = false
+    }
+
+    // One admin dialog: bootout + remove plist + chown back to current user
+    private func deactivateLaunchDaemon(restoreUser: String) throws {
+        let cmds = [
+            "launchctl bootout system/\(launchAgentLabel) 2>/dev/null",
+            "rm -f '\(launchDaemonPlistPath)'",
+            "chown -R \(restoreUser):staff /Library/Wired3"  // back to staff for LaunchAgent
+        ].joined(separator: " && ")
+
+        try runPrivileged(cmds, error: WiredServerError.launchDaemonRemoveFailed(""))
+        daemonAccountsVerified = false
+    }
+
+    // Used by toggleDaemonStartAtBoot — updates existing plist with one admin dialog
+    private func reinstallDaemonPlist() throws {
+        let tempURL = try writeDaemonPlistToTemp()
+        let cmds = [
+            "cp '\(tempURL.path)' '\(launchDaemonPlistPath)'",
+            "chmod 644 '\(launchDaemonPlistPath)'",
+            "chown root:wheel '\(launchDaemonPlistPath)'"
+        ].joined(separator: " && ")
+        try runPrivileged(cmds, error: WiredServerError.launchDaemonInstallFailed(""))
+    }
+
+    private func writeDaemonPlistToTemp() throws -> URL {
+        let plist: [String: Any] = [
+            "Label": launchAgentLabel,
+            "ProgramArguments": [
+                installedBinaryPath,
+                "--working-directory", workingDirectory,
+                "--db", databasePath,
+                "--config", configPath,
+                "--root", currentServerRootPath()
+            ],
+            "UserName": daemonUserName,
+            "WorkingDirectory": workingDirectory,
+            "RunAtLoad": daemonStartAtBoot,
+            "KeepAlive": false,
+            "StandardOutPath": logPath,
+            "StandardErrorPath": logPath
+        ]
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fr.read-write.wired3.server.plist")
+        guard (plist as NSDictionary).write(to: tempURL, atomically: true) else {
+            throw WiredServerError.launchDaemonWriteFailed
+        }
+        return tempURL
+    }
+
+    // MARK: - Privileged execution
+
+    // Session cache: password stays valid for 30 s (like sudo timeout)
+    private var sessionPassword: String?
+    private var sessionPasswordExpiry: Date = .distantPast
+
+    private func resolveAdminCredential() -> String? {
+        // 1. In-memory session cache (avoids repeated Touch ID for multi-step operations)
+        if let cached = sessionPassword, Date() < sessionPasswordExpiry {
+            return cached
+        }
+        sessionPassword = nil
+
+        // 2. Keychain via Touch ID
+        if BiometricCredentialStore.isAvailable && BiometricCredentialStore.hasStoredCredential {
+            if let pw = BiometricCredentialStore.load(reason: L("touchid.reason")) {
+                cacheSessionPassword(pw)
+                return pw
+            }
+        }
+
+        // 3. Custom password dialog
+        guard let pw = promptAdminPassword() else { return nil }
+        cacheSessionPassword(pw)
+        return pw
+    }
+
+    private func cacheSessionPassword(_ password: String) {
+        sessionPassword = password
+        sessionPasswordExpiry = Date().addingTimeInterval(30)
+    }
+
+    private func runPrivileged(_ shellScript: String, error fallbackError: WiredServerError) throws {
+        guard let pw = resolveAdminCredential() else {
+            throw fallbackError
+        }
+
+        let (succeeded, isAuthFailure) = executePrivileged(shellScript: shellScript, password: pw)
+        if !succeeded {
+            sessionPassword = nil
+            if isAuthFailure {
+                // Only wipe the keychain entry on confirmed auth failure (wrong password),
+                // not on shell command errors — those leave a valid credential untouched.
+                if BiometricCredentialStore.hasStoredCredential {
+                    BiometricCredentialStore.delete()
+                    hasTouchIDCredential = false
+                }
+            }
+            let msg = L("touchid.wrong_password")
+            switch fallbackError {
+            case .launchDaemonInstallFailed:     throw WiredServerError.launchDaemonInstallFailed(msg)
+            case .launchDaemonRemoveFailed:      throw WiredServerError.launchDaemonRemoveFailed(msg)
+            case .systemDirectoryCreationFailed: throw WiredServerError.systemDirectoryCreationFailed(msg)
+            default:                             throw fallbackError
+            }
+        }
+
+        // Offer to save for Touch ID after first successful manual entry
+        if BiometricCredentialStore.isAvailable && !BiometricCredentialStore.hasStoredCredential {
+            offerTouchIDSave(password: pw)
+        }
+    }
+
+    /// Execute a shell command with an explicit admin password via AppleScript.
+    /// Returns (success, isAuthFailure). AppleScript error codes < 0 indicate auth/system
+    /// failures; positive codes are shell exit statuses (command ran but failed).
+    @discardableResult
+    private func executePrivileged(shellScript: String, password: String) -> (Bool, Bool) {
+        let escapedPw = password
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let appleScript = "do shell script \"\(shellScript)\" with administrator privileges password \"\(escapedPw)\""
+        var errorInfo: NSDictionary?
+        NSAppleScript(source: appleScript)?.executeAndReturnError(&errorInfo)
+        guard let errorInfo else { return (true, false) }
+        let code = errorInfo[NSAppleScript.errorNumber] as? Int ?? 0
+        return (false, code < 0)
+    }
+
+    /// Show a custom password dialog. Returns the entered password, or nil if cancelled.
+    private func promptAdminPassword() -> String? {
+        let alert = NSAlert()
+        alert.messageText = L("touchid.dialog.title")
+        alert.informativeText = L("touchid.dialog.message")
+        alert.addButton(withTitle: L("common.ok"))
+        alert.addButton(withTitle: L("common.cancel"))
+
+        let field = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        field.placeholderString = L("touchid.dialog.placeholder")
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        let pw = field.stringValue
+        return pw.isEmpty ? nil : pw
+    }
+
+    /// Ask the user once whether to save the password for Touch ID.
+    private func offerTouchIDSave(password: String) {
+        let alert = NSAlert()
+        alert.messageText = L("touchid.save.title")
+        alert.informativeText = L("touchid.save.message")
+        alert.addButton(withTitle: L("touchid.save.enable"))
+        alert.addButton(withTitle: L("common.cancel"))
+        if alert.runModal() == .alertFirstButtonReturn {
+            BiometricCredentialStore.save(password: password)
+            hasTouchIDCredential = true
+        }
+    }
+
+    func forgetTouchIDCredential() {
+        BiometricCredentialStore.delete()
+        hasTouchIDCredential = false
+    }
+
+    private func findFreeSystemUID() throws -> Int {
+        let output = runCommand("/usr/bin/dscl", [".", "-list", "/Users", "UniqueID"])
+        let used = Set(output.components(separatedBy: .newlines).compactMap { line -> Int? in
+            let parts = line.split(separator: " ").map(String.init)
+            return parts.count >= 2 ? Int(parts.last ?? "") : nil
+        })
+        for uid in 400...499 where !used.contains(uid) { return uid }
+        throw WiredServerError.launchDaemonInstallFailed(
+            "No free UID available in the 400–499 system range. Free a UID and try again."
+        )
+    }
+
+    private func findFreeSystemGID() throws -> Int {
+        let output = runCommand("/usr/bin/dscl", [".", "-list", "/Groups", "PrimaryGroupID"])
+        let used = Set(output.components(separatedBy: .newlines).compactMap { line -> Int? in
+            let parts = line.split(separator: " ").map(String.init)
+            return parts.count >= 2 ? Int(parts.last ?? "") : nil
+        })
+        for gid in 400...499 where !used.contains(gid) { return gid }
+        throw WiredServerError.launchDaemonInstallFailed(
+            "No free GID available in the 400–499 system range. Free a GID and try again."
+        )
+    }
+
+    private func groupGID(for group: String) -> Int {
+        let output = runCommand("/usr/bin/dscl", [".", "-read", "/Groups/\(group)", "PrimaryGroupID"])
+        for line in output.components(separatedBy: .newlines) {
+            let parts = line.split(separator: " ").map(String.init)
+            if parts.first == "PrimaryGroupID:", let gid = Int(parts.last ?? "") {
+                return gid
+            }
+        }
+        return 20  // fall back to staff GID
+    }
+
+    // MARK: - Wired 2.5 Migration
+
+    @MainActor func chooseMigrationSource() {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = false
         panel.canChooseFiles = true


### PR DESCRIPTION
> **Note:** This PR depends on #77 (LaunchDaemon mode) being merged first. The macOS CI failure is a missing-symbol error (`ServerInstallMode`, `refreshFDAStatusPrivileged`) introduced by that PR. Everything compiles cleanly on top of #77.

## Summary

- Fix a false-positive FDA check: the original implementation used `su -m` (fails because `_wired` has `UserShell=/usr/bin/false`) then `sudo -u` (can hang in a non-interactive AppleScript shell context). Both are replaced by running the actual `wired3` binary directly as root — TCC on macOS 12+ enforces FDA grants by the binary's code signature, not by UID, so this gives accurate results without the blocking risk.
- When the external-volume / FDA check fails, a new **"Open Full Disk Access…"** button deep-links directly to System Settings → Privacy & Security → Full Disk Access (correct URL for both macOS 12 and 13+), so the user can grant access without navigating manually.
- `fda.open_settings` key added to all three locale files (`en`, `de`, `fr`).

## Changes

| File | What changed |
|---|---|
| `WiredServerViewModel.swift` | Replace `su -m` / `sudo -u` with root `wired3 --check-access`; add `openFullDiskAccessSettings()` with OS-version URL |
| `Tabs.swift` | Add "Open Full Disk Access…" button to `ExternalVolumeWarningView` |
| `*/Localizable.strings` | Add `fda.open_settings` key in en/de/fr |

## Test plan

- [ ] With LaunchDaemon active and files directory on an external volume, the FDA warning banner appears
- [ ] Clicking "Open Full Disk Access…" opens System Settings at the Full Disk Access pane
- [ ] After granting access and clicking "Re-check", the banner transitions to the green "passed" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)