### PR TITLE
fix(url): use URLComponents.password to avoid percent-encoding corruption

### DIFF
--- a/Sources/WiredSwift/Network/Url.swift
+++ b/Sources/WiredSwift/Network/Url.swift
@@ -38,10 +38,12 @@ public class Url: NSObject {
 
     private func decompose() {
         if let u = URL(string: self.base) {
+            // URL.user/password return the percent-encoded form; URLComponents returns decoded values.
+            let comps = URLComponents(url: u, resolvingAgainstBaseURL: false)
             self.hostname   = u.host!
             self.port       = u.port ?? Wired.wiredPort
-            self.login      = u.user ?? "guest"
-            self.password   = u.password ?? ""
+            self.login      = comps?.user ?? "guest"
+            self.password   = comps?.password ?? ""
             self.scheme     = u.scheme!
         } else {
             Logger.error("ERROR: Invalid URL")


### PR DESCRIPTION
## Summary

`Url.decompose()` used `URL.password` to extract the password component after parsing a URL string. Despite Apple's documentation stating the property is "percent-decoded", it actually returns the percent-**encoded** form — so passwords containing `?`, `%`, or `&` arrive corrupted after a URL round-trip.

For example, setting `URLComponents.password = "secret?%&"` produces the URL string `...secret%3F%25&@host...`, and reading it back via `URL.password` yields `"secret%3F%25&"` instead of `"secret?%&"`.

`URLComponents(url:resolvingAgainstBaseURL:).password` correctly returns the decoded plaintext.

## Root cause

```swift
// Before — URL.password returns percent-encoded form
self.password = u.password ?? ""

// After — URLComponents.password returns decoded plaintext
let comps = URLComponents(url: u, resolvingAgainstBaseURL: false)
self.password = comps?.password ?? ""
```

## Impact

Any code that builds a URL string with `URLComponents` (setting `components.password = plaintextPassword`) and then parses it back through `Url(withString:)` will receive a corrupted password for any account whose password contains `?`, `%`, or `&`. Authentication silently fails — the server closes the connection after `client_key` with "Network error", with no indication that the wrong password was used.

Accounts with alphanumeric-only passwords are unaffected, which is why the bug is easy to miss.

## Test plan

- [ ] Verify that `Url(withString: "wired://user:p%40ss%3F%25@host:4871").password` returns `"p@ss?%"` (not `"p%40ss%3F%25"`)
- [ ] Confirm authentication succeeds for an account whose password contains `?`, `%`, or `&`

🤖 Generated with [Claude Code](https://claude.com/claude-code)