### PR TITLE
fix(auth): reset isLegacy flag when admin edits account password

### DIFF
--- a/Sources/wired3/Core/ServerController+Admin.swift
+++ b/Sources/wired3/Core/ServerController+Admin.swift
@@ -817,6 +817,7 @@ extension ServerController {
                 account.passwordSalt = result.salt
                 passwordChanged = true
             }
+            account.isLegacy = false
         }
         if let group = message.string(forField: "wired.account.group") {
             account.group = group


### PR DESCRIPTION
## Summary

When an admin changes a user's password via the **Edit Account** UI (`wired.account.edit`), the server stores the new password as a SHA-256 hash — but previously failed to reset the `is_legacy` flag. Accounts migrated from Wired 2.5 carry `is_legacy = true`, which tells the connecting client to use SHA-1 for the key-exchange derivation. With a SHA-256 hash stored but `is_legacy` still set, the server and client derive different values for `serverPassword1Data`, causing ECDSA verification to fail with *"Password mismatch during key exchange"* — even after the password was successfully changed by the admin.

The fix adds `account.isLegacy = false` in `receiveAccountEditUser` whenever a non-empty password field is present in the edit message, mirroring the behaviour already present in `receiveAccountChangePassword`.

## Changed file

`Sources/wired3/Core/ServerController+Admin.swift` — one line added inside `receiveAccountEditUser`:

```swift
if let password = message.string(forField: "wired.account.password"), !password.isEmpty {
    let result = normalizedPasswordForStorage(password)
    if result.hash != account.password {
        account.password = result.hash
        account.passwordSalt = result.salt
        passwordChanged = true
    }
    account.isLegacy = false   // ← reset legacy flag whenever password is explicitly set
}
```

## Test plan

- [ ] Create a user account with `is_legacy = 1` in the DB (or migrate one from Wired 2.5)
- [ ] As admin, open the account and set a new password via Edit Account
- [ ] Verify `is_legacy` is now `0` in the DB after the edit
- [ ] Confirm the user can log in with the new password
- [ ] Confirm existing non-legacy accounts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)