### PR TITLE
fix(server-app): show binary update dialog when server is stopped

### DIFF
--- a/Sources/WiredServerApp/ContentView.swift
+++ b/Sources/WiredServerApp/ContentView.swift
@@ -43,12 +43,18 @@ struct ContentView: View {
             Text(model.lastErrorMessage)
         }
         .alert(L("alert.binary_updated.title"), isPresented: $model.showRestartAfterUpdateAlert) {
-            Button(L("alert.binary_updated.restart")) {
-                Task { await model.restartServer() }
+            Button(model.isRunning ? L("alert.binary_updated.restart") : L("alert.binary_updated.start")) {
+                Task {
+                    if model.isRunning {
+                        await model.restartServer()
+                    } else {
+                        await model.startServer()
+                    }
+                }
             }
             Button(L("alert.binary_updated.later"), role: .cancel) {}
         } message: {
-            Text(L("alert.binary_updated.message"))
+            Text(model.isRunning ? L("alert.binary_updated.message") : L("alert.binary_updated.message.stopped"))
         }
         .alert(L("alert.initial_password.title"), isPresented: $model.showInitialPasswordAlert) {
             Button(L("alert.initial_password.copy")) {

--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -3,6 +3,8 @@
 "alert.binary_updated.title" = "Server aktualisiert";
 "alert.binary_updated.message" = "Eine neue Version der Server-Binary wurde installiert. Der laufende Server verwendet noch die alte Version. Möchten Sie ihn jetzt neu starten?";
 "alert.binary_updated.restart" = "Jetzt neu starten";
+"alert.binary_updated.start" = "Jetzt starten";
+"alert.binary_updated.message.stopped" = "Eine neue Version der Server-Binary wurde installiert. Möchten Sie den Server jetzt starten?";
 "alert.binary_updated.later" = "Später";
 "alert.privileged_update.title" = "Server-Update verfügbar";
 "alert.privileged_update.message" = "Eine neue Version der Server-Binary ist in dieser App enthalten. Jetzt installieren? Ihr Administrator-Passwort wird benötigt.";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -7,6 +7,8 @@
 "alert.privileged_update.later" = "Later";
 "alert.binary_updated.message" = "A new version of the server binary has been installed. The running server is still using the previous version. Would you like to restart it now?";
 "alert.binary_updated.restart" = "Restart Now";
+"alert.binary_updated.start" = "Start Now";
+"alert.binary_updated.message.stopped" = "A new version of the server binary has been installed. Would you like to start the server now?";
 "alert.binary_updated.later" = "Later";
 "alert.initial_password.title" = "Initial Admin Password";
 "alert.initial_password.message" = "The server has been initialized with a random admin password. Save it now — it will not be shown again.";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -7,6 +7,8 @@
 "alert.privileged_update.later" = "Plus tard";
 "alert.binary_updated.message" = "Une nouvelle version du binaire serveur a été installée. Le serveur en cours d'exécution utilise encore l'ancienne version. Voulez-vous le redémarrer maintenant ?";
 "alert.binary_updated.restart" = "Redémarrer maintenant";
+"alert.binary_updated.start" = "Démarrer maintenant";
+"alert.binary_updated.message.stopped" = "Une nouvelle version du binaire serveur a été installée. Voulez-vous démarrer le serveur maintenant ?";
 "alert.binary_updated.later" = "Plus tard";
 "alert.initial_password.title" = "Mot de passe admin initial";
 "alert.initial_password.message" = "Le serveur a été initialisé avec un mot de passe admin aléatoire. Notez-le maintenant, il ne sera plus affiché.";

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -227,7 +227,7 @@ final class WiredServerViewModel: ObservableObject {
         refreshAdminStatus()
         refreshLogText()
         refreshDashboard(force: true)
-        if binaryWasUpdated && isRunning {
+        if binaryWasUpdated {
             showRestartAfterUpdateAlert = true
         }
     }


### PR DESCRIPTION
## Summary

- The binary update dialog was only shown when the server was already running. If the server was stopped when a new bundled binary was detected, the update was silently skipped.
- Remove the `isRunning` guard from `synchronizeInstalledBinaryIfNeeded` so the dialog always appears after a binary update.
- Adapt the alert button label ("Restart Now" vs "Start Now") and message text to reflect the actual server state.
- Add the two new localization keys to en, de, and fr.

## Test plan

- [ ] With server stopped: launch app with a newer bundled binary → dialog appears with "Start Now" button → clicking it starts the server with the new binary
- [ ] With server running: same scenario → dialog appears with "Restart Now" button → clicking it restarts the server
- [ ] "Later" button dismisses the dialog in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)