### PR TITLE
feat(p7): chat reactions and server-stamped message IDs (Wired 3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to WiredSwift are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Protocol — Wired 3.2
+
+- Bumped `<p7:protocol version="3.2">`. The 3.2 spec is wire-compatible with 3.1
+  via the per-session compatibility diff introduced in #87 — a 3.2 server can
+  serve a 3.1 client and vice-versa with the new fields/messages filtered
+  transparently on the wire.
+- Public-chat broadcasts now carry a server-stamped `wired.chat.message.id`
+  (length-prefixed string, UUID rendered as text). 3.1 receivers silently skip
+  it via the receiver-tolerance machinery.
+- New chat reactions API mirroring `wired.board.reaction.*`:
+  `wired.chat.add_reaction`, `wired.chat.remove_reaction`,
+  `wired.chat.get_reactions`, `wired.chat.reaction_list`,
+  `wired.chat.reaction_added`, `wired.chat.reaction_removed`.
+- New permission `wired.account.chat.add_reactions`.
+- Reactions live in an in-memory ring buffer (default 500 messages per chat);
+  when a message scrolls off the buffer its reactions are dropped — consistent
+  with the "chat is a stream" model. No on-disk persistence in 3.2.
+
 ## [3.0-beta.23+49] — 2026-05-05
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Compared to classic Wired 2.0 deployments and clients, Wired 3.0 adds a broader 
 - **Live typing indicator** in chat conversations, including protocol-level typing state broadcasts
 - **Offline private messaging** so clients can send encrypted private messages to disconnected users and have them delivered when the recipient next logs in
 - **Board reactions** on posts, with dedicated account privilege support for adding reactions
+- **Chat reactions** on public-chat messages (Wired 3.2), with server-assigned message identifiers and a `wired.account.chat.add_reactions` privilege
 - **Continuous folder sync** with a dedicated sync daemon (`wiredsyncd` on macOS) for keeping local folders and remote Wired shares aligned
 - **Remote board search** so clients can query discussions server-side and jump directly to matching threads or snippets
 - **FTS5-backed file search** on supported SQLite builds, with automatic fallback to `LIKE` queries when FTS5 is unavailable

--- a/Sources/WiredSwift/Resources/wired.xml
+++ b/Sources/WiredSwift/Resources/wired.xml
@@ -3,7 +3,7 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://www.read-write.fr/wired/html/p7-specification.xsd"
              name="Wired"
-             version="3.1">
+             version="3.2">
     <p7:documentation>
         TBD
         
@@ -314,6 +314,58 @@
             <p7:documentation>
                 Ephemeral typing state for a user in a chat. True indicates that the user is currently
                 typing, false indicates that typing has stopped.
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.chat.message.id" type="string" id="4007" version="3.2">
+            <p7:documentation>
+                Stable identifier for a single chat message, assigned by the server upon receipt of
+                [message:wired.chat.send_say] or [message:wired.chat.send_me] and stamped on the
+                resulting [message:wired.chat.say] / [message:wired.chat.me] broadcast. Encoded as a
+                length-prefixed string (UUID rendered as text) so that 3.1 receivers transparently
+                skip it via the receiver-tolerance machinery — fixed-size types like uuid would
+                desync older parsers.
+
+                Reactions reference this id. Reactions live as long as the message stays in the
+                server's in-memory chat ring buffer; once it is evicted, reactions are dropped.
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.chat.reaction.emoji" type="string" id="4020" version="3.2">
+            <p7:documentation>
+                Unicode emoji character(s) identifying a reaction on a chat message. Mirrors
+                [field:wired.board.reaction.emoji].
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.chat.reaction.count" type="uint32" id="4021" version="3.2">
+            <p7:documentation>
+                Total number of distinct accounts that have reacted with a given emoji on the target
+                chat message. Mirrors [field:wired.board.reaction.count]. Scoped to chat reaction
+                messages, which 3.1 peers ignore wholesale, so the fixed-size encoding is safe.
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.chat.reaction.is_own" type="bool" id="4022" version="3.2">
+            <p7:documentation>
+                Whether the currently authenticated account has reacted with this emoji on the
+                target chat message. Mirrors [field:wired.board.reaction.is_own].
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.chat.reaction.nick" type="string" id="4023" version="3.2">
+            <p7:documentation>
+                Public display nick of a user who reacted on a chat message, captured at the moment
+                of the reaction. Mirrors [field:wired.board.reaction.nick].
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.chat.reaction.nicks" type="string" id="4024" version="3.2">
+            <p7:documentation>
+                Pipe-separated list of display nicks that reacted with a specific emoji on a chat
+                message. Mirrors [field:wired.board.reaction.nicks]. Optional field of
+                [message:wired.chat.reaction_list].
+            </p7:documentation>
+        </p7:field>
+        <p7:field name="wired.chat.reaction.emojis" type="string" id="4025" version="3.2">
+            <p7:documentation>
+                Pipe-separated list of distinct emoji characters that have at least one reaction on
+                a chat message. Reserved for compact previews in future chat surfaces; not currently
+                emitted by the server.
             </p7:documentation>
         </p7:field>
 
@@ -1051,6 +1103,12 @@
                 Indicates whether the account gives the privilege of searching boards.
             </p7:documentation>
         </p7:field>
+        <p7:field name="wired.account.chat.add_reactions" type="bool" id="8099" version="3.2">
+            <p7:documentation>
+                When set, allows the account to add and remove emoji reactions on chat messages.
+                Mirror of [field:wired.account.board.add_reactions] for the chat surface.
+            </p7:documentation>
+        </p7:field>
         <p7:field name="wired.account.board.add_reactions" type="bool" id="8095" version="3.1">
             <p7:documentation>
                 Indicates whether the account gives the privilege of adding or removing emoji reactions
@@ -1607,6 +1665,7 @@
             <p7:member field="wired.account.chat.create_chats" />
             <p7:member field="wired.account.chat.create_public_chats" />
             <p7:member field="wired.account.chat.delete_public_chats" />
+            <p7:member field="wired.account.chat.add_reactions" />
             <p7:member field="wired.account.message.send_messages" />
             <p7:member field="wired.account.message.send_offline_messages" />
             <p7:member field="wired.account.user.list_offline_users" />
@@ -2074,11 +2133,16 @@
             <p7:documentation>
                 Normal chat message for a chat. [field:wired.chat.say] may be the empty string if
                 [field:wired.attachment.ids] contains at least one attachment ID.
+
+                As of 3.2 the server stamps every public-chat say with a stable
+                [field:wired.chat.message.id]. Pre-3.2 receivers silently skip it via the
+                receiver-tolerance machinery.
             </p7:documentation>
             <p7:parameter field="wired.chat.id" use="required" version="2.0" />
             <p7:parameter field="wired.user.id" use="required" version="2.0" />
             <p7:parameter field="wired.chat.say" use="required" version="2.0" />
             <p7:parameter field="wired.attachment.descriptors" version="3.2" />
+            <p7:parameter field="wired.chat.message.id" version="3.2" />
         </p7:message>
 
         <p7:message name="wired.chat.send_me" id="4016" version="2.0">
@@ -2094,11 +2158,15 @@
         <p7:message name="wired.chat.me" id="4017" version="2.0">
             <p7:documentation>
                 Action chat message for a chat. [field:wired.chat.me] may not be the empty string.
+
+                As of 3.2 the server stamps every public-chat me with a stable
+                [field:wired.chat.message.id].
             </p7:documentation>
             <p7:parameter field="wired.chat.id" use="required" version="2.0" />
             <p7:parameter field="wired.user.id" use="required" version="2.0" />
             <p7:parameter field="wired.chat.me" use="required" version="2.0" />
             <p7:parameter field="wired.attachment.descriptors" version="3.2" />
+            <p7:parameter field="wired.chat.message.id" version="3.2" />
         </p7:message>
 
         <p7:message name="wired.chat.create_chat" id="4018" version="2.0">
@@ -2230,6 +2298,86 @@
             <p7:parameter field="wired.chat.id" use="required" version="3.1" />
             <p7:parameter field="wired.user.id" use="required" version="3.1" />
             <p7:parameter field="wired.chat.typing" use="required" version="3.1" />
+        </p7:message>
+
+        <p7:message name="wired.chat.add_reaction" id="4033" version="3.2">
+            <p7:documentation>
+                Add an emoji reaction on a chat message. The server records the reaction against
+                [field:wired.chat.message.id] in the chat's in-memory ring buffer and broadcasts
+                [message:wired.chat.reaction_added] to every member of the target chat.
+
+                Requires [field:wired.account.chat.add_reactions]. If the message id is unknown
+                (older than the buffer or never seen) the server replies with
+                [enum:wired.error.invalid_message].
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.2" />
+            <p7:parameter field="wired.chat.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.message.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.emoji" use="required" version="3.2" />
+        </p7:message>
+
+        <p7:message name="wired.chat.remove_reaction" id="4034" version="3.2">
+            <p7:documentation>
+                Remove the caller's emoji reaction from a chat message. The server broadcasts
+                [message:wired.chat.reaction_removed] to every member of the target chat.
+
+                Requires [field:wired.account.chat.add_reactions].
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.2" />
+            <p7:parameter field="wired.chat.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.message.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.emoji" use="required" version="3.2" />
+        </p7:message>
+
+        <p7:message name="wired.chat.get_reactions" id="4035" version="3.2">
+            <p7:documentation>
+                Request the reaction summary for a single chat message. The server replies with
+                zero or more [message:wired.chat.reaction_list] messages — one per distinct emoji —
+                followed by [message:wired.okay].
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.2" />
+            <p7:parameter field="wired.chat.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.message.id" use="required" version="3.2" />
+        </p7:message>
+
+        <p7:message name="wired.chat.reaction_list" id="4036" version="3.2">
+            <p7:documentation>
+                One reaction summary item sent in response to [message:wired.chat.get_reactions].
+                Each message represents a single emoji and its aggregate count for the requested
+                chat message.
+            </p7:documentation>
+            <p7:parameter field="wired.transaction" version="3.2" />
+            <p7:parameter field="wired.chat.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.message.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.emoji" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.count" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.is_own" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.nicks" version="3.2" />
+        </p7:message>
+
+        <p7:message name="wired.chat.reaction_added" id="4037" version="3.2">
+            <p7:documentation>
+                Broadcast to every member of a chat when an emoji reaction is added on a chat
+                message. [field:wired.chat.reaction.count] reflects the updated total count for
+                this emoji on the message after the addition.
+            </p7:documentation>
+            <p7:parameter field="wired.chat.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.message.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.emoji" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.count" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.nick" use="required" version="3.2" />
+        </p7:message>
+
+        <p7:message name="wired.chat.reaction_removed" id="4038" version="3.2">
+            <p7:documentation>
+                Broadcast to every member of a chat when an emoji reaction is removed from a chat
+                message. When [field:wired.chat.reaction.count] reaches zero the client should
+                remove the reaction indicator entirely.
+            </p7:documentation>
+            <p7:parameter field="wired.chat.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.message.id" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.emoji" use="required" version="3.2" />
+            <p7:parameter field="wired.chat.reaction.count" use="required" version="3.2" />
         </p7:message>
 
         <p7:message name="wired.message.send_message" id="5000" version="2.0">

--- a/Sources/wired3/Controllers/ChatsController.swift
+++ b/Sources/wired3/Controllers/ChatsController.swift
@@ -43,6 +43,9 @@ extension ChatsController {
 
     func remove(chat: Chat) {
         clearTypingState(forChatID: chat.chatID)
+        chatReactionStores.exclusivelyWrite {
+            self._chatReactionStores.removeValue(forKey: chat.chatID)
+        }
 
         self.chatsLock.exclusivelyWrite {
             self.chats[chat.chatID] = nil
@@ -141,6 +144,16 @@ extension ChatsController {
 
         App.serverController.replyOK(client: client, message: message)
 
+        // 3.2: stamp a stable message ID on every public-chat say/me so
+        // clients can reference it for reactions. Pre-3.2 receivers skip
+        // this length-prefixed string field via receiver tolerance.
+        var stampedMessageID: String?
+        if !(chat is PrivateChat) {
+            let id = UUID().uuidString
+            stampedMessageID = id
+            reactionsStore(for: chat)?.register(messageID: id)
+        }
+
         chat.withClients { toClient in
             let messageName = isSay ? "wired.chat.say" : "wired.chat.me"
             let reply = P7Message(withName: messageName, spec: toClient.socket.spec)
@@ -149,6 +162,9 @@ extension ChatsController {
             reply.addParameter(field: messageName, value: string)
             if let descriptors, !descriptors.isEmpty {
                 reply.addParameter(field: "wired.attachment.descriptors", value: App.attachmentsController.descriptorStrings(descriptors))
+            }
+            if let stampedMessageID {
+                reply.addParameter(field: "wired.chat.message.id", value: stampedMessageID)
             }
             App.serverController.send(message: reply, client: toClient)
         }
@@ -280,6 +296,11 @@ public class ChatsController: TableController {
     private let typingStateLock = Lock()
     private let typingCleanupQueue = DispatchQueue(label: "wired3.chats.typing-cleanup")
     private var typingCleanupTimer: DispatchSourceTimer?
+
+    // Chat reactions (Wired 3.2). Per-public-chat in-memory ring buffer of
+    // recent message IDs and the reactions attached to them.
+    var _chatReactionStores: [UInt32: ChatReactionsStore] = [:]
+    let chatReactionStores: Lock = Lock()
 
     /// Creates a new `ChatsController` and starts the typing-state cleanup timer.
     ///

--- a/Sources/wired3/Core/ServerController+ChatReactions.swift
+++ b/Sources/wired3/Core/ServerController+ChatReactions.swift
@@ -1,0 +1,302 @@
+//
+//  ServerController+ChatReactions.swift
+//  wired3
+//
+//  Handles wired.chat.add_reaction, wired.chat.remove_reaction,
+//  wired.chat.get_reactions and stamps server-assigned message IDs
+//  on outgoing wired.chat.say / wired.chat.me broadcasts.
+//
+//  State lives in ChatReactionsStore — an in-memory ring buffer per
+//  public chat. When a message scrolls off the buffer, its reactions
+//  are dropped; this is consistent with the "chat is a stream" model
+//  and is documented in the 3.2 spec.
+//
+
+import Foundation
+import WiredSwift
+
+/// In-memory ring buffer of recent chat messages, plus the per-message
+/// reaction state. One instance per public chat, owned by ChatsController.
+public final class ChatReactionsStore {
+    /// Default size negotiated for 3.2.
+    public static let defaultBufferSize = 500
+
+    private struct Entry {
+        let messageID: String
+        var reactions: [String: String]   // login -> emoji
+        var nicks: [String: String]       // login -> nick (snapshot)
+    }
+
+    private let lock = NSLock()
+    private var buffer: [Entry] = []
+    private var index: [String: Int] = [:]   // messageID -> position in buffer
+    private let capacity: Int
+
+    public init(capacity: Int = ChatReactionsStore.defaultBufferSize) {
+        self.capacity = capacity
+    }
+
+    /// Stamp a new message id into the buffer. Evicts the oldest entry when
+    /// the ring is full.
+    public func register(messageID: String) {
+        lock.lock(); defer { lock.unlock() }
+        if buffer.count >= capacity {
+            let evicted = buffer.removeFirst()
+            index.removeValue(forKey: evicted.messageID)
+            // Indices shift by one; rebuild lazily — only entries kept.
+            for i in 0..<buffer.count { index[buffer[i].messageID] = i }
+        }
+        buffer.append(Entry(messageID: messageID, reactions: [:], nicks: [:]))
+        index[messageID] = buffer.count - 1
+    }
+
+    public struct ToggleResult {
+        public let added: Bool
+        public let count: Int
+        public let removedEmoji: String?
+        public let removedCount: Int
+    }
+
+    /// Add a reaction. If the same login already reacted with a different
+    /// emoji on this message, the old reaction is replaced (single reaction
+    /// per user per message — same model as boards).
+    public func add(messageID: String, emoji: String, login: String, nick: String) -> ToggleResult? {
+        lock.lock(); defer { lock.unlock() }
+        guard let idx = index[messageID] else { return nil }
+        var entry = buffer[idx]
+        let removedEmoji = entry.reactions[login]
+        entry.reactions[login] = emoji
+        entry.nicks[login] = nick
+        buffer[idx] = entry
+
+        let count = entry.reactions.values.filter { $0 == emoji }.count
+        let removedCount: Int
+        if let old = removedEmoji, old != emoji {
+            removedCount = entry.reactions.values.filter { $0 == old }.count
+        } else {
+            removedCount = 0
+        }
+        return ToggleResult(
+            added: true,
+            count: count,
+            removedEmoji: (removedEmoji != emoji) ? removedEmoji : nil,
+            removedCount: removedCount
+        )
+    }
+
+    /// Remove the caller's reaction. Returns nil when the message id is
+    /// unknown (evicted) or when the caller had no matching reaction.
+    public func remove(messageID: String, emoji: String, login: String) -> ToggleResult? {
+        lock.lock(); defer { lock.unlock() }
+        guard let idx = index[messageID] else { return nil }
+        var entry = buffer[idx]
+        guard entry.reactions[login] == emoji else { return nil }
+        entry.reactions.removeValue(forKey: login)
+        entry.nicks.removeValue(forKey: login)
+        buffer[idx] = entry
+        let count = entry.reactions.values.filter { $0 == emoji }.count
+        return ToggleResult(added: false, count: count, removedEmoji: nil, removedCount: 0)
+    }
+
+    public struct Summary {
+        public let emoji: String
+        public let count: Int
+        public let isOwn: Bool
+        public let nicks: [String]
+    }
+
+    /// Build the per-emoji summaries for a message, with `isOwn` resolved
+    /// against `currentLogin`. Returns an empty array when the message id
+    /// is unknown (evicted from the buffer).
+    public func summaries(messageID: String, currentLogin: String) -> [Summary] {
+        lock.lock(); defer { lock.unlock() }
+        guard let idx = index[messageID] else { return [] }
+        let entry = buffer[idx]
+        var byEmoji: [String: (count: Int, isOwn: Bool, nicks: [String])] = [:]
+        // Stable order: iterate logins sorted to keep nicks deterministic.
+        for login in entry.reactions.keys.sorted() {
+            let emoji = entry.reactions[login]!
+            let nick = entry.nicks[login] ?? login
+            var slot = byEmoji[emoji] ?? (count: 0, isOwn: false, nicks: [])
+            slot.count += 1
+            if login == currentLogin { slot.isOwn = true }
+            slot.nicks.append(nick)
+            byEmoji[emoji] = slot
+        }
+        return byEmoji
+            .map { Summary(emoji: $0.key, count: $0.value.count, isOwn: $0.value.isOwn, nicks: $0.value.nicks) }
+            .sorted { $0.emoji < $1.emoji }
+    }
+
+    /// Whether the buffer currently knows about this message id.
+    public func contains(messageID: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return index[messageID] != nil
+    }
+}
+
+extension ChatsController {
+    /// Returns (or lazily creates) the reactions store for a public chat.
+    /// Private chats get nil — reactions on private messages are out of
+    /// scope for 3.2 per the issue.
+    public func reactionsStore(for chat: Chat) -> ChatReactionsStore? {
+        if chat is PrivateChat { return nil }
+        return chatReactionStores.exclusivelyWrite {
+            if let existing = self._chatReactionStores[chat.chatID] { return existing }
+            let store = ChatReactionsStore()
+            self._chatReactionStores[chat.chatID] = store
+            return store
+        }
+    }
+}
+
+extension ServerController {
+
+    // MARK: - Reaction handlers
+
+    func receiveChatAddReaction(client: Client, message: P7Message) {
+        guard let user = client.user else {
+            App.serverController.replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
+            return
+        }
+        guard user.hasPrivilege(name: "wired.account.chat.add_reactions") else {
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+            return
+        }
+        guard let chatID = message.uint32(forField: "wired.chat.id"),
+              let messageID = message.string(forField: "wired.chat.message.id"), !messageID.isEmpty,
+              let emoji = message.string(forField: "wired.chat.reaction.emoji"), !emoji.isEmpty
+        else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        guard let chat = App.chatsController.chat(withID: chatID) else {
+            App.serverController.replyError(client: client, error: "wired.error.chat_not_found", message: message)
+            return
+        }
+        guard chat.client(withID: client.userID) != nil else {
+            App.serverController.replyError(client: client, error: "wired.error.not_on_chat", message: message)
+            return
+        }
+        guard let store = App.chatsController.reactionsStore(for: chat) else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        let nick = client.nick ?? user.username ?? ""
+        let login = user.username ?? ""
+        guard let result = store.add(messageID: messageID, emoji: emoji, login: login, nick: nick) else {
+            // Unknown message id — likely evicted from the ring buffer.
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        App.serverController.replyOK(client: client, message: message)
+
+        if let oldEmoji = result.removedEmoji {
+            broadcastChatReaction(chat: chat, messageID: messageID, emoji: oldEmoji,
+                                  count: result.removedCount, nick: nick, added: false)
+        }
+        broadcastChatReaction(chat: chat, messageID: messageID, emoji: emoji,
+                              count: result.count, nick: nick, added: true)
+    }
+
+    func receiveChatRemoveReaction(client: Client, message: P7Message) {
+        guard let user = client.user else {
+            App.serverController.replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
+            return
+        }
+        guard user.hasPrivilege(name: "wired.account.chat.add_reactions") else {
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+            return
+        }
+        guard let chatID = message.uint32(forField: "wired.chat.id"),
+              let messageID = message.string(forField: "wired.chat.message.id"), !messageID.isEmpty,
+              let emoji = message.string(forField: "wired.chat.reaction.emoji"), !emoji.isEmpty
+        else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        guard let chat = App.chatsController.chat(withID: chatID) else {
+            App.serverController.replyError(client: client, error: "wired.error.chat_not_found", message: message)
+            return
+        }
+        guard chat.client(withID: client.userID) != nil else {
+            App.serverController.replyError(client: client, error: "wired.error.not_on_chat", message: message)
+            return
+        }
+        guard let store = App.chatsController.reactionsStore(for: chat) else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        let login = user.username ?? ""
+        let nick = client.nick ?? login
+        guard let result = store.remove(messageID: messageID, emoji: emoji, login: login) else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        App.serverController.replyOK(client: client, message: message)
+        broadcastChatReaction(chat: chat, messageID: messageID, emoji: emoji,
+                              count: result.count, nick: nick, added: false)
+    }
+
+    func receiveChatGetReactions(client: Client, message: P7Message) {
+        guard let user = client.user else {
+            App.serverController.replyError(client: client, error: "wired.error.message_out_of_sequence", message: message)
+            return
+        }
+        guard let chatID = message.uint32(forField: "wired.chat.id"),
+              let messageID = message.string(forField: "wired.chat.message.id"), !messageID.isEmpty
+        else {
+            App.serverController.replyError(client: client, error: "wired.error.invalid_message", message: message)
+            return
+        }
+        guard let chat = App.chatsController.chat(withID: chatID) else {
+            App.serverController.replyError(client: client, error: "wired.error.chat_not_found", message: message)
+            return
+        }
+        guard chat.client(withID: client.userID) != nil else {
+            App.serverController.replyError(client: client, error: "wired.error.not_on_chat", message: message)
+            return
+        }
+        guard let store = App.chatsController.reactionsStore(for: chat) else {
+            App.serverController.replyOK(client: client, message: message)
+            return
+        }
+        let login = user.username ?? ""
+        for summary in store.summaries(messageID: messageID, currentLogin: login) {
+            let reply = P7Message(withName: "wired.chat.reaction_list", spec: self.spec)
+            reply.addParameter(field: "wired.chat.id", value: chatID)
+            reply.addParameter(field: "wired.chat.message.id", value: messageID)
+            reply.addParameter(field: "wired.chat.reaction.emoji", value: summary.emoji)
+            reply.addParameter(field: "wired.chat.reaction.count", value: UInt32(summary.count))
+            reply.addParameter(field: "wired.chat.reaction.is_own", value: summary.isOwn)
+            if !summary.nicks.isEmpty {
+                reply.addParameter(field: "wired.chat.reaction.nicks", value: summary.nicks.joined(separator: "|"))
+            }
+            self.reply(client: client, reply: reply, message: message)
+        }
+        App.serverController.replyOK(client: client, message: message)
+    }
+
+    // MARK: - Broadcast
+
+    private func broadcastChatReaction(chat: Chat, messageID: String, emoji: String,
+                                       count: Int, nick: String, added: Bool) {
+        let messageName = added ? "wired.chat.reaction_added" : "wired.chat.reaction_removed"
+        chat.withClients { toClient in
+            // Skip clients on a pre-3.2 spec — they don't know the message
+            // and would log an unknown-message warning. The compatibility
+            // diff machinery would also drop the whole frame, so this is
+            // belt-and-braces.
+            guard toClient.socket.peerKnows(messageNamed: messageName) else { return }
+            let broadcast = P7Message(withName: messageName, spec: toClient.socket.spec)
+            broadcast.addParameter(field: "wired.chat.id", value: chat.chatID)
+            broadcast.addParameter(field: "wired.chat.message.id", value: messageID)
+            broadcast.addParameter(field: "wired.chat.reaction.emoji", value: emoji)
+            broadcast.addParameter(field: "wired.chat.reaction.count", value: UInt32(count))
+            if added {
+                broadcast.addParameter(field: "wired.chat.reaction.nick", value: nick)
+            }
+            App.serverController.send(message: broadcast, client: toClient)
+        }
+    }
+}

--- a/Sources/wired3/Core/ServerController.swift
+++ b/Sources/wired3/Core/ServerController.swift
@@ -740,6 +740,12 @@ public class ServerController: ServerDelegate {
             App.chatsController.setTopic(message: message, client: client)
         } else if message.name == "wired.chat.kick_user" {
             App.chatsController.kickUser(message: message, client: client)
+        } else if message.name == "wired.chat.add_reaction" {
+            self.receiveChatAddReaction(client: client, message: message)
+        } else if message.name == "wired.chat.remove_reaction" {
+            self.receiveChatRemoveReaction(client: client, message: message)
+        } else if message.name == "wired.chat.get_reactions" {
+            self.receiveChatGetReactions(client: client, message: message)
         } else if message.name == "wired.message.send_message" {
             self.receiveMessageSendMessage(client: client, message: message)
         } else if message.name == "wired.message.send_offline_message" {

--- a/Tests/WiredSwiftTests/P7SocketIOTests.swift
+++ b/Tests/WiredSwiftTests/P7SocketIOTests.swift
@@ -237,7 +237,7 @@ final class P7SocketIOTests: XCTestCase {
 
         XCTAssertNil(serverError)
         XCTAssertEqual(client.remoteName, "Wired")
-        XCTAssertEqual(client.remoteVersion, "3.1")
+        XCTAssertEqual(client.remoteVersion, "3.2")
         XCTAssertFalse(client.compressionEnabled)
         XCTAssertFalse(client.encryptionEnabled)
         XCTAssertFalse(client.checksumEnabled)

--- a/Tests/wired3IntegrationTests/Lot6ChatReactionsIntegrationTests.swift
+++ b/Tests/wired3IntegrationTests/Lot6ChatReactionsIntegrationTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+import WiredSwift
+@testable import wired3Lib
+
+/// End-to-end test for Wired 3.2 chat reactions.
+///
+/// Exercises the full flow:
+///   1. send_say → server stamps `wired.chat.message.id` on the broadcast
+///   2. add_reaction → broadcast `reaction_added` to peers
+///   3. get_reactions → enumerated `reaction_list` entries
+///   4. remove_reaction → broadcast `reaction_removed`
+final class Lot6ChatReactionsIntegrationTests: SerializedIntegrationTestCase {
+
+    func testChatReactionsRoundTrip() throws {
+        let runtime = try IntegrationServerRuntime()
+        try runtime.start()
+        runtime.ensurePrivilegedUser(username: "it_admin", password: "secret")
+        runtime.ensurePrivilegedUser(username: "it_admin_2", password: "secret2")
+        defer { try? runtime.stop() }
+
+        let c1 = try runtime.connectClient(username: "it_admin", password: "secret")
+        defer { c1.disconnect() }
+        try sendClientInfoAndExpectServerInfo(socket: c1)
+        _ = try sendLoginAndExpectSuccess(socket: c1, username: "it_admin", password: "secret")
+        drainMessages(socket: c1)
+
+        let c2 = try runtime.connectClient(username: "it_admin_2", password: "secret2")
+        defer { c2.disconnect() }
+        try sendClientInfoAndExpectServerInfo(socket: c2)
+        _ = try sendLoginAndExpectSuccess(socket: c2, username: "it_admin_2", password: "secret2")
+        drainMessages(socket: c2)
+
+        // Both join the default public chat (id 1).
+        let chatID: UInt32 = 1
+        for s in [c1, c2] {
+            let join = P7Message(withName: "wired.chat.join_chat", spec: s.spec)
+            join.addParameter(field: "wired.chat.id", value: chatID)
+            XCTAssertTrue(s.write(join))
+            _ = try readMessage(from: s, expectedName: "wired.chat.user_list.done", maxReads: 30)
+            _ = try readMessage(from: s, expectedName: "wired.chat.topic", maxReads: 30)
+        }
+        // Drain the user_join broadcast c1 sees from c2.
+        _ = tryReadMessage(from: c1, expectedNames: ["wired.chat.user_join"], maxReads: 40, timeout: 0.25)
+
+        // c1 sends a message and learns its server-stamped id from the broadcast.
+        let say = P7Message(withName: "wired.chat.send_say", spec: c1.spec)
+        say.addParameter(field: "wired.chat.id", value: chatID)
+        say.addParameter(field: "wired.chat.say", value: "hello reactions")
+        XCTAssertTrue(c1.write(say))
+        _ = try readMessage(from: c1, expectedName: "wired.okay", maxReads: 20)
+        let sayBroadcast = try readMessage(from: c1, expectedName: "wired.chat.say", maxReads: 30)
+        let messageID = try XCTUnwrap(sayBroadcast.string(forField: "wired.chat.message.id"),
+                                      "Server must stamp wired.chat.message.id on public-chat say")
+        XCTAssertFalse(messageID.isEmpty)
+
+        // c2 should see the same broadcast with the same id (drain to it).
+        let c2Say = try readMessage(from: c2, expectedName: "wired.chat.say", maxReads: 30)
+        XCTAssertEqual(c2Say.string(forField: "wired.chat.message.id"), messageID)
+
+        // c2 reacts. Expect okay + reaction_added broadcast on both ends.
+        let add = P7Message(withName: "wired.chat.add_reaction", spec: c2.spec)
+        add.addParameter(field: "wired.chat.id", value: chatID)
+        add.addParameter(field: "wired.chat.message.id", value: messageID)
+        add.addParameter(field: "wired.chat.reaction.emoji", value: "👍")
+        XCTAssertTrue(c2.write(add))
+        _ = try readMessage(from: c2, expectedName: "wired.okay", maxReads: 20)
+
+        let added = try readMessage(from: c1, expectedName: "wired.chat.reaction_added", maxReads: 40)
+        XCTAssertEqual(added.string(forField: "wired.chat.message.id"), messageID)
+        XCTAssertEqual(added.string(forField: "wired.chat.reaction.emoji"), "👍")
+        XCTAssertEqual(added.uint32(forField: "wired.chat.reaction.count"), 1)
+        XCTAssertEqual(added.string(forField: "wired.chat.reaction.nick"), "it_admin_2")
+
+        // c1 fetches the reaction list and checks isOwn=false (c1 didn't react).
+        let get = P7Message(withName: "wired.chat.get_reactions", spec: c1.spec)
+        get.addParameter(field: "wired.chat.id", value: chatID)
+        get.addParameter(field: "wired.chat.message.id", value: messageID)
+        XCTAssertTrue(c1.write(get))
+        let list = try readMessage(from: c1, expectedName: "wired.chat.reaction_list", maxReads: 30)
+        XCTAssertEqual(list.string(forField: "wired.chat.reaction.emoji"), "👍")
+        XCTAssertEqual(list.uint32(forField: "wired.chat.reaction.count"), 1)
+        XCTAssertEqual(list.bool(forField: "wired.chat.reaction.is_own"), false)
+        _ = try readMessage(from: c1, expectedName: "wired.okay", maxReads: 10)
+
+        // c2 removes its reaction; c1 sees reaction_removed.
+        let remove = P7Message(withName: "wired.chat.remove_reaction", spec: c2.spec)
+        remove.addParameter(field: "wired.chat.id", value: chatID)
+        remove.addParameter(field: "wired.chat.message.id", value: messageID)
+        remove.addParameter(field: "wired.chat.reaction.emoji", value: "👍")
+        XCTAssertTrue(c2.write(remove))
+        _ = try readMessage(from: c2, expectedName: "wired.okay", maxReads: 20)
+        let removed = try readMessage(from: c1, expectedName: "wired.chat.reaction_removed", maxReads: 30)
+        XCTAssertEqual(removed.string(forField: "wired.chat.message.id"), messageID)
+        XCTAssertEqual(removed.uint32(forField: "wired.chat.reaction.count"), 0)
+
+        // Reacting on an unknown id surfaces invalid_message.
+        let bogus = P7Message(withName: "wired.chat.add_reaction", spec: c2.spec)
+        bogus.addParameter(field: "wired.chat.id", value: chatID)
+        bogus.addParameter(field: "wired.chat.message.id", value: "00000000-0000-0000-0000-000000000000")
+        bogus.addParameter(field: "wired.chat.reaction.emoji", value: "🚫")
+        XCTAssertTrue(c2.write(bogus))
+        let err = try readMessage(from: c2, expectedName: "wired.error", maxReads: 20)
+        XCTAssertEqual(err.enumeration(forField: "wired.error"), 1) // invalid_message
+    }
+
+    /// Mirrors the manual test plan from PR #89: synthesize a "3.1" spec by
+    /// stripping every 3.2 chat reaction item from the bundled XML and verify
+    /// the compatibility diff identifies what a 3.2 sender would have to drop
+    /// when speaking to a 3.1 peer.
+    func testCompatibilityDiffStripsChatReactionItemsFor31Peer() throws {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/WiredSwift/Resources/wired.xml")
+        let xml = try String(contentsOf: url, encoding: .utf8)
+        let stripped = stripChatReactionsAndBumpTo31(xml)
+        let local = try XCTUnwrap(P7Spec(withUrl: url))
+        let remote = try XCTUnwrap(P7Spec(withString: stripped))
+        let diff = CompatibilityDiff.diff(local: local, remote: remote)
+
+        // The 3.2 chat reaction message ids (4033..4038) must show up as
+        // unknown to the 3.1 peer; sender filtering will drop them.
+        let droppedMessageIDs: [Int] = [4033, 4034, 4035, 4036, 4037, 4038]
+        for id in droppedMessageIDs {
+            XCTAssertTrue(diff.messagesUnknownToRemote.contains(UInt32(id)),
+                          "Diff should mark message id \(id) as unknown to a stripped 3.1 peer")
+        }
+        XCTAssertTrue(diff.fieldsUnknownToRemote.contains(4007),
+                      "Diff should mark wired.chat.message.id (4007) as unknown to a stripped 3.1 peer")
+    }
+
+    private func stripChatReactionsAndBumpTo31(_ xml: String) -> String {
+        var out = xml
+        // Re-id every 3.2 chat reaction field/message/permission so they look
+        // foreign to the diff; the actual XML structure is unchanged.
+        let renames: [(String, String)] = [
+            ("id=\"4007\" version=\"3.2\"", "id=\"99007\" version=\"3.2\""),
+            ("id=\"4020\" version=\"3.2\"", "id=\"99020\" version=\"3.2\""),
+            ("id=\"4021\" version=\"3.2\"", "id=\"99021\" version=\"3.2\""),
+            ("id=\"4022\" version=\"3.2\"", "id=\"99022\" version=\"3.2\""),
+            ("id=\"4023\" version=\"3.2\"", "id=\"99023\" version=\"3.2\""),
+            ("id=\"4024\" version=\"3.2\"", "id=\"99024\" version=\"3.2\""),
+            ("id=\"4025\" version=\"3.2\"", "id=\"99025\" version=\"3.2\""),
+            ("id=\"4033\" version=\"3.2\"", "id=\"99033\" version=\"3.2\""),
+            ("id=\"4034\" version=\"3.2\"", "id=\"99034\" version=\"3.2\""),
+            ("id=\"4035\" version=\"3.2\"", "id=\"99035\" version=\"3.2\""),
+            ("id=\"4036\" version=\"3.2\"", "id=\"99036\" version=\"3.2\""),
+            ("id=\"4037\" version=\"3.2\"", "id=\"99037\" version=\"3.2\""),
+            ("id=\"4038\" version=\"3.2\"", "id=\"99038\" version=\"3.2\""),
+        ]
+        for (from, to) in renames {
+            out = out.replacingOccurrences(of: from, with: to)
+        }
+        return out
+    }
+}


### PR DESCRIPTION
## Summary

- Bumps the protocol to `<p7:protocol version=\"3.2\">` and introduces a chat-reactions surface mirroring `wired.board.reaction.*`.
- Public-chat broadcasts now carry a server-assigned `wired.chat.message.id` (length-prefixed UUID string) so clients have a stable handle for reactions, optimistic-UI correlation, and future edits.
- Per public chat, an in-memory ring buffer (default 500 messages) tracks reactions; messages that scroll off the buffer drop their reactions, consistent with the \"chat is a stream\" model. No on-disk persistence in 3.2.
- New permission `wired.account.chat.add_reactions` (id 8099, 3.2). Reacting on an unknown message id surfaces `wired.error.invalid_message`.

Wire-compat with 3.1 is provided by the per-session compatibility diff introduced in #87 — pre-3.2 receivers transparently skip the new length-prefixed field on `wired.chat.say` / `wired.chat.me`, and the new reaction messages are filtered out wholesale on the wire. The companion macOS UI gates itself on `peerKnows(messageNamed: \"wired.chat.add_reaction\")` to keep degradation clean.

Closes #90. Companion: [Wired-macOS#40](https://github.com/nark/Wired-macOS/issues/40).

## Test plan

- [x] `swift build` is green.
- [x] New `Lot6ChatReactionsIntegrationTests` covers the full round-trip (send_say → server-stamped id → add_reaction → broadcast → get_reactions → remove_reaction → broadcast) plus the unknown-id error path. Both tests pass locally.
- [x] `Lot6` also synthesises a stripped 3.1 spec from the bundled XML and asserts that the compatibility diff identifies every new 3.2 chat-reactions message/field as unknown to the older peer (validates sender-side filtering).
- [ ] Manual verification against the macOS client (#40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)