### PR TITLE
fix(index): prevent stack overflow via async pendingRebuild

### DIFF
--- a/Sources/wired3/Controllers/IndexController.swift
+++ b/Sources/wired3/Controllers/IndexController.swift
@@ -223,9 +223,13 @@ public class IndexController: TableController {
             // If cancelled, forceReindex() has already queued a fresh rebuild via
             // indexQueue.async; letting pendingRebuild fire here too would cause a
             // redundant extra traversal immediately after the forced one.
+            //
+            // IMPORTANT: use indexQueue.async, not a direct recursive call.
+            // A synchronous call here overflows the stack when finalisation keeps
+            // failing (pendingRebuild stays true → 400+ frames → SIGBUS).
             if !wasCancelled && pendingRebuild {
                 pendingRebuild = false
-                performFullRebuild()
+                indexQueue.async { [weak self] in self?.performFullRebuild() }
             }
         }
 


### PR DESCRIPTION
## Summary

`performFullRebuild()` called itself synchronously from its own `defer` block when `pendingRebuild` was true. Under sustained file-system activity (pendingRebuild staying true across consecutive builds), this produces 400+ frames of recursive self-invocation and terminates the process with SIGBUS.

- Replace the direct recursive call with `indexQueue.async { [weak self] in self?.performFullRebuild() }` so the next rebuild is scheduled as a fresh stack frame

## Files changed

- `Sources/wired3/Controllers/IndexController.swift` (1 file, 4 lines)

## Test plan

- [ ] Start server with a large files directory and trigger rapid file-system changes that keep re-indexing active — process should not crash
- [ ] Normal re-index flow (SIGUSR1 or UI button) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)