### PR TITLE
ci(review): add automated Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Claude Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           model: claude-sonnet-4-6
           mode: review
           direct_prompt: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,73 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-sonnet-4-6
+          mode: review
+          direct_prompt: |
+            Tu es le relecteur officiel de WiredSwift — la bibliothèque Swift et
+            le daemon `wired3` qui implémentent le protocole binaire Wired (P7) :
+            parsing protocole, sockets, crypto (ECDSA, ECDH, ciphers), serveur
+            chat / fichiers / boards / transferts.
+
+            Relis cette pull request avec trois priorités, dans cet ordre :
+
+            1. **Sécurité** — c'est un projet réseau, c'est la priorité n°1 :
+               - parsing de `P7Message` / `P7Socket` : longueurs de champs,
+                 désérialisation, débordements, allocations contrôlées par le pair
+               - crypto : usage correct des primitives, pas de constantes en dur,
+                 pas de downgrade silencieux, IV / nonces uniques
+               - auth, sessions, brute-force, rate limiting (cf. `Tests/.../auth`)
+               - chemins de fichiers côté `files` / transferts : path traversal,
+                 symlinks, fuites hors du root partagé
+               - injection SQL via GRDB (préfère les requêtes paramétrées)
+               - `force_try`, `try!`, force-unwraps sur des entrées réseau
+
+            2. **Philosophie du projet** :
+               - **Compatibilité protocole** : si la PR touche `wired.xml`, vérifier
+                 que les règles de `COMPATIBILITY.md` sont respectées (attribut
+                 `version="X.Y"` sur chaque nouveau champ/message/enum, bump de la
+                 version racine, tests `CompatibilityTests`, types length-prefixed
+                 pour les champs optionnels). C'est non négociable.
+               - Code Swift idiomatique, respect du style `.swiftlint.yml`
+                 (4 espaces, camelCase, ligne <160 chars).
+               - Pas de nouveau `// swiftlint:disable` sans TODO justifié.
+               - Conventional commits (`feat(p7):`, `fix(auth):`, etc.).
+               - Simplicité avant abstraction : trois lignes similaires valent
+                 mieux qu'une abstraction prématurée.
+
+            3. **Qualité générale** — bugs probables, edge cases (peer hostile,
+               connexion coupée en plein message, payloads tronqués), lisibilité,
+               tests manquants.
+
+            **Ton et style** :
+            - Bienveillant, encourageant, jamais condescendant. L'auteur a passé
+              du temps sur cette PR — souligne d'abord ce qui est bien fait.
+            - Tutoie l'auteur, parle en français.
+            - Distingue clairement :
+              - 🔴 **Bloquant** — sécurité, compat protocole cassée
+              - 🟡 **À corriger** — bugs, conventions
+              - 💡 **Suggestion / question** — à discuter
+              - ✨ **Bien joué** — ce qui mérite d'être salué
+            - Si la PR est propre, dis-le franchement, pas de critique inventée.
+            - Sois concis : pas de paraphrase du diff, va aux points qui comptent.
+            - Termine par un petit mot positif pour l'auteur.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md — WiredSwift
+
+Notes pour Claude (et autres assistants IA) qui travaillent sur ce dépôt.
+
+## Ce que ce repo contient
+
+- **`WiredSwift`** : bibliothèque Swift — parser du protocole binaire Wired (P7),
+  crypto (ECDSA/ECDH/ciphers), couche connexion/socket.
+- **`wired3`** : daemon serveur — auth, chat, fichiers, boards, transferts.
+- **`WiredServerApp`** : wrapper macOS GUI autour de `wired3`.
+
+Arbre principal : `Sources/WiredSwift/{P7,Crypto,Network,Core}`.
+Spec protocole : `Sources/WiredSwift/Resources/wired.xml`.
+
+## Documentation déjà existante — lis-la avant d'agir
+
+| Fichier | Quand le consulter |
+|---|---|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Setup, style, conventions de commit, workflow PR |
+| [COMPATIBILITY.md](COMPATIBILITY.md) | **Toute modification de `wired.xml` doit suivre ces règles** |
+| [SECURITY.md](SECURITY.md) | Politique de signalement de vulnérabilité |
+| [README.md](README.md) | Vue d'ensemble, build, run |
+| [CHANGELOG.md](CHANGELOG.md) | Historique des changements |
+
+## Règles non négociables
+
+1. **Compat protocole** : un changement de `wired.xml` requiert l'attribut
+   `version="X.Y"` sur chaque entrée modifiée/ajoutée, le bump de la version
+   racine du protocole, et un test dans `Tests/WiredSwiftTests/CompatibilityTests.swift`.
+   Cf. [COMPATIBILITY.md](COMPATIBILITY.md).
+2. **Sécurité d'abord** : ce code parse du réseau non fiable. Valide les
+   longueurs, évite les force-unwraps sur des entrées du pair, ne fais jamais
+   confiance à un payload.
+3. **SwiftLint** : `swiftlint lint` doit passer. Pas de nouveau
+   `// swiftlint:disable` sans `// TODO:` qui explique pourquoi.
+4. **Conventional Commits** : `feat(scope): …`, `fix(scope): …`, etc. Scopes
+   courants : `p7`, `auth`, `chat`, `files`, `lint`, `ci`.
+5. **Jamais de commit direct sur `main`/`master`** — toujours via PR.
+
+## Commandes utiles
+
+```bash
+swift build --product wired3
+swift test
+swiftlint lint
+swiftlint --fix              # corrections stylistiques auto
+```
+
+Pre-commit hook (SwiftLint) : `bash Scripts/install-hooks.sh`.
+
+## Review automatique
+
+Les PR sont relues automatiquement par Claude (Sonnet 4.6) via
+[.github/workflows/claude-review.yml](.github/workflows/claude-review.yml).
+La review est indicative — elle ne bloque pas le merge. Le focus est :
+sécurité, compatibilité protocole, qualité.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml` — runs the official `anthropics/claude-code-action` (Sonnet 4.6) on each PR open / sync / reopen, posting a single review comment focused on **security**, **protocol compatibility** (`wired.xml` / `COMPATIBILITY.md`), and project conventions.
- Adds `CLAUDE.md` to orient AI-assisted contributions toward the existing docs (`CONTRIBUTING.md`, `COMPATIBILITY.md`, `SECURITY.md`) instead of duplicating them.

## Setup required before this can run
Authenticated via Claude OAuth token (consumes the subscription quota instead of API billing).

1. Generate the token locally: `claude setup-token` (requires Claude Code CLI, signed into a Pro/Max/Team account)
2. Add a repository secret `CLAUDE_CODE_OAUTH_TOKEN` (Settings → Secrets and variables → Actions) with the token returned by the command

The workflow skips draft PRs.

## Test plan
- [ ] Generate and add the `CLAUDE_CODE_OAUTH_TOKEN` secret
- [ ] Merge this PR
- [ ] Open a small follow-up PR and confirm Claude posts a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)