### PR TITLE
fix(i18n): parse .strings as UTF-8 and use safe bundle search

### DIFF
--- a/Sources/WiredServerApp/Localization.swift
+++ b/Sources/WiredServerApp/Localization.swift
@@ -49,27 +49,92 @@ private final class Localizer {
     }
 
     private static func loadTable(for language: AppLanguage) -> [String: String] {
+        let lproj = "\(language.rawValue).lproj"
+        let filename = "Localizable.strings"
         for bundle in candidateBundles() {
-            guard
-                let path = bundle.path(
-                    forResource: "Localizable",
-                    ofType: "strings",
-                    inDirectory: nil,
-                    forLocalization: language.rawValue
-                ),
-                let table = NSDictionary(contentsOfFile: path) as? [String: String]
-            else {
-                continue
+            // Try both resourceURL and bundleURL: SPM flat bundles expose
+            // resources at bundleURL, app bundles at resourceURL (Contents/Resources/).
+            for root in [bundle.resourceURL, bundle.bundleURL].compactMap({ $0 }) {
+                let url = root.appendingPathComponent(lproj).appendingPathComponent(filename)
+                if let table = parseStringsFile(at: url), !table.isEmpty {
+                    return table
+                }
             }
-
-            return table
         }
-
         return [:]
     }
 
+    // NSDictionary(contentsOf:) cannot parse UTF-8-without-BOM .strings files —
+    // it silently returns nil. Read as UTF-8 and parse the "key" = "value"; format.
+    private static func parseStringsFile(at url: URL) -> [String: String]? {
+        guard let content = try? String(contentsOf: url, encoding: .utf8),
+              !content.isEmpty else { return nil }
+        let pattern = try! NSRegularExpression(
+            pattern: #"^"((?:[^"\\]|\\.)*)"\s*=\s*"((?:[^"\\]|\\.)*)"\s*;"#,
+            options: [.anchorsMatchLines]
+        )
+        var result: [String: String] = [:]
+        let nsContent = content as NSString
+        let range = NSRange(location: 0, length: nsContent.length)
+        for match in pattern.matches(in: content, range: range) {
+            guard let keyRange = Range(match.range(at: 1), in: content),
+                  let valRange = Range(match.range(at: 2), in: content) else { continue }
+            result[unescape(String(content[keyRange]))] = unescape(String(content[valRange]))
+        }
+        return result.isEmpty ? nil : result
+    }
+
+    private static func unescape(_ s: String) -> String {
+        var result = ""
+        result.reserveCapacity(s.count)
+        var i = s.startIndex
+        while i < s.endIndex {
+            let c = s[i]
+            if c == "\\", s.index(after: i) < s.endIndex {
+                let next = s.index(after: i)
+                switch s[next] {
+                case "n":  result.append("\n"); i = s.index(after: next); continue
+                case "t":  result.append("\t"); i = s.index(after: next); continue
+                case "r":  result.append("\r"); i = s.index(after: next); continue
+                case "\"": result.append("\""); i = s.index(after: next); continue
+                case "\\": result.append("\\"); i = s.index(after: next); continue
+                default: break
+                }
+            }
+            result.append(c)
+            i = s.index(after: i)
+        }
+        return result
+    }
+
     private static func candidateBundles() -> [Bundle] {
-        [.module, .main]
+        // Bundle.module calls assertionFailure when the SPM resource bundle is absent
+        // from the app package, crashing at startup. Search for it manually instead
+        // so we can fall back to Bundle.main without a crash.
+        // Search roots mirror the 6 paths that SPM's generated Bundle.module checks.
+        let spmBundleName = "WiredSwift_WiredServerApp"
+        let finder = Localizer.self
+        let roots: [URL?] = [
+            Bundle.main.resourceURL,
+            Bundle(for: finder).resourceURL,
+            Bundle.main.resourceURL?
+                .deletingLastPathComponent().deletingLastPathComponent()
+                .appendingPathComponent("Resources"),
+            Bundle(for: finder).resourceURL?
+                .deletingLastPathComponent().deletingLastPathComponent()
+                .appendingPathComponent("Resources"),
+            Bundle(for: finder).resourceURL?
+                .deletingLastPathComponent()
+                .appendingPathComponent("Resources"),
+            Bundle(for: finder).resourceURL?
+                .deletingLastPathComponent(),
+        ]
+        for root in roots.compactMap({ $0 }) {
+            if let b = Bundle(url: root.appendingPathComponent("\(spmBundleName).bundle")) {
+                return [b, .main]
+            }
+        }
+        return [.main]
     }
 }
 

--- a/Sources/WiredServerApp/Localization.swift
+++ b/Sources/WiredServerApp/Localization.swift
@@ -64,15 +64,21 @@ private final class Localizer {
         return [:]
     }
 
+    // Compiled once — pattern is a compile-time constant, no need to recompile per call.
+    private static let stringsPattern: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(
+            pattern: #"^"((?:[^"\\]|\\.)*)"\s*=\s*"((?:[^"\\]|\\.)*)"\s*;"#,
+            options: [.anchorsMatchLines]
+        )
+    }()
+
     // NSDictionary(contentsOf:) cannot parse UTF-8-without-BOM .strings files —
     // it silently returns nil. Read as UTF-8 and parse the "key" = "value"; format.
     private static func parseStringsFile(at url: URL) -> [String: String]? {
         guard let content = try? String(contentsOf: url, encoding: .utf8),
               !content.isEmpty else { return nil }
-        let pattern = try! NSRegularExpression(
-            pattern: #"^"((?:[^"\\]|\\.)*)"\s*=\s*"((?:[^"\\]|\\.)*)"\s*;"#,
-            options: [.anchorsMatchLines]
-        )
+        let pattern = stringsPattern
         var result: [String: String] = [:]
         let nsContent = content as NSString
         let range = NSRange(location: 0, length: nsContent.length)


### PR DESCRIPTION
## Summary

Two silent failures in the localization loader that cause every key to fall back to its raw key string at runtime:

**1. `NSDictionary(contentsOfFile:)` silently returns `nil` for UTF-8-without-BOM `.strings` files**

The Foundation `NSDictionary` property-list loader requires a byte-order mark (BOM) to detect UTF-8. The `.strings` files in this project are UTF-8 without a BOM, so it returns `nil` on every load — every string falls back to its key.

Fix: replace with a custom UTF-8 regex parser that reads the file as `String(contentsOf:encoding:.utf8)` and matches the standard `"key" = "value";` format, including backslash escape sequences (`\n`, `\t`, `\"`, `\\`).

**2. `Bundle.module` crashes at startup when the SPM resource bundle is absent**

`Bundle.module` is generated by SPM's build plugin and calls `assertionFailure()` if the expected `WiredSwift_WiredServerApp.bundle` is not present in the app package. On some build configurations the bundle is placed at a path the generated code doesn't check.

Fix: replace `[.module, .main]` in `candidateBundles()` with a manual search over the same 6 root paths that SPM's generated `Bundle.module` itself checks, falling back to `Bundle.main` without crashing if none are found.

## Files changed

- `Sources/WiredServerApp/Localization.swift` (1 file)

## Test plan

- [ ] Build and run WiredServerApp with system language set to German — UI strings appear in German, not as raw keys
- [ ] Build and run with system language set to French — French strings load correctly
- [ ] Build and run with system language set to English — English strings load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)