### PR TITLE
fix(ui): stop main-thread hang in appendLog during server startup

### DIFF
--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -95,6 +95,8 @@ final class WiredServerViewModel: ObservableObject {
     private let fileManager = FileManager.default
     private var pollTimer: Timer?
     private var process: Process?
+    private var isPolling = false
+    private var logLineBuffer: [String] = []
 
     private let userDefaults = UserDefaults.standard
     private let launchAtAppStartKey = "wiredswift.server.launchAtAppStart"
@@ -1018,20 +1020,22 @@ final class WiredServerViewModel: ObservableObject {
         }
 
         if let content = try? String(contentsOfFile: logPath, encoding: .utf8) {
-            let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
-            logsText = lines.suffix(400).joined(separator: "\n")
+            let all = content.components(separatedBy: "\n")
+            logLineBuffer = Array(all.suffix(400))
+            logsText = logLineBuffer.joined(separator: "\n")
         }
     }
 
     private func appendLog(_ text: String) {
         guard !text.isEmpty else { return }
-        let current = logsText + text
-        let lines = current.split(separator: "\n", omittingEmptySubsequences: false)
-        logsText = lines.suffix(400).joined(separator: "\n")
+        // Maintain a separate line buffer so we never re-split the accumulated
+        // logsText string on every call (was O(n²) during rapid log output).
+        logLineBuffer.append(contentsOf: text.components(separatedBy: "\n"))
+        if logLineBuffer.count > 400 { logLineBuffer.removeFirst(logLineBuffer.count - 400) }
+        logsText = logLineBuffer.joined(separator: "\n")
 
         // Detect initial admin password generated on first launch
         if initialAdminPassword.isEmpty, text.contains("INITIAL ADMIN PASSWORD") {
-            // Extract password between "INITIAL ADMIN PASSWORD: " and " ==="
             if let range = text.range(of: "INITIAL ADMIN PASSWORD: "),
                let endRange = text[range.upperBound...].range(of: " ===") {
                 let password = String(text[range.upperBound..<endRange.lowerBound])
@@ -1041,8 +1045,7 @@ final class WiredServerViewModel: ObservableObject {
                 }
             }
         }
-
-        refreshDashboard()
+        // Dashboard is refreshed by the polling loop — no subprocess call here.
     }
 
     private func bootstrapRuntimeIfNeeded() {


### PR DESCRIPTION
## Problem

`appendLog()` was calling `refreshDashboard()` on every log line received from the wired3 binary. `refreshDashboard()` calls `refreshDashboardLightweight()` which (in LaunchAgent mode) calls `activeServerPIDs()` → `runProcess(pgrep -x wired3)` → `NSTask.waitUntilExit` — all on the `@MainActor`. During server startup, the binary can emit dozens of log lines per second, causing the UI to freeze with a spinning beachball.

A `sample(1)` trace confirmed the main thread was 92% blocked in `String.split` and 4% blocked in `waitUntilExit`, both inside `appendLog`.

## Fix

- Remove the `refreshDashboard()` call from `appendLog()`. The polling loop already calls `refreshDashboard()` every 2 seconds via `pollState()`, making the per-line call redundant.
- Replace the O(n²) string-split pattern (re-splitting the full `logsText` string on every append to trim to 400 lines) with a dedicated `logLineBuffer: [String]` that is appended to incrementally. `refreshLogText()` seeds the buffer so both code paths stay in sync.

## Test plan

- [ ] Start server in LaunchAgent mode — no beachball during startup
- [ ] Switch between LaunchAgent and LaunchDaemon several times — no hang
- [ ] Log view still shows up to 400 lines and updates while the server is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)