### PR TITLE
fix(files): block privilege escalation via set_permissions on sync folders

### DIFF
--- a/Sources/wired3/Controllers/FilesController.swift
+++ b/Sources/wired3/Controllers/FilesController.swift
@@ -628,6 +628,15 @@ public class FilesController {
             return
         }
 
+        // Prevent privilege escalation: block a non-owner from assigning themselves as owner,
+        // which would grant new read access to the folder.
+        if let existingPrivileges = FilePrivilege(path: realPath) {
+            if existingPrivileges.owner != user.username && owner == user.username {
+                App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+                return
+            }
+        }
+
         var mode: File.FilePermissions = []
         if ownerRead { mode.insert(.ownerRead) }
         if ownerWrite { mode.insert(.ownerWrite) }

--- a/Sources/wired3/Controllers/FilesController.swift
+++ b/Sources/wired3/Controllers/FilesController.swift
@@ -628,13 +628,23 @@ public class FilesController {
             return
         }
 
+        let finalPath = resolveAliasesAndSymlinks(in: realPath)
+
         // Prevent privilege escalation: block a non-owner from assigning themselves as owner,
         // which would grant new read access to the folder.
-        if let existingPrivileges = FilePrivilege(path: realPath) {
-            if existingPrivileges.owner != user.username && owner == user.username {
+        // finalPath (alias/symlink-resolved) is used so metadata is read from the canonical location.
+        if let existingPrivileges = FilePrivilege(path: finalPath) {
+            if existingPrivileges.owner != user.username,
+               owner == user.username {
                 App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
                 return
             }
+        } else if owner == user.username,
+                  !user.hasPrivilege(name: "wired.account.settings.edit") {
+            // No permissions file yet: only admins may claim initial ownership to prevent
+            // a first-caller-wins escalation on folders that were never explicitly permissioned.
+            App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
+            return
         }
 
         var mode: File.FilePermissions = []
@@ -644,8 +654,6 @@ public class FilesController {
         if groupWrite { mode.insert(.groupWrite) }
         if everyoneRead { mode.insert(.everyoneRead) }
         if everyoneWrite { mode.insert(.everyoneWrite) }
-
-        let finalPath = resolveAliasesAndSymlinks(in: realPath)
 
         let wiredMetaPath = finalPath.stringByAppendingPathComponent(path: ".wired")
         do {

--- a/Sources/wired3/Controllers/FilesController.swift
+++ b/Sources/wired3/Controllers/FilesController.swift
@@ -640,9 +640,9 @@ public class FilesController {
                 return
             }
         } else if owner == user.username,
-                  !user.hasPrivilege(name: "wired.account.settings.edit") {
-            // No permissions file yet: only admins may claim initial ownership to prevent
-            // a first-caller-wins escalation on folders that were never explicitly permissioned.
+                  !user.hasPrivilege(name: "wired.account.account.edit_users") {
+            // No permissions file yet: only admins (edit_users) may claim initial ownership to
+            // prevent a first-caller-wins escalation on folders never explicitly permissioned.
             App.serverController.replyError(client: client, error: "wired.error.permission_denied", message: message)
             return
         }


### PR DESCRIPTION
## Summary

- A user with `wired.account.file.set_permissions` could assign themselves as owner of a sync folder they do not own, granting new read access to that folder.
- Fix reads the existing owner from `.wired/permissions` via `FilePrivilege(path:)` and rejects the request with `wired.error.permission_denied` when a non-owner attempts to claim ownership.
- The check works regardless of whether `.wired/type` is present.

## Test plan

- [ ] As non-owner user: open Get Info on a sync folder owned by another user, change owner to yourself, Save → server rejects with permission denied
- [ ] As current owner: change owner to another user → succeeds
- [ ] As current owner: change mode bits or group without changing owner → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)