### PR TITLE
fix(files): hide macOS Icon\r sidecar from directory listings

### DIFF
--- a/Sources/wired3/Controllers/FilesController.swift
+++ b/Sources/wired3/Controllers/FilesController.swift
@@ -1061,8 +1061,8 @@ public class FilesController {
         }
 
         for file in files {
-            // skip invisible file
-            if file.hasPrefix(".") {
+            // skip dotfiles and the macOS custom-icon sidecar ("Icon\r")
+            if file.hasPrefix(".") || file == "Icon\r" {
                 continue
             }
 


### PR DESCRIPTION
## Summary

macOS creates an invisible file named `Icon\r` (literally "Icon" + carriage return 0x0D) in any folder that has a custom Finder icon. The existing filter in `replyListRecursive` only skips dotfiles (`hasPrefix(".")`), so this file appeared in Wired file listings and could not be deleted (path operations choke on the embedded control character).

One-line fix: extend the skip condition to also match `"Icon\r"`.

## Test plan

- [ ] Set a custom icon on any folder inside the Wired files root (paste an image onto the folder in Get Info)
- [ ] Connect with a client and browse that directory — the `Icon` entry should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)