### PR TITLE
feat(database): manual snapshot trigger via SIGUSR2

### DIFF
--- a/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/de.lproj/Localizable.strings
@@ -124,7 +124,7 @@
 "database.snapshot.trigger_now" = "Snapshot jetzt erstellen";
 "status.snapshot_triggered" = "Datenbank-Snapshot ausgelöst.";
 "status.snapshot_not_running" = "Der Server läuft nicht.";
-"status.snapshot_failed" = "Snapshot konnte nicht ausgelöst werden — PID-Datei nicht gefunden.";
+"status.snapshot_failed" = "Snapshot konnte nicht ausgelöst werden — Signal konnte nicht an den Serverprozess gesendet werden.";
 "database.events.section" = "Ereignisaufbewahrung";
 "database.events.retention" = "Ereignisse automatisch löschen";
 "database.events.help" = "Löscht Ereignisse, die älter als das gewählte Aufbewahrungsfenster sind.";

--- a/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/en.lproj/Localizable.strings
@@ -124,7 +124,7 @@
 "database.snapshot.trigger_now" = "Create Snapshot Now";
 "status.snapshot_triggered" = "Database snapshot triggered.";
 "status.snapshot_not_running" = "Server is not running.";
-"status.snapshot_failed" = "Failed to trigger snapshot — PID file not found.";
+"status.snapshot_failed" = "Failed to trigger snapshot — could not send signal to server process.";
 "database.events.section" = "Event Retention";
 "database.events.retention" = "Automatically purge events";
 "database.events.help" = "Deletes events older than the selected retention window.";

--- a/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WiredServerApp/Resources/fr.lproj/Localizable.strings
@@ -124,7 +124,7 @@
 "database.snapshot.trigger_now" = "Créer un snapshot maintenant";
 "status.snapshot_triggered" = "Snapshot de la base de données déclenché.";
 "status.snapshot_not_running" = "Le serveur n'est pas en cours d'exécution.";
-"status.snapshot_failed" = "Échec du déclenchement du snapshot — fichier PID introuvable.";
+"status.snapshot_failed" = "Échec du déclenchement du snapshot — impossible d'envoyer le signal au processus serveur.";
 "database.events.section" = "Rétention des événements";
 "database.events.retention" = "Purger automatiquement les événements";
 "database.events.help" = "Supprime les événements plus anciens que la durée de rétention choisie.";

--- a/Sources/WiredServerApp/Tabs.swift
+++ b/Sources/WiredServerApp/Tabs.swift
@@ -393,6 +393,11 @@ struct DatabaseTabView: View {
                     Text(L("database.snapshot.help"))
                         .font(.footnote)
                         .foregroundStyle(.secondary)
+
+                    Button(L("database.snapshot.trigger_now")) {
+                        model.triggerSnapshotNow()
+                    }
+                    .disabled(!model.isRunning)
                 }
 
                 Section(L("database.events.section")) {

--- a/Sources/WiredServerApp/WiredServerViewModel.swift
+++ b/Sources/WiredServerApp/WiredServerViewModel.swift
@@ -1471,6 +1471,21 @@ final class WiredServerViewModel: ObservableObject {
         sendSignal(SIGUSR1)
     }
 
+    /// Send SIGUSR2 to trigger an immediate database snapshot.
+    func triggerSnapshotNow() {
+        let pidPath = URL(fileURLWithPath: workingDirectory)
+            .appendingPathComponent("wired3.pid").path
+        guard FileManager.default.fileExists(atPath: pidPath) else {
+            statusMessage = L("status.snapshot_not_running")
+            return
+        }
+        if sendSignal(SIGUSR2) {
+            statusMessage = L("status.snapshot_triggered")
+        } else {
+            statusMessage = L("status.snapshot_failed")
+        }
+    }
+
     /// Read the PID file and send `signal` to the running wired3 process.
     @discardableResult
     private func sendSignal(_ signal: Int32) -> Bool {

--- a/Sources/wired3/Controllers/DatabaseController.swift
+++ b/Sources/wired3/Controllers/DatabaseController.swift
@@ -83,10 +83,16 @@ public class DatabaseController {
 
         let tmpURL = destinationURL.appendingPathExtension("tmp")
         try? FileManager.default.removeItem(at: tmpURL)
-        try? FileManager.default.removeItem(at: destinationURL)
+        // Do NOT remove the existing backup here — if the write below fails the
+        // previous good backup would already be gone. Only replace it after success.
 
-        let destination = try DatabaseQueue(path: tmpURL.path)
-        try dbQueue.backup(to: destination)
+        do {
+            let destination = try DatabaseQueue(path: tmpURL.path)
+            try dbQueue.backup(to: destination)
+        } catch {
+            try? FileManager.default.removeItem(at: tmpURL)
+            throw error
+        }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
             try FileManager.default.removeItem(at: destinationURL)

--- a/Sources/wired3/Core/AppController.swift
+++ b/Sources/wired3/Core/AppController.swift
@@ -331,7 +331,7 @@ public class AppController {
         timer.resume()
     }
 
-    private func createDatabaseSnapshot() {
+    public func createDatabaseSnapshot() {
         guard let databaseController = self.databaseController else { return }
 
         do {

--- a/Sources/wired3/main.swift
+++ b/Sources/wired3/main.swift
@@ -149,10 +149,20 @@ struct Wired: ParsableCommand {
         }
         sigusr1Source.resume()
 
+        // Install SIGUSR2 handler for on-demand database snapshot.
+        signal(SIGUSR2, SIG_IGN)
+        let sigusr2Source = DispatchSource.makeSignalSource(signal: SIGUSR2, queue: DispatchQueue.global())
+        sigusr2Source.setEventHandler {
+            Logger.info("SIGUSR2 received, triggering database snapshot...")
+            App.createDatabaseSnapshot()
+        }
+        sigusr2Source.resume()
+
         App.start()
 
         sighupSource.cancel()
         sigusr1Source.cancel()
+        sigusr2Source.cancel()
         try? FileManager.default.removeItem(atPath: resolved.pidPath)
     }
 


### PR DESCRIPTION
## Summary

- **SIGUSR2 handler** in `main.swift`: sending `kill -USR2 <pid>` (or `launchctl kill SIGUSR2 system/com.wired3`) to a running server now triggers an immediate database backup, without any restart
- **Safety fix** in `DatabaseController.createSnapshot()`: the previous implementation deleted the existing `.bak` before writing the new one — a failed write destroyed the last good backup. Now the old backup is only replaced after the new `.tmp` write succeeds; on failure, the `.tmp` is cleaned up
- **`createDatabaseSnapshot()` made `public`** in `AppController` so the `main` module can call it across the `wired3Lib` boundary
- **"Create Snapshot Now" button** in `DatabaseTabView` sends `SIGUSR2` via `kill(pid, SIGUSR2)` to the running process; disabled when the server is not running

Localization strings (`database.snapshot.trigger_now`, `status.snapshot_triggered`, `status.snapshot_not_running`, `status.snapshot_failed`) are already present in all three locales on `main`.

## Files changed

| File | Change |
|---|---|
| `Sources/wired3/main.swift` | SIGUSR2 DispatchSource handler |
| `Sources/wired3/Core/AppController.swift` | `private` → `public` on `createDatabaseSnapshot()` |
| `Sources/wired3/Controllers/DatabaseController.swift` | Backup-safety fix in `createSnapshot()` |
| `Sources/WiredServerApp/WiredServerViewModel.swift` | `triggerSnapshotNow()` method |
| `Sources/WiredServerApp/Tabs.swift` | "Create Snapshot Now" button |

## Test plan

- [ ] Send `kill -USR2 $(cat /Library/Wired3/wired3.pid)` while server is running — snapshot file appears / is refreshed
- [ ] Click "Create Snapshot Now" button in Database tab — status message confirms success
- [ ] Button is disabled when server is not running
- [ ] Simulate a write failure (read-only FS) — previous `.bak` is preserved, no `.tmp` left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)